### PR TITLE
Remove broken parentheses

### DIFF
--- a/gobot/generate.go
+++ b/gobot/generate.go
@@ -159,7 +159,7 @@ func New{{.UpperName}}Driver(a *{{.UpperName}}Adaptor, name string) *{{.UpperNam
   return &{{.UpperName}}Driver{
     Driver: *gobot.NewDriver(
       name,
-      "{{.Name}}.{{.UpperName}}Driver}}",
+      "{{.Name}}.{{.UpperName}}Driver",
       a,
     ),
   }


### PR DESCRIPTION
gobot cli outputs wrong driver name.

``` go
func NewHogeDriver(a *HogeAdaptor, name string) *HogeDriver {
  return &HogeDriver{
    Driver: *gobot.NewDriver(
      name,
      "hoge.HogeDriver}}",
      a,
    ),
  }
}
```
