### PR TITLE
Fix platform digispark installation docs on OS X

### DIFF
--- a/source/documentation/platforms/digispark.html.haml
+++ b/source/documentation/platforms/digispark.html.haml
@@ -36,7 +36,7 @@ servo_driver: true
   %p To install libusb on OSX using Homebrew:
   :markdown
         :::bash
-        brew install libusb
+        brew install libusb-compat
 
   %h3 Ubuntu
   %p To install libusb on linux:


### PR DESCRIPTION
I was trying to install gobot-digispark following the docs and got an error of a missing library `usb.h` file. I checked if `libusb` was installed and it was. I started searching for `libusb` packages in homebrew and found that there was a package named `libusb-compat` that has dependency on `libusb`. It solved the problem. 

This was the error I was getting when trying to run the program that toggles the LED on and off.

``` sh
$ go run gobot.go
# github.com/hybridgroup/gobot-digispark
In file included from ../../.go/src/github.com/hybridgroup/gobot-digispark/littleWire.go:4:
./littleWire.h:34:13: fatal error: 'usb.h' file not found
   #include <usb.h>       // this is libusb, see http://libusb.sourceforge.net/
            ^
1 error generated.
```

This is the `libusb-compat` package in hombrew:

``` sh
$ brew info libusb-compat
libusb-compat: stable 0.1.5 (bottled)
http://www.libusb.org/
Not installed
From: https://github.com/Homebrew/homebrew/commits/master/Library/Formula/libusb-compat.rb
==> Dependencies
Build: pkg-config ✔
Required: libusb ✔
==> Options
--universal
    Build a universal binary
```
