### PR TITLE
sphero: return collision data as a struct

### DIFF
--- a/examples/sphero.go
+++ b/examples/sphero.go
@@ -16,7 +16,7 @@ func main() {
 
 	work := func() {
 		gobot.On(spheroDriver.Event("collision"), func(data interface{}) {
-			fmt.Println("Collision Detected!")
+			fmt.Printf("Collision Detected! %+v\n", data)
 		})
 
 		gobot.Every(3*time.Second, func() {


### PR DESCRIPTION
Delivers the data payload for sphero collisions as a struct rather than raw bytes.

redux of #93
