### PR TITLE
Fix platform paths

### DIFF
--- a/platforms/ardrone/README.md
+++ b/platforms/ardrone/README.md
@@ -9,7 +9,7 @@ https://github.com/hybridgroup/gobot
 
 ## Installing
 ```
-go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/platforms/ardrone
+go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/gobot/platforms/ardrone
 ```
 ## Using
 ```go

--- a/platforms/beaglebone/README.md
+++ b/platforms/beaglebone/README.md
@@ -6,7 +6,7 @@ This package provides the Gobot adaptor for the [Beaglebone Black](http://beagle
 
 ## Installing
 ```
-go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/platforms/beaglebone
+go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/platforms/gobot/beaglebone
 ```
 
 ## Cross compiling for the Beaglebone Black

--- a/platforms/digispark/README.md
+++ b/platforms/digispark/README.md
@@ -22,9 +22,9 @@ To install libusb on linux:
 $ sudo apt-get install libusb-dev
 ```
 
-Now you can install the package with 
+Now you can install the package with
 ```
-go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/platforms/digispark
+go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/gobot/platforms/digispark
 ```
 
 ## Examples
@@ -57,7 +57,7 @@ func main() {
 ```
 ## Connecting to Digispark
 
-If your Digispark already has the Little Wire protocol firmware installed, you can connect right away with Gobot. 
+If your Digispark already has the Little Wire protocol firmware installed, you can connect right away with Gobot.
 
 Otherwise, for instructions on how to install Little Wire on a Digispark check out http://digistump.com/board/index.php/topic,160.0.html
 

--- a/platforms/firmata/README.md
+++ b/platforms/firmata/README.md
@@ -1,11 +1,11 @@
 # Firmata
 
-This package provides the adaptor for microcontrollers such as Arduino that support the [Firmata](http://firmata.org/wiki/Main_Page) protocol 
+This package provides the adaptor for microcontrollers such as Arduino that support the [Firmata](http://firmata.org/wiki/Main_Page) protocol
 
 ## Getting Started
 
 ```
-go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/platforms/firmata
+go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/gobot/platforms/firmata
 ```
 
 ## Example

--- a/platforms/gpio/README.md
+++ b/platforms/gpio/README.md
@@ -6,7 +6,7 @@ This package provides drivers for [General Purpose Input/Output (GPIO)](https://
 
 ## Installing
 ```
-go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/platforms/gpio
+go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/gobot/platforms/gpio
 ```
 
 ## Hardware Support

--- a/platforms/i2c/README.md
+++ b/platforms/i2c/README.md
@@ -6,7 +6,7 @@ This package provides drivers for [i2c](https://en.wikipedia.org/wiki/I%C2%B2C)d
 
 ## Installing
 ```
-go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/platforms/i2c
+go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/gobot/platforms/i2c
 ```
 
 ## Hardware Support

--- a/platforms/joystick/README.md
+++ b/platforms/joystick/README.md
@@ -20,9 +20,9 @@ $ brew install sdl2
 $ sudo apt-get install libsdl2-2.0-0
 ```
 
-Now you can install the package with 
+Now you can install the package with
 ```
-go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/platforms/joystick
+go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/gobot/platforms/joystick
 ```
 
 ## Usage

--- a/platforms/leap/README.md
+++ b/platforms/leap/README.md
@@ -1,4 +1,4 @@
-# Leap 
+# Leap
 
 This package provides the Gobot adaptor and driver for the [Leap Motion](https://www.leapmotion.com/)
 
@@ -8,7 +8,7 @@ First install the [Leap Motion Software](https://www.leapmotion.com/setup)
 
 Now you can install the package with
 ```
-go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/platforms/leap
+go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/gobot/platforms/leap
 ```
 
 ## Example

--- a/platforms/neurosky/README.md
+++ b/platforms/neurosky/README.md
@@ -1,10 +1,10 @@
-# Neurosky 
+# Neurosky
 
 This package contains the Gobot adaptor and driver for the [Neurosky Mindwave Mobile EEG](http://store.neurosky.com/products/mindwave-mobile).
 
 ## Installing
 ```
-go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/platforms/neurosky
+go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/gobot/platforms/neurosky
 ```
 
 ## How To Connect

--- a/platforms/opencv/README.md
+++ b/platforms/opencv/README.md
@@ -11,21 +11,21 @@ This package requires `opencv` to be installed on your system
 To install `opencv` on OSX using Homebrew:
 
 ```
-$ brew tap homebrew/science && brew install opencv 
+$ brew tap homebrew/science && brew install opencv
 ```
 
 ### Ubuntu
 
 Follow the official [OpenCV installation guide](http://docs.opencv.org/doc/tutorials/introduction/linux_install/linux_install.html)
 
-### Windows 
+### Windows
 
 Follow the official [OpenCV installation guide](http://docs.opencv.org/doc/tutorials/introduction/windows_install/windows_install.html#windows-installation)
 
 
-Now you can install the package with 
+Now you can install the package with
 ```
-go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/platforms/opencv
+go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/gobot/platforms/opencv
 ```
 
 ## Using

--- a/platforms/spark/README.md
+++ b/platforms/spark/README.md
@@ -4,7 +4,7 @@ This package provides the Gobot adaptor for the [Spark Core](https://www.spark.i
 
 ## Installing
 ```
-go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/platforms/spark
+go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/gobot/platforms/spark
 ```
 
 ## Example

--- a/platforms/sphero/README.md
+++ b/platforms/sphero/README.md
@@ -4,7 +4,7 @@ This package provides the Gobot adaptor and driver for the [Sphero](http://www.g
 
 ## Installing
 ```
-go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/platforms/sphero
+go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/gobot/platforms/sphero
 ```
 
 ## How To Connect


### PR DESCRIPTION
The `go install` paths in the platform READMEs are wrong.
