### PR TITLE
Name C.H.I.P. pins according to printed names

### DIFF
--- a/examples/chip_blink.go
+++ b/examples/chip_blink.go
@@ -12,7 +12,7 @@ func main() {
 	gbot := gobot.NewGobot()
 
 	chipAdaptor := chip.NewChipAdaptor("chip")
-	led := gpio.NewLedDriver(chipAdaptor, "led", "U14_13")
+	led := gpio.NewLedDriver(chipAdaptor, "led", "XIO-P0")
 
 	work := func() {
 		gobot.Every(1*time.Second, func() {

--- a/examples/chip_button.go
+++ b/examples/chip_button.go
@@ -12,7 +12,7 @@ func main() {
 	gbot := gobot.NewGobot()
 
 	chipAdaptor := chip.NewChipAdaptor("chip")
-	button := gpio.NewButtonDriver(chipAdaptor, "button", "U14_13")
+	button := gpio.NewButtonDriver(chipAdaptor, "button", "XIO-P0")
 
 	work := func() {
 		gobot.On(button.Event("push"), func(data interface{}) {

--- a/examples/chip_button_led.go
+++ b/examples/chip_button_led.go
@@ -10,8 +10,8 @@ func main() {
 	gbot := gobot.NewGobot()
 
 	chipAdaptor := chip.NewChipAdaptor("chip")
-	button := gpio.NewButtonDriver(chipAdaptor, "button", "U14_19")
-	led := gpio.NewLedDriver(chipAdaptor, "led", "U14_20")
+	button := gpio.NewButtonDriver(chipAdaptor, "button", "XIO-P6")
+	led := gpio.NewLedDriver(chipAdaptor, "led", "XIO-P7")
 
 	work := func() {
 		gobot.On(button.Event("push"), func(data interface{}) {

--- a/platforms/chip/chip_adaptor.go
+++ b/platforms/chip/chip_adaptor.go
@@ -23,14 +23,14 @@ type ChipAdaptor struct {
 }
 
 var pins = map[string]int{
-	"U14_13": 408,
-	"U14_14": 409,
-	"U14_15": 410,
-	"U14_16": 411,
-	"U14_17": 412,
-	"U14_18": 413,
-	"U14_19": 414,
-	"U14_20": 415,
+	"XIO-P0": 408,
+	"XIO-P1": 409,
+	"XIO-P2": 410,
+	"XIO-P3": 411,
+	"XIO-P4": 412,
+	"XIO-P5": 413,
+	"XIO-P6": 414,
+	"XIO-P7": 415,
 }
 
 // NewChipAdaptor creates a ChipAdaptor with the specified name
@@ -99,7 +99,7 @@ func (c *ChipAdaptor) digitalPin(pin string, dir string) (sysfsPin sysfs.Digital
 }
 
 // DigitalRead reads digital value from the specified pin.
-// Valids pins are XIO-P0 through XIO-P1 (pins 13-20 on header 14).
+// Valids pins are XIO-P0 through XIO-P7 (pins 13-20 on header 14).
 func (c *ChipAdaptor) DigitalRead(pin string) (val int, err error) {
 	sysfsPin, err := c.digitalPin(pin, sysfs.IN)
 	if err != nil {
@@ -109,7 +109,7 @@ func (c *ChipAdaptor) DigitalRead(pin string) (val int, err error) {
 }
 
 // DigitalWrite writes digital value to the specified pin.
-// Valids pins are XIO-P0 through XIO-P1 (pins 13-20 on header 14).
+// Valids pins are XIO-P0 through XIO-P7 (pins 13-20 on header 14).
 func (c *ChipAdaptor) DigitalWrite(pin string, val byte) (err error) {
 	sysfsPin, err := c.digitalPin(pin, sysfs.OUT)
 	if err != nil {
@@ -120,7 +120,7 @@ func (c *ChipAdaptor) DigitalWrite(pin string, val byte) (err error) {
 
 // I2cStart starts an i2c device in specified address.
 // This assumes that the bus used is /dev/i2c-1, which corresponds to
-// pins labeled TWI1 (pins 9 and 11 on header 13).
+// pins labeled TWI1-SDA and TW1-SCK (pins 9 and 11 on header 13).
 func (c *ChipAdaptor) I2cStart(address int) (err error) {
 	if c.i2cDevice == nil {
 		c.i2cDevice, err = sysfs.NewI2cDevice("/dev/i2c-1", address)

--- a/platforms/chip/chip_adaptor_test.go
+++ b/platforms/chip/chip_adaptor_test.go
@@ -53,14 +53,14 @@ func TestChipAdaptorDigitalIO(t *testing.T) {
 
 	sysfs.SetFilesystem(fs)
 
-	a.DigitalWrite("U14_13", 1)
+	a.DigitalWrite("XIO-P0", 1)
 	gobot.Assert(t, fs.Files["/sys/class/gpio/gpio408/value"].Contents, "1")
 
 	fs.Files["/sys/class/gpio/gpio415/value"].Contents = "1"
-	i, _ := a.DigitalRead("U14_20")
+	i, _ := a.DigitalRead("XIO-P7")
 	gobot.Assert(t, i, 1)
 
-	gobot.Assert(t, a.DigitalWrite("U13_99", 1), errors.New("Not a valid pin"))
+	gobot.Assert(t, a.DigitalWrite("XIO-P10", 1), errors.New("Not a valid pin"))
 }
 
 func TestChipAdaptorI2c(t *testing.T) {


### PR DESCRIPTION
It's more convenient to refer to a pin by the name that's printed right
on the header itself instead of having to count the pin number.

Signed-off-by: Hrishikesh Tapaswi <hrishikesh195@yahoo.com>