### PR TITLE
added Halt() to a collection of devices

### DIFF
--- a/device.go
+++ b/device.go
@@ -5,6 +5,12 @@ import (
 	"reflect"
 )
 
+type Device interface {
+	Init() bool
+	Start() bool
+	Halt() bool
+}
+
 type device struct {
 	Name     string          `json:"name"`
 	Type     string          `json:"driver"`
@@ -13,10 +19,13 @@ type device struct {
 	Driver   DriverInterface `json:"-"`
 }
 
-type Device interface {
-	Init() bool
-	Start() bool
-	Halt() bool
+type devices []*device
+
+// Halt() stop all the devices.
+func (d devices) Halt() {
+	for _, device := range d {
+		device.Halt()
+	}
 }
 
 func NewDevice(driver DriverInterface, r *Robot) *device {

--- a/master.go
+++ b/master.go
@@ -42,7 +42,7 @@ func (m *Master) Start() {
 	// waiting on something coming on the channel
 	_ = <-c
 	for _, r := range m.Robots {
-		r.haltDevices()
+		r.GetDevices().Halt()
 		r.finalizeConnections()
 	}
 

--- a/robot.go
+++ b/robot.go
@@ -113,20 +113,14 @@ func (r *Robot) startDevices() bool {
 	return success
 }
 
-func (r *Robot) haltDevices() {
-	for _, device := range r.devices {
-		device.Halt()
-	}
-}
-
 func (r *Robot) finalizeConnections() {
 	for _, connection := range r.connections {
 		connection.Finalize()
 	}
 }
 
-func (r *Robot) GetDevices() []*device {
-	return r.devices
+func (r *Robot) GetDevices() devices {
+	return devices(r.devices)
 }
 
 func (r *Robot) GetDevice(name string) *device {


### PR DESCRIPTION
I added a devices type alias (might want to export it) so one can operate on a collection of devices.
I found that the API was cleaner when halting devices so the robot doesn't have to have any knowledge of halt and that is instead handled at the collection level.

Note that if we need to do more things on the devices, we could also implement an iterator:

``` go
func(coll devices) Each(f func(*device)) {
  for _, d := range coll {
    f(d)
  }
}

// which can be called like so
r.devices.Each(func(d *device){
  d.Halt()
})
```
