### PR TITLE
Correct the release command sent to pi-blaster.

### DIFF
--- a/platforms/raspi/raspi_adaptor.go
+++ b/platforms/raspi/raspi_adaptor.go
@@ -165,7 +165,7 @@ func (r *RaspiAdaptor) Finalize() (errs []error) {
 		}
 	}
 	for _, pin := range r.pwmPins {
-		if err := r.piBlaster(fmt.Sprintf("%v=release\n", pin)); err != nil {
+		if err := r.piBlaster(fmt.Sprintf("release %v\n", pin)); err != nil {
 			errs = append(errs, err)
 		}
 	}


### PR DESCRIPTION
The release command sent to pi-blaster from Finalize in the RaspiAdaptor uses the wrong syntax. As a result, pi-blaster prints "Bad input: ..." to STDERR and continues to apply the last PWM value written to the pin.

Code demonstrating the issue: https://github.com/ekyoung/gobot-pi-blaster-release-issue