### PR TITLE
Use Seek to speed up read/write in sysfs

### DIFF
--- a/platforms/intel-iot/edison/edison_adaptor_test.go
+++ b/platforms/intel-iot/edison/edison_adaptor_test.go
@@ -65,6 +65,7 @@ func initTestEdisonAdaptor() (*EdisonAdaptor, *sysfs.MockFilesystem) {
 		"/sys/class/gpio/gpio221/direction",
 		"/sys/class/gpio/gpio243/value",
 		"/sys/class/gpio/gpio243/direction",
+		"/sys/class/gpio/gpio229/value",
 		"/sys/class/gpio/gpio229/direction",
 		"/sys/class/gpio/gpio253/value",
 		"/sys/class/gpio/gpio253/direction",

--- a/sysfs/digital_pin_bench_test.go
+++ b/sysfs/digital_pin_bench_test.go
@@ -1,0 +1,21 @@
+package sysfs
+
+import "testing"
+
+func BenchmarkDigitalRead(b *testing.B) {
+	fs := NewMockFilesystem([]string{
+		"/sys/class/gpio/export",
+		"/sys/class/gpio/unexport",
+		"/sys/class/gpio/gpio10/value",
+		"/sys/class/gpio/gpio10/direction",
+	})
+
+	SetFilesystem(fs)
+	pin := NewDigitalPin(10)
+	pin.Write(1)
+
+	for i := 0; i < b.N; i++ {
+		pin.Read()
+	}
+
+}

--- a/sysfs/digital_pin_test.go
+++ b/sysfs/digital_pin_test.go
@@ -24,53 +24,60 @@ func TestDigitalPin(t *testing.T) {
 	gobot.Assert(t, pin.label, "custom")
 
 	pin = NewDigitalPin(10).(*digitalPin)
+	gobot.Assert(t, pin.pin, "10")
 	gobot.Assert(t, pin.label, "gpio10")
+	gobot.Assert(t, pin.value, nil)
 
-	pin.Unexport()
+	err := pin.Unexport()
+	gobot.Assert(t, err, nil)
 	gobot.Assert(t, fs.Files["/sys/class/gpio/unexport"].Contents, "10")
 
-	pin.Export()
-	gobot.Assert(t, fs.Files["/sys/class/gpio/unexport"].Contents, "10")
+	err = pin.Export()
+	gobot.Assert(t, err, nil)
+	gobot.Assert(t, fs.Files["/sys/class/gpio/export"].Contents, "10")
+	gobot.Refute(t, pin.value, nil)
 
-	pin.Write(1)
+	err = pin.Write(1)
+	gobot.Assert(t, err, nil)
 	gobot.Assert(t, fs.Files["/sys/class/gpio/gpio10/value"].Contents, "1")
 
-	pin.Direction(IN)
+	err = pin.Direction(IN)
+	gobot.Assert(t, err, nil)
 	gobot.Assert(t, fs.Files["/sys/class/gpio/gpio10/direction"].Contents, "in")
 
 	data, _ := pin.Read()
 	gobot.Assert(t, 1, data)
 
 	pin2 := NewDigitalPin(30, "custom")
-	err := pin2.Write(1)
+	err = pin2.Write(1)
 	gobot.Refute(t, err, nil)
 
 	data, err = pin2.Read()
 	gobot.Refute(t, err, nil)
 	gobot.Assert(t, data, 0)
 
-	writeFile = func(string, []byte) (int, error) {
+	writeFile = func(File, []byte) (int, error) {
 		return 0, &os.PathError{Err: syscall.EINVAL}
 	}
 
 	err = pin.Unexport()
 	gobot.Assert(t, err, nil)
 
-	writeFile = func(string, []byte) (int, error) {
+	writeFile = func(File, []byte) (int, error) {
 		return 0, &os.PathError{Err: errors.New("write error")}
 	}
 
 	err = pin.Unexport()
 	gobot.Assert(t, err.(*os.PathError).Err, errors.New("write error"))
 
-	writeFile = func(string, []byte) (int, error) {
+	writeFile = func(File, []byte) (int, error) {
 		return 0, &os.PathError{Err: syscall.EBUSY}
 	}
 
 	err = pin.Export()
 	gobot.Assert(t, err, nil)
 
-	writeFile = func(string, []byte) (int, error) {
+	writeFile = func(File, []byte) (int, error) {
 		return 0, &os.PathError{Err: errors.New("write error")}
 	}
 

--- a/sysfs/fs.go
+++ b/sysfs/fs.go
@@ -11,6 +11,7 @@ type File interface {
 	Sync() (err error)
 	Read(b []byte) (n int, err error)
 	ReadAt(b []byte, off int64) (n int, err error)
+	Seek(offset int64, whence int) (ret int64, err error)
 	Fd() uintptr
 	Close() error
 }

--- a/sysfs/fs_mock.go
+++ b/sysfs/fs_mock.go
@@ -32,6 +32,10 @@ func (f *MockFile) Write(b []byte) (n int, err error) {
 	return f.WriteString(string(b))
 }
 
+func (f *MockFile) Seek(offset int64, whence int) (ret int64, err error) {
+	return offset, nil
+}
+
 // WriteString writes s to f.Contents
 func (f *MockFile) WriteString(s string) (ret int, err error) {
 	f.Contents = s


### PR DESCRIPTION
This maintains `direction` and `value` `File`s for each DigitalPin
implementation. Instead of Open/Read/Close we now only do Seek/Read,
this speeds up Read/Write operations a bit.

A silly benchmark on the mock FS gives:

benchmark                  old ns/op     new ns/op     delta
BenchmarkDigitalRead-8     647           7.36          -98.86%

benchmark                  old allocs     new allocs     delta
BenchmarkDigitalRead-8     5              0              -100.00%

benchmark                  old bytes     new bytes     delta
BenchmarkDigitalRead-8     96            0             -100.00%