### PR TITLE
firmata: explicitly send a firmwareQuery when connecting

### DIFF
--- a/platforms/firmata/firmata.go
+++ b/platforms/firmata/firmata.go
@@ -111,6 +111,7 @@ func (b *board) connect() (err error) {
 			return err
 		}
 		b.initBoard()
+		b.queryFirmware()
 		for {
 			if err = b.queryReportVersion(); err != nil {
 				return err


### PR DESCRIPTION
Firmata preemptively answers a firmwareQuery when the board is
reset, and we depend on that behaviour.  However, that doesn't seem
to be very reliable (see #173), hence this change.

Fixes #173