### PR TITLE
Fixed event race condition

### DIFF
--- a/examples/ardrone.go
+++ b/examples/ardrone.go
@@ -14,12 +14,12 @@ func main() {
 	drone := ardrone.NewArdroneDriver(ardroneAdaptor, "Drone")
 
 	work := func() {
-		drone.TakeOff()
 		gobot.On(drone.Event("flying"), func(data interface{}) {
 			gobot.After(3*time.Second, func() {
 				drone.Land()
 			})
 		})
+		drone.TakeOff()
 	}
 
 	robot := gobot.NewRobot("drone",


### PR DESCRIPTION
Relates to the example given for the Parrot AR2 Drone.

If this is anything like the Bebop, then taking off immediately fires the "flying" event, but these events aren't buffered so attaching an event handler afterwards achieves nothing. When I ran the same code for the Bebop (as suggested on the site) it never landed, prompting an emergency connect-with-phone-hammer-buttons scramble. Swapping the event registration with the takeoff method call fixed the problem immediately.