### PR TITLE
Added Firmata Reset function to firmata adaptor.

### DIFF
--- a/platforms/firmata/firmata_adaptor.go
+++ b/platforms/firmata/firmata_adaptor.go
@@ -1,6 +1,7 @@
 package firmata
 
 import (
+	"fmt"
 	"io"
 	"strconv"
 	"time"
@@ -25,6 +26,7 @@ var _ i2c.I2c = (*FirmataAdaptor)(nil)
 type firmataBoard interface {
 	Connect(io.ReadWriteCloser) error
 	Disconnect() error
+	Reset() error
 	Pins() []client.Pin
 	AnalogWrite(int, int) error
 	SetPinMode(int, int) error
@@ -99,6 +101,12 @@ func (f *FirmataAdaptor) Disconnect() (err error) {
 		return f.board.Disconnect()
 	}
 	return nil
+}
+
+// Reset board firmware
+func (f *FirmataAdaptor) Reset() (err error) {
+	fmt.Println("Send rest")
+	return f.board.Reset()
 }
 
 // Finalize terminates the firmata connection

--- a/platforms/firmata/firmata_adaptor_test.go
+++ b/platforms/firmata/firmata_adaptor_test.go
@@ -57,6 +57,7 @@ func (mockFirmataBoard) Connect(io.ReadWriteCloser) error { return nil }
 func (m mockFirmataBoard) Disconnect() error {
 	return m.disconnectError
 }
+func (mockFirmataBoard) Reset() error { return nil }
 func (m mockFirmataBoard) Pins() []client.Pin {
 	return m.pins
 }
@@ -114,6 +115,11 @@ func TestFirmataAdaptorConnect(t *testing.T) {
 	a.board = newMockFirmataBoard()
 	gobot.Assert(t, len(a.Connect()), 0)
 
+}
+
+func TestFirmataAdaptorReset(t *testing.T) {
+	a := initTestFirmataAdaptor()
+	a.Reset()
 }
 
 func TestFirmataAdaptorServoWrite(t *testing.T) {


### PR DESCRIPTION
Hi,
I need the Reset function out of the Firmata Protocoll/Client available through the firmata adaptor. Since it is already implemented on Client side, it might be a good idea to add this on plattform level too.