### PR TITLE
Save ~1000 goroutines

### DIFF
--- a/utils_test.go
+++ b/utils_test.go
@@ -66,12 +66,20 @@ func TestAfter(t *testing.T) {
 }
 
 func TestPublish(t *testing.T) {
-	e := &Event{Chan: make(chan interface{}, 1)}
+	c := make(chan interface{}, 1)
+
+	cb := callback{
+		f: func(val interface{}) {
+			c <- val
+		},
+	}
+
+	e := &Event{Callbacks: []callback{cb}}
 	Publish(e, 1)
 	Publish(e, 2)
 	Publish(e, 3)
 	Publish(e, 4)
-	i := <-e.Chan
+	i := <-c
 	Assert(t, i, 1)
 
 	var e1 = (*Event)(nil)


### PR DESCRIPTION
Previous code spawns ~1000 go-routines due to NewEvent in my test. Removing a
goroutine and making the loop of callbacks happen directly in Write with
a lock reduces this to ~12 in my test.

While I agree that explicit locks are not nearly as nice looking as implicitly locking channels, I think the gain in simpler stack traces (~1000 x a few lines gives a LONG trace!) is enough of a reason by itself to include this change. I see no performance penalty of interest (the amount of locks have not been reduced - every channel is a locked queue, and the time to loop over a slice that often has a count of 1 is negligible), but there might be a small performance gain overall, due to lower count of goroutines and active locks that the scheduler has to keep track of. That is, however, just a bold and unscientific claim.

(This is #215 reopened on dev)