### PR TITLE
Get I2C functionality before doing SMBus block I/O

### DIFF
--- a/examples/chip_wiichuck.go
+++ b/examples/chip_wiichuck.go
@@ -26,6 +26,9 @@ func main() {
 		gobot.On(wiichuck.Event("z"), func(data interface{}) {
 			fmt.Println("z")
 		})
+		gobot.On(wiichuck.Event("error"), func(data interface{}) {
+			fmt.Println("Wiichuck error:", data)
+		})
 	}
 
 	robot := gobot.NewRobot("chuck",

--- a/examples/firmata_wiichuck.go
+++ b/examples/firmata_wiichuck.go
@@ -26,6 +26,9 @@ func main() {
 		gobot.On(wiichuck.Event("z"), func(data interface{}) {
 			fmt.Println("z")
 		})
+		gobot.On(wiichuck.Event("error"), func(data interface{}) {
+			fmt.Println("Wiichuck error:", data)
+		})
 	}
 
 	robot := gobot.NewRobot("chuck",

--- a/sysfs/i2c_device_test.go
+++ b/sysfs/i2c_device_test.go
@@ -43,7 +43,7 @@ func TestNewI2cDevice(t *testing.T) {
 
 	n, err = i.Read(buf)
 
-	gobot.Assert(t, n, 4)
+	gobot.Assert(t, n, 3)
 	gobot.Assert(t, err, nil)
 
 }


### PR DESCRIPTION
In the sysfs i2cDevice implementation, use an ioctl to get the adapter
functionality mask. Prefer SMBus block I/O but if it's not available,
perform read/write calls directly on the file descriptor.

Improve Wiichuck error handling. Add a 1 ms delay between I/O operations
to the Wiichuck; this dramatically improves reliability.

Signed-off-by: Hrishikesh Tapaswi <hrishikesh195@yahoo.com>