### PR TITLE
Fix for analog lag

### DIFF
--- a/platforms/joystick/joystick_driver.go
+++ b/platforms/joystick/joystick_driver.go
@@ -116,8 +116,7 @@ func (j *JoystickDriver) Start() (errs []error) {
 
 	go func() {
 		for {
-			event := j.poll()
-			if event != nil {
+			for event := j.poll(); event != nil; event = j.poll() {
 				if err = j.handleEvent(event); err != nil {
 					gobot.Publish(j.Event("error"), err)
 				}


### PR DESCRIPTION
### Issue:
Lag occurs when events are produced faster than poll interval. 
### Reproduce the issue:
run the example code with analog joystick and move the analog sticks analog sticks. Two sticks at a time produce even more prominent lag.
### Fix:
finish all the stacked events at once and sleep through the interval