### PR TITLE
Make dev branch target more explicit in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 This document is based on the [io.js contribution guidelines](https://github.com/nodejs/io.js/blob/master/CONTRIBUTING.md)
 
+## Target Branch
+**Please open all non-hotfix PRs against the `dev` branch!**
+
+Gobot follows a ["git flow"](http://nvie.com/posts/a-successful-git-branching-model/)-style model for managing development.
+
+
 ## Issue Contributions
 
 When opening new issues or commenting on existing issues on this repository


### PR DESCRIPTION
We've had some high-value PRs lag a bit because they weren't originally opened against `dev` as CONTRIBUTING specifies. Let's make that more explicit.

Making this PR against `master` so that it will be more easily seen. Might oughta be back ported to `dev` too, but I leave that to @deadprogram.