### PR TITLE
Fix: Sphero partial collision data

### DIFF
--- a/platforms/sphero/sphero_driver.go
+++ b/platforms/sphero/sphero_driver.go
@@ -239,27 +239,24 @@ func (s *SpheroDriver) calculateChecksum(packet *packet) uint8 {
 }
 
 func (s *SpheroDriver) readHeader() []uint8 {
-	data := s.readNextChunk(5)
-	if data == nil {
-		return nil
-	}
-	return data
+	return s.readNextChunk(5)
 }
 
 func (s *SpheroDriver) readBody(length uint8) []uint8 {
-	data := s.readNextChunk(length)
-	if data == nil {
-		return nil
-	}
-	return data
+	return s.readNextChunk(int(length))
 }
 
-func (s *SpheroDriver) readNextChunk(length uint8) []uint8 {
-	time.Sleep(1000 * time.Microsecond)
-	var read = make([]uint8, int(length))
-	l, err := s.adaptor().sp.Read(read[:])
-	if err != nil || length != uint8(l) {
-		return nil
+func (s *SpheroDriver) readNextChunk(length int) []uint8 {
+	read := make([]uint8, length)
+	bytesRead := 0
+
+	for bytesRead < length {
+		time.Sleep(1 * time.Millisecond)
+		n, err := s.adaptor().sp.Read(read[bytesRead:])
+		if err != nil {
+			return nil
+		}
+		bytesRead += n
 	}
 	return read
 }


### PR DESCRIPTION
The previous behavior would throw out the data if incomplete rather than waiting for additional data.

On some async packets there would be a DLEN of 17 but no body (some of the body was retrieved, but not all 17 bytes, so nil was returned).

With this change it waits for enough data.
