### PR TITLE
platforms/leap: use golang.org/x/net/websocket

### DIFF
--- a/platforms/leap/leap_motion_adaptor.go
+++ b/platforms/leap/leap_motion_adaptor.go
@@ -3,8 +3,8 @@ package leap
 import (
 	"io"
 
-	"code.google.com/p/go.net/websocket"
 	"github.com/hybridgroup/gobot"
+	"golang.org/x/net/websocket"
 )
 
 var _ gobot.Adaptor = (*LeapMotionAdaptor)(nil)

--- a/platforms/leap/leap_motion_driver.go
+++ b/platforms/leap/leap_motion_driver.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"io"
 
-	"code.google.com/p/go.net/websocket"
 	"github.com/hybridgroup/gobot"
+	"golang.org/x/net/websocket"
 )
 
 var _ gobot.Driver = (*LeapMotionDriver)(nil)


### PR DESCRIPTION
- `code.google.com/p/...` will disappear.
- use the new home for the `go.xyz` sub repos