### PR TITLE
code depending on "testing" package must be in _test.go files

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func initTestAPI() *API {
@@ -39,22 +40,22 @@ func TestRobeaux(t *testing.T) {
 	request, _ := http.NewRequest("GET", "/index.html", nil)
 	response := httptest.NewRecorder()
 	a.ServeHTTP(response, request)
-	gobot.Assert(t, response.Code, 200)
+	gobottest.Assert(t, response.Code, 200)
 	// js assets
 	request, _ = http.NewRequest("GET", "/js/script.js", nil)
 	response = httptest.NewRecorder()
 	a.ServeHTTP(response, request)
-	gobot.Assert(t, response.Code, 200)
+	gobottest.Assert(t, response.Code, 200)
 	// css assets
 	request, _ = http.NewRequest("GET", "/css/application.css", nil)
 	response = httptest.NewRecorder()
 	a.ServeHTTP(response, request)
-	gobot.Assert(t, response.Code, 200)
+	gobottest.Assert(t, response.Code, 200)
 	// unknown asset
 	request, _ = http.NewRequest("GET", "/js/fake/file.js", nil)
 	response = httptest.NewRecorder()
 	a.ServeHTTP(response, request)
-	gobot.Assert(t, response.Code, 404)
+	gobottest.Assert(t, response.Code, 404)
 }
 
 func TestIndex(t *testing.T) {
@@ -64,8 +65,8 @@ func TestIndex(t *testing.T) {
 
 	a.ServeHTTP(response, request)
 
-	gobot.Assert(t, http.StatusMovedPermanently, response.Code)
-	gobot.Assert(t, "/index.html", response.HeaderMap["Location"][0])
+	gobottest.Assert(t, http.StatusMovedPermanently, response.Code)
+	gobottest.Assert(t, "/index.html", response.HeaderMap["Location"][0])
 }
 
 func TestMcp(t *testing.T) {
@@ -76,8 +77,8 @@ func TestMcp(t *testing.T) {
 
 	var body map[string]interface{}
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Refute(t, body["MCP"].(map[string]interface{})["robots"], nil)
-	gobot.Refute(t, body["MCP"].(map[string]interface{})["commands"], nil)
+	gobottest.Refute(t, body["MCP"].(map[string]interface{})["robots"], nil)
+	gobottest.Refute(t, body["MCP"].(map[string]interface{})["commands"], nil)
 }
 
 func TestMcpCommands(t *testing.T) {
@@ -88,7 +89,7 @@ func TestMcpCommands(t *testing.T) {
 
 	var body map[string]interface{}
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body["commands"], []interface{}{"TestFunction"})
+	gobottest.Assert(t, body["commands"], []interface{}{"TestFunction"})
 }
 
 func TestExecuteMcpCommand(t *testing.T) {
@@ -105,7 +106,7 @@ func TestExecuteMcpCommand(t *testing.T) {
 	a.ServeHTTP(response, request)
 
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body.(map[string]interface{})["result"], "hey Beep Boop")
+	gobottest.Assert(t, body.(map[string]interface{})["result"], "hey Beep Boop")
 
 	// unknown command
 	request, _ = http.NewRequest("GET",
@@ -117,7 +118,7 @@ func TestExecuteMcpCommand(t *testing.T) {
 	a.ServeHTTP(response, request)
 
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body.(map[string]interface{})["error"], "Unknown Command")
+	gobottest.Assert(t, body.(map[string]interface{})["error"], "Unknown Command")
 }
 
 func TestRobots(t *testing.T) {
@@ -128,7 +129,7 @@ func TestRobots(t *testing.T) {
 
 	var body map[string]interface{}
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, len(body["robots"].([]interface{})), 3)
+	gobottest.Assert(t, len(body["robots"].([]interface{})), 3)
 }
 
 func TestRobot(t *testing.T) {
@@ -141,14 +142,14 @@ func TestRobot(t *testing.T) {
 
 	var body map[string]interface{}
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body["robot"].(map[string]interface{})["name"].(string), "Robot1")
+	gobottest.Assert(t, body["robot"].(map[string]interface{})["name"].(string), "Robot1")
 
 	// unknown robot
 	request, _ = http.NewRequest("GET", "/api/robots/UnknownRobot1", nil)
 	a.ServeHTTP(response, request)
 
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body["error"], "No Robot found with the name UnknownRobot1")
+	gobottest.Assert(t, body["error"], "No Robot found with the name UnknownRobot1")
 }
 
 func TestRobotDevices(t *testing.T) {
@@ -161,14 +162,14 @@ func TestRobotDevices(t *testing.T) {
 
 	var body map[string]interface{}
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, len(body["devices"].([]interface{})), 3)
+	gobottest.Assert(t, len(body["devices"].([]interface{})), 3)
 
 	// unknown robot
 	request, _ = http.NewRequest("GET", "/api/robots/UnknownRobot1/devices", nil)
 	a.ServeHTTP(response, request)
 
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body["error"], "No Robot found with the name UnknownRobot1")
+	gobottest.Assert(t, body["error"], "No Robot found with the name UnknownRobot1")
 }
 
 func TestRobotCommands(t *testing.T) {
@@ -181,14 +182,14 @@ func TestRobotCommands(t *testing.T) {
 
 	var body map[string]interface{}
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body["commands"], []interface{}{"robotTestFunction"})
+	gobottest.Assert(t, body["commands"], []interface{}{"robotTestFunction"})
 
 	// unknown robot
 	request, _ = http.NewRequest("GET", "/api/robots/UnknownRobot1/commands", nil)
 	a.ServeHTTP(response, request)
 
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body["error"], "No Robot found with the name UnknownRobot1")
+	gobottest.Assert(t, body["error"], "No Robot found with the name UnknownRobot1")
 }
 
 func TestExecuteRobotCommand(t *testing.T) {
@@ -204,7 +205,7 @@ func TestExecuteRobotCommand(t *testing.T) {
 	a.ServeHTTP(response, request)
 
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body.(map[string]interface{})["result"], "hey Robot1, Beep Boop")
+	gobottest.Assert(t, body.(map[string]interface{})["result"], "hey Robot1, Beep Boop")
 
 	// unknown command
 	request, _ = http.NewRequest("GET",
@@ -216,7 +217,7 @@ func TestExecuteRobotCommand(t *testing.T) {
 	a.ServeHTTP(response, request)
 
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body.(map[string]interface{})["error"], "Unknown Command")
+	gobottest.Assert(t, body.(map[string]interface{})["error"], "Unknown Command")
 
 	// uknown robot
 	request, _ = http.NewRequest("GET",
@@ -227,7 +228,7 @@ func TestExecuteRobotCommand(t *testing.T) {
 	a.ServeHTTP(response, request)
 
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body.(map[string]interface{})["error"], "No Robot found with the name UnknownRobot1")
+	gobottest.Assert(t, body.(map[string]interface{})["error"], "No Robot found with the name UnknownRobot1")
 }
 
 func TestRobotDevice(t *testing.T) {
@@ -243,7 +244,7 @@ func TestRobotDevice(t *testing.T) {
 
 	var body map[string]interface{}
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body["device"].(map[string]interface{})["name"].(string), "Device1")
+	gobottest.Assert(t, body["device"].(map[string]interface{})["name"].(string), "Device1")
 
 	// unknown device
 	request, _ = http.NewRequest("GET",
@@ -251,7 +252,7 @@ func TestRobotDevice(t *testing.T) {
 	a.ServeHTTP(response, request)
 
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body["error"], "No Device found with the name UnknownDevice1")
+	gobottest.Assert(t, body["error"], "No Device found with the name UnknownDevice1")
 }
 
 func TestRobotDeviceCommands(t *testing.T) {
@@ -267,7 +268,7 @@ func TestRobotDeviceCommands(t *testing.T) {
 
 	var body map[string]interface{}
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, len(body["commands"].([]interface{})), 2)
+	gobottest.Assert(t, len(body["commands"].([]interface{})), 2)
 
 	// unknown device
 	request, _ = http.NewRequest("GET",
@@ -276,7 +277,7 @@ func TestRobotDeviceCommands(t *testing.T) {
 	)
 	a.ServeHTTP(response, request)
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body["error"], "No Device found with the name UnknownDevice1")
+	gobottest.Assert(t, body["error"], "No Device found with the name UnknownDevice1")
 }
 
 func TestExecuteRobotDeviceCommand(t *testing.T) {
@@ -293,7 +294,7 @@ func TestExecuteRobotDeviceCommand(t *testing.T) {
 	a.ServeHTTP(response, request)
 
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body.(map[string]interface{})["result"].(string), "hello human")
+	gobottest.Assert(t, body.(map[string]interface{})["result"].(string), "hello human")
 
 	// unknown command
 	request, _ = http.NewRequest("GET",
@@ -305,7 +306,7 @@ func TestExecuteRobotDeviceCommand(t *testing.T) {
 	a.ServeHTTP(response, request)
 
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body.(map[string]interface{})["error"], "Unknown Command")
+	gobottest.Assert(t, body.(map[string]interface{})["error"], "Unknown Command")
 
 	// unknown device
 	request, _ = http.NewRequest("GET",
@@ -316,7 +317,7 @@ func TestExecuteRobotDeviceCommand(t *testing.T) {
 	a.ServeHTTP(response, request)
 
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body.(map[string]interface{})["error"], "No Device found with the name UnknownDevice1")
+	gobottest.Assert(t, body.(map[string]interface{})["error"], "No Device found with the name UnknownDevice1")
 
 }
 
@@ -330,14 +331,14 @@ func TestRobotConnections(t *testing.T) {
 
 	var body map[string]interface{}
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, len(body["connections"].([]interface{})), 3)
+	gobottest.Assert(t, len(body["connections"].([]interface{})), 3)
 
 	// unknown robot
 	request, _ = http.NewRequest("GET", "/api/robots/UnknownRobot1/connections", nil)
 	a.ServeHTTP(response, request)
 
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body["error"], "No Robot found with the name UnknownRobot1")
+	gobottest.Assert(t, body["error"], "No Robot found with the name UnknownRobot1")
 }
 
 func TestRobotConnection(t *testing.T) {
@@ -353,7 +354,7 @@ func TestRobotConnection(t *testing.T) {
 
 	var body map[string]interface{}
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body["connection"].(map[string]interface{})["name"].(string), "Connection1")
+	gobottest.Assert(t, body["connection"].(map[string]interface{})["name"].(string), "Connection1")
 
 	// unknown connection
 	request, _ = http.NewRequest("GET",
@@ -362,7 +363,7 @@ func TestRobotConnection(t *testing.T) {
 	)
 	a.ServeHTTP(response, request)
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body["error"], "No Connection found with the name UnknownConnection1")
+	gobottest.Assert(t, body["error"], "No Connection found with the name UnknownConnection1")
 }
 
 func TestRobotDeviceEvent(t *testing.T) {
@@ -396,7 +397,7 @@ func TestRobotDeviceEvent(t *testing.T) {
 		case resp := <-respc:
 			reader := bufio.NewReader(resp.Body)
 			data, _ := reader.ReadString('\n')
-			gobot.Assert(t, data, "data: \"event-data\"\n")
+			gobottest.Assert(t, data, "data: \"event-data\"\n")
 			done = true
 		case <-timer.C:
 			t.Error("Not receiving data")
@@ -411,7 +412,7 @@ func TestRobotDeviceEvent(t *testing.T) {
 
 	var body map[string]interface{}
 	json.NewDecoder(response.Body).Decode(&body)
-	gobot.Assert(t, body["error"], "No Event found with the name UnknownEvent")
+	gobottest.Assert(t, body["error"], "No Event found with the name UnknownEvent")
 }
 
 func TestAPIRouter(t *testing.T) {
@@ -421,35 +422,35 @@ func TestAPIRouter(t *testing.T) {
 	request, _ := http.NewRequest("HEAD", "/test", nil)
 	response := httptest.NewRecorder()
 	a.ServeHTTP(response, request)
-	gobot.Assert(t, response.Code, 200)
+	gobottest.Assert(t, response.Code, 200)
 
 	a.Get("/test", func(res http.ResponseWriter, req *http.Request) {})
 	request, _ = http.NewRequest("GET", "/test", nil)
 	response = httptest.NewRecorder()
 	a.ServeHTTP(response, request)
-	gobot.Assert(t, response.Code, 200)
+	gobottest.Assert(t, response.Code, 200)
 
 	a.Post("/test", func(res http.ResponseWriter, req *http.Request) {})
 	request, _ = http.NewRequest("POST", "/test", nil)
 	response = httptest.NewRecorder()
 	a.ServeHTTP(response, request)
-	gobot.Assert(t, response.Code, 200)
+	gobottest.Assert(t, response.Code, 200)
 
 	a.Put("/test", func(res http.ResponseWriter, req *http.Request) {})
 	request, _ = http.NewRequest("PUT", "/test", nil)
 	response = httptest.NewRecorder()
 	a.ServeHTTP(response, request)
-	gobot.Assert(t, response.Code, 200)
+	gobottest.Assert(t, response.Code, 200)
 
 	a.Delete("/test", func(res http.ResponseWriter, req *http.Request) {})
 	request, _ = http.NewRequest("DELETE", "/test", nil)
 	response = httptest.NewRecorder()
 	a.ServeHTTP(response, request)
-	gobot.Assert(t, response.Code, 200)
+	gobottest.Assert(t, response.Code, 200)
 
 	a.Options("/test", func(res http.ResponseWriter, req *http.Request) {})
 	request, _ = http.NewRequest("OPTIONS", "/test", nil)
 	response = httptest.NewRecorder()
 	a.ServeHTTP(response, request)
-	gobot.Assert(t, response.Code, 200)
+	gobottest.Assert(t, response.Code, 200)
 }

--- a/api/basic_auth_test.go
+++ b/api/basic_auth_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func TestBasicAuth(t *testing.T) {
@@ -17,11 +17,11 @@ func TestBasicAuth(t *testing.T) {
 	request.SetBasicAuth("admin", "password")
 	response := httptest.NewRecorder()
 	a.ServeHTTP(response, request)
-	gobot.Assert(t, response.Code, 200)
+	gobottest.Assert(t, response.Code, 200)
 
 	request, _ = http.NewRequest("GET", "/api/", nil)
 	request.SetBasicAuth("admin", "wrongPassword")
 	response = httptest.NewRecorder()
 	a.ServeHTTP(response, request)
-	gobot.Assert(t, response.Code, 401)
+	gobottest.Assert(t, response.Code, 401)
 }

--- a/api/cors_test.go
+++ b/api/cors_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func TestCORSIsOriginAllowed(t *testing.T) {
@@ -13,50 +13,50 @@ func TestCORSIsOriginAllowed(t *testing.T) {
 	cors.generatePatterns()
 
 	// When all the origins are accepted
-	gobot.Assert(t, cors.isOriginAllowed("http://localhost:8000"), true)
-	gobot.Assert(t, cors.isOriginAllowed("http://localhost:3001"), true)
-	gobot.Assert(t, cors.isOriginAllowed("http://server.com"), true)
+	gobottest.Assert(t, cors.isOriginAllowed("http://localhost:8000"), true)
+	gobottest.Assert(t, cors.isOriginAllowed("http://localhost:3001"), true)
+	gobottest.Assert(t, cors.isOriginAllowed("http://server.com"), true)
 
 	// When one origin is accepted
 	cors = &CORS{AllowOrigins: []string{"http://localhost:8000"}}
 	cors.generatePatterns()
 
-	gobot.Assert(t, cors.isOriginAllowed("http://localhost:8000"), true)
-	gobot.Assert(t, cors.isOriginAllowed("http://localhost:3001"), false)
-	gobot.Assert(t, cors.isOriginAllowed("http://server.com"), false)
+	gobottest.Assert(t, cors.isOriginAllowed("http://localhost:8000"), true)
+	gobottest.Assert(t, cors.isOriginAllowed("http://localhost:3001"), false)
+	gobottest.Assert(t, cors.isOriginAllowed("http://server.com"), false)
 
 	// When several origins are accepted
 	cors = &CORS{AllowOrigins: []string{"http://localhost:*", "http://server.com"}}
 	cors.generatePatterns()
 
-	gobot.Assert(t, cors.isOriginAllowed("http://localhost:8000"), true)
-	gobot.Assert(t, cors.isOriginAllowed("http://localhost:3001"), true)
-	gobot.Assert(t, cors.isOriginAllowed("http://server.com"), true)
+	gobottest.Assert(t, cors.isOriginAllowed("http://localhost:8000"), true)
+	gobottest.Assert(t, cors.isOriginAllowed("http://localhost:3001"), true)
+	gobottest.Assert(t, cors.isOriginAllowed("http://server.com"), true)
 
 	// When several origins are accepted within the same domain
 	cors = &CORS{AllowOrigins: []string{"http://*.server.com"}}
 	cors.generatePatterns()
 
-	gobot.Assert(t, cors.isOriginAllowed("http://localhost:8000"), false)
-	gobot.Assert(t, cors.isOriginAllowed("http://localhost:3001"), false)
-	gobot.Assert(t, cors.isOriginAllowed("http://foo.server.com"), true)
-	gobot.Assert(t, cors.isOriginAllowed("http://api.server.com"), true)
+	gobottest.Assert(t, cors.isOriginAllowed("http://localhost:8000"), false)
+	gobottest.Assert(t, cors.isOriginAllowed("http://localhost:3001"), false)
+	gobottest.Assert(t, cors.isOriginAllowed("http://foo.server.com"), true)
+	gobottest.Assert(t, cors.isOriginAllowed("http://api.server.com"), true)
 }
 
 func TestCORSAllowedHeaders(t *testing.T) {
 	cors := &CORS{AllowOrigins: []string{"*"}, AllowHeaders: []string{"Header1", "Header2"}}
 
-	gobot.Assert(t, cors.AllowedHeaders(), "Header1,Header2")
+	gobottest.Assert(t, cors.AllowedHeaders(), "Header1,Header2")
 }
 
 func TestCORSAllowedMethods(t *testing.T) {
 	cors := &CORS{AllowOrigins: []string{"*"}, AllowMethods: []string{"GET", "POST"}}
 
-	gobot.Assert(t, cors.AllowedMethods(), "GET,POST")
+	gobottest.Assert(t, cors.AllowedMethods(), "GET,POST")
 
 	cors.AllowMethods = []string{"GET", "POST", "PUT"}
 
-	gobot.Assert(t, cors.AllowedMethods(), "GET,POST,PUT")
+	gobottest.Assert(t, cors.AllowedMethods(), "GET,POST,PUT")
 }
 
 func TestCORS(t *testing.T) {
@@ -70,7 +70,7 @@ func TestCORS(t *testing.T) {
 	request.Header.Set("Origin", allowedOrigin[0])
 	response := httptest.NewRecorder()
 	api.ServeHTTP(response, request)
-	gobot.Assert(t, response.Header()["Access-Control-Allow-Origin"], allowedOrigin)
+	gobottest.Assert(t, response.Header()["Access-Control-Allow-Origin"], allowedOrigin)
 
 	// Not accepted Origin
 	disallowedOrigin := []string{"http://disallowed.com"}
@@ -78,6 +78,6 @@ func TestCORS(t *testing.T) {
 	request.Header.Set("Origin", disallowedOrigin[0])
 	response = httptest.NewRecorder()
 	api.ServeHTTP(response, request)
-	gobot.Refute(t, response.Header()["Access-Control-Allow-Origin"], disallowedOrigin)
-	gobot.Refute(t, response.Header()["Access-Control-Allow-Origin"], allowedOrigin)
+	gobottest.Refute(t, response.Header()["Access-Control-Allow-Origin"], disallowedOrigin)
+	gobottest.Refute(t, response.Header()["Access-Control-Allow-Origin"], allowedOrigin)
 }

--- a/commander_test.go
+++ b/commander_test.go
@@ -1,6 +1,10 @@
 package gobot
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/hybridgroup/gobot/gobottest"
+)
 
 func TestCommaner(t *testing.T) {
 	c := NewCommander()
@@ -13,8 +17,8 @@ func TestCommaner(t *testing.T) {
 	}
 
 	command := c.Command("test")
-	Refute(t, command, nil)
+	gobottest.Refute(t, command, nil)
 
 	command = c.Command("booyeah")
-	Assert(t, command, (func(map[string]interface{}) interface{})(nil))
+	gobottest.Assert(t, command, (func(map[string]interface{}) interface{})(nil))
 }

--- a/eventer_test.go
+++ b/eventer_test.go
@@ -1,6 +1,10 @@
 package gobot
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/hybridgroup/gobot/gobottest"
+)
 
 func TestEventer(t *testing.T) {
 	e := NewEventer()
@@ -11,8 +15,8 @@ func TestEventer(t *testing.T) {
 	}
 
 	event := e.Event("test")
-	Refute(t, event, nil)
+	gobottest.Refute(t, event, nil)
 
 	event = e.Event("booyeah")
-	Assert(t, event, (*Event)(nil))
+	gobottest.Assert(t, event, (*Event)(nil))
 }

--- a/examples_test.go
+++ b/examples_test.go
@@ -2,9 +2,11 @@ package gobot_test
 
 import (
 	"fmt"
-	"github.com/hybridgroup/gobot"
 	"testing"
 	"time"
+
+	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func ExampleEvery() {
@@ -64,12 +66,12 @@ func ExampleAssert() {
 	t := &testing.T{}
 	var a int = 100
 	var b int = 100
-	gobot.Assert(t, a, b)
+	gobottest.Assert(t, a, b)
 }
 
 func ExampleRefute() {
 	t := &testing.T{}
 	var a int = 100
 	var b int = 200
-	gobot.Refute(t, a, b)
+	gobottest.Refute(t, a, b)
 }

--- a/gobot_test.go
+++ b/gobot_test.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"os"
 	"testing"
+
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func TestConnectionEach(t *testing.T) {
@@ -14,7 +16,7 @@ func TestConnectionEach(t *testing.T) {
 	r.Connections().Each(func(conn Connection) {
 		i++
 	})
-	Assert(t, r.Connections().Len(), i)
+	gobottest.Assert(t, r.Connections().Len(), i)
 }
 
 func initTestGobot() *Gobot {
@@ -30,29 +32,29 @@ func initTestGobot() *Gobot {
 }
 
 func TestVersion(t *testing.T) {
-	Assert(t, version, Version())
+	gobottest.Assert(t, version, Version())
 }
 
 func TestNullReadWriteCloser(t *testing.T) {
 	n := &NullReadWriteCloser{}
 	i, _ := n.Write([]byte{1, 2, 3})
-	Assert(t, i, 3)
+	gobottest.Assert(t, i, 3)
 	i, _ = n.Read(make([]byte, 10))
-	Assert(t, i, 10)
-	Assert(t, n.Close(), nil)
+	gobottest.Assert(t, i, 10)
+	gobottest.Assert(t, n.Close(), nil)
 }
 
 func TestGobotRobot(t *testing.T) {
 	g := initTestGobot()
-	Assert(t, g.Robot("Robot1").Name, "Robot1")
-	Assert(t, g.Robot("Robot4"), (*Robot)(nil))
-	Assert(t, g.Robot("Robot4").Device("Device1"), (Device)(nil))
-	Assert(t, g.Robot("Robot4").Connection("Connection1"), (Connection)(nil))
-	Assert(t, g.Robot("Robot1").Device("Device4"), (Device)(nil))
-	Assert(t, g.Robot("Robot1").Device("Device1").Name(), "Device1")
-	Assert(t, g.Robot("Robot1").Devices().Len(), 3)
-	Assert(t, g.Robot("Robot1").Connection("Connection4"), (Connection)(nil))
-	Assert(t, g.Robot("Robot1").Connections().Len(), 3)
+	gobottest.Assert(t, g.Robot("Robot1").Name, "Robot1")
+	gobottest.Assert(t, g.Robot("Robot4"), (*Robot)(nil))
+	gobottest.Assert(t, g.Robot("Robot4").Device("Device1"), (Device)(nil))
+	gobottest.Assert(t, g.Robot("Robot4").Connection("Connection1"), (Connection)(nil))
+	gobottest.Assert(t, g.Robot("Robot1").Device("Device4"), (Device)(nil))
+	gobottest.Assert(t, g.Robot("Robot1").Device("Device1").Name(), "Device1")
+	gobottest.Assert(t, g.Robot("Robot1").Devices().Len(), 3)
+	gobottest.Assert(t, g.Robot("Robot1").Connection("Connection4"), (Connection)(nil))
+	gobottest.Assert(t, g.Robot("Robot1").Connections().Len(), 3)
 }
 
 func TestGobotToJSON(t *testing.T) {
@@ -61,14 +63,14 @@ func TestGobotToJSON(t *testing.T) {
 		return nil
 	})
 	json := NewJSONGobot(g)
-	Assert(t, len(json.Robots), g.Robots().Len())
-	Assert(t, len(json.Commands), len(g.Commands()))
+	gobottest.Assert(t, len(json.Robots), g.Robots().Len())
+	gobottest.Assert(t, len(json.Commands), len(g.Commands()))
 }
 
 func TestGobotStart(t *testing.T) {
 	g := initTestGobot()
-	Assert(t, len(g.Start()), 0)
-	Assert(t, len(g.Stop()), 0)
+	gobottest.Assert(t, len(g.Start()), 0)
+	gobottest.Assert(t, len(g.Stop()), 0)
 }
 
 func TestGobotStartErrors(t *testing.T) {
@@ -90,8 +92,8 @@ func TestGobotStartErrors(t *testing.T) {
 		}
 	}
 
-	Assert(t, len(g.Start()), 1)
-	Assert(t, len(g.Stop()), 0)
+	gobottest.Assert(t, len(g.Start()), 1)
+	gobottest.Assert(t, len(g.Stop()), 0)
 
 	testDriverStart = func() (errs []error) { return }
 	testAdaptorConnect = func() (errs []error) {
@@ -100,8 +102,8 @@ func TestGobotStartErrors(t *testing.T) {
 		}
 	}
 
-	Assert(t, len(g.Start()), 1)
-	Assert(t, len(g.Stop()), 0)
+	gobottest.Assert(t, len(g.Start()), 1)
+	gobottest.Assert(t, len(g.Stop()), 0)
 
 	testDriverStart = func() (errs []error) { return }
 	testAdaptorConnect = func() (errs []error) { return }
@@ -122,6 +124,6 @@ func TestGobotStartErrors(t *testing.T) {
 		}
 	}
 
-	Assert(t, len(g.Start()), 0)
-	Assert(t, len(g.Stop()), 2)
+	gobottest.Assert(t, len(g.Start()), 0)
+	gobottest.Assert(t, len(g.Stop()), 2)
 }

--- a/gobottest/gobottest.go
+++ b/gobottest/gobottest.go
@@ -1,0 +1,35 @@
+package gobottest
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+var errFunc = func(t *testing.T, message string) {
+	t.Errorf(message)
+}
+
+func logFailure(t *testing.T, message string) {
+	_, file, line, _ := runtime.Caller(2)
+	s := strings.Split(file, "/")
+	errFunc(t, fmt.Sprintf("%v:%v: %v", s[len(s)-1], line, message))
+}
+
+// Assert checks if a and b are equal, emis a t.Errorf if they are not equal.
+func Assert(t *testing.T, a interface{}, b interface{}) {
+	if !reflect.DeepEqual(a, b) {
+		logFailure(t, fmt.Sprintf("%v - \"%v\", should equal,  %v - \"%v\"",
+			a, reflect.TypeOf(a), b, reflect.TypeOf(b)))
+	}
+}
+
+// Refute checks if a and b are equal, emis a t.Errorf if they are equal.
+func Refute(t *testing.T, a interface{}, b interface{}) {
+	if reflect.DeepEqual(a, b) {
+		logFailure(t, fmt.Sprintf("%v - \"%v\", should not equal,  %v - \"%v\"",
+			a, reflect.TypeOf(a), b, reflect.TypeOf(b)))
+	}
+}

--- a/gobottest/gobottest_test.go
+++ b/gobottest/gobottest_test.go
@@ -1,0 +1,37 @@
+package gobottest
+
+import "testing"
+
+func TestAssert(t *testing.T) {
+	err := ""
+	errFunc = func(t *testing.T, message string) {
+		err = message
+	}
+
+	Assert(t, 1, 1)
+	if err != "" {
+		t.Errorf("Assert failed: 1 should equal 1")
+	}
+
+	Assert(t, 1, 2)
+	if err == "" {
+		t.Errorf("Assert failed: 1 should not equal 2")
+	}
+}
+
+func TestRefute(t *testing.T) {
+	err := ""
+	errFunc = func(t *testing.T, message string) {
+		err = message
+	}
+
+	Refute(t, 1, 2)
+	if err != "" {
+		t.Errorf("Refute failed: 1 should not be 2")
+	}
+
+	Refute(t, 1, 1)
+	if err == "" {
+		t.Errorf("Refute failed: 1 should not be 1")
+	}
+}

--- a/gobottest/gobottest_test.go
+++ b/gobottest/gobottest_test.go
@@ -14,7 +14,7 @@ func TestAssert(t *testing.T) {
 	}
 
 	Assert(t, 1, 2)
-	if err == "" {
+	if err != `gobottest_test.go:16: 1 - "int", should equal,  2 - "int"` {
 		t.Errorf("Assert failed: 1 should not equal 2")
 	}
 }
@@ -31,7 +31,7 @@ func TestRefute(t *testing.T) {
 	}
 
 	Refute(t, 1, 1)
-	if err == "" {
+	if err != `gobottest_test.go:33: 1 - "int", should not equal,  1 - "int"` {
 		t.Errorf("Refute failed: 1 should not be 1")
 	}
 }

--- a/platforms/ardrone/ardrone_adaptor_test.go
+++ b/platforms/ardrone/ardrone_adaptor_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func initTestArdroneAdaptor() *ArdroneAdaptor {
@@ -17,24 +17,24 @@ func initTestArdroneAdaptor() *ArdroneAdaptor {
 
 func TestArdroneAdaptor(t *testing.T) {
 	a := NewArdroneAdaptor("drone")
-	gobot.Assert(t, a.Name(), "drone")
-	gobot.Assert(t, a.config.Ip, "192.168.1.1")
+	gobottest.Assert(t, a.Name(), "drone")
+	gobottest.Assert(t, a.config.Ip, "192.168.1.1")
 
 	a = NewArdroneAdaptor("drone", "192.168.100.100")
-	gobot.Assert(t, a.config.Ip, "192.168.100.100")
+	gobottest.Assert(t, a.config.Ip, "192.168.100.100")
 }
 
 func TestArdroneAdaptorConnect(t *testing.T) {
 	a := initTestArdroneAdaptor()
-	gobot.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, len(a.Connect()), 0)
 
 	a.connect = func(a *ArdroneAdaptor) (drone, error) {
 		return nil, errors.New("connection error")
 	}
-	gobot.Assert(t, a.Connect()[0], errors.New("connection error"))
+	gobottest.Assert(t, a.Connect()[0], errors.New("connection error"))
 }
 
 func TestArdroneAdaptorFinalize(t *testing.T) {
 	a := initTestArdroneAdaptor()
-	gobot.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, len(a.Finalize()), 0)
 }

--- a/platforms/ardrone/ardrone_driver_test.go
+++ b/platforms/ardrone/ardrone_driver_test.go
@@ -3,7 +3,7 @@ package ardrone
 import (
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func initTestArdroneDriver() *ArdroneDriver {
@@ -18,18 +18,18 @@ func initTestArdroneDriver() *ArdroneDriver {
 
 func TestArdroneDriver(t *testing.T) {
 	d := initTestArdroneDriver()
-	gobot.Assert(t, d.Name(), "drone")
-	gobot.Assert(t, d.Connection().Name(), "drone")
+	gobottest.Assert(t, d.Name(), "drone")
+	gobottest.Assert(t, d.Connection().Name(), "drone")
 }
 
 func TestArdroneDriverStart(t *testing.T) {
 	d := initTestArdroneDriver()
-	gobot.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, len(d.Start()), 0)
 }
 
 func TestArdroneDriverHalt(t *testing.T) {
 	d := initTestArdroneDriver()
-	gobot.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, len(d.Halt()), 0)
 }
 func TestArdroneDriverTakeOff(t *testing.T) {
 	d := initTestArdroneDriver()

--- a/platforms/beaglebone/beaglebone_adaptor_test.go
+++ b/platforms/beaglebone/beaglebone_adaptor_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 	"github.com/hybridgroup/gobot/sysfs"
 )
 
@@ -74,26 +74,26 @@ func TestBeagleboneAdaptor(t *testing.T) {
 		return []string{pattern + "5"}, nil
 	}
 
-	gobot.Assert(t, a.PwmWrite("P9_99", 175), errors.New("Not a valid pin"))
+	gobottest.Assert(t, a.PwmWrite("P9_99", 175), errors.New("Not a valid pin"))
 	a.PwmWrite("P9_14", 175)
-	gobot.Assert(
+	gobottest.Assert(
 		t,
 		fs.Files["/sys/devices/ocp.3/pwm_test_P9_14.5/period"].Contents,
 		"500000",
 	)
-	gobot.Assert(
+	gobottest.Assert(
 		t,
 		fs.Files["/sys/devices/ocp.3/pwm_test_P9_14.5/duty"].Contents,
 		"343137",
 	)
 
 	a.ServoWrite("P9_14", 100)
-	gobot.Assert(
+	gobottest.Assert(
 		t,
 		fs.Files["/sys/devices/ocp.3/pwm_test_P9_14.5/period"].Contents,
 		"16666666",
 	)
-	gobot.Assert(
+	gobottest.Assert(
 		t,
 		fs.Files["/sys/devices/ocp.3/pwm_test_P9_14.5/duty"].Contents,
 		"1898148",
@@ -102,26 +102,26 @@ func TestBeagleboneAdaptor(t *testing.T) {
 	// Analog
 	fs.Files["/sys/devices/ocp.3/helper.5/AIN1"].Contents = "567\n"
 	i, _ := a.AnalogRead("P9_40")
-	gobot.Assert(t, i, 567)
+	gobottest.Assert(t, i, 567)
 
 	i, err := a.AnalogRead("P9_99")
-	gobot.Assert(t, err, errors.New("Not a valid pin"))
+	gobottest.Assert(t, err, errors.New("Not a valid pin"))
 
 	// DigitalIO
 	a.DigitalWrite("usr1", 1)
-	gobot.Assert(t,
+	gobottest.Assert(t,
 		fs.Files["/sys/devices/ocp.3/gpio-leds.8/leds/beaglebone:green:usr1/brightness"].Contents,
 		"1",
 	)
 
 	a.DigitalWrite("P9_12", 1)
-	gobot.Assert(t, fs.Files["/sys/class/gpio/gpio60/value"].Contents, "1")
+	gobottest.Assert(t, fs.Files["/sys/class/gpio/gpio60/value"].Contents, "1")
 
-	gobot.Assert(t, a.DigitalWrite("P9_99", 1), errors.New("Not a valid pin"))
+	gobottest.Assert(t, a.DigitalWrite("P9_99", 1), errors.New("Not a valid pin"))
 
 	fs.Files["/sys/class/gpio/gpio10/value"].Contents = "1"
 	i, _ = a.DigitalRead("P8_31")
-	gobot.Assert(t, i, 1)
+	gobottest.Assert(t, i, 1)
 
 	// I2c
 	sysfs.SetSyscall(&sysfs.MockSyscall{})
@@ -131,7 +131,7 @@ func TestBeagleboneAdaptor(t *testing.T) {
 
 	a.I2cWrite(0xff, []byte{0x00, 0x01})
 	data, _ := a.I2cRead(0xff, 2)
-	gobot.Assert(t, data, []byte{0x00, 0x01})
+	gobottest.Assert(t, data, []byte{0x00, 0x01})
 
-	gobot.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, len(a.Finalize()), 0)
 }

--- a/platforms/bebop/bebop_adaptor_test.go
+++ b/platforms/bebop/bebop_adaptor_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func initTestBebopAdaptor() *BebopAdaptor {
@@ -18,16 +18,16 @@ func initTestBebopAdaptor() *BebopAdaptor {
 
 func TestBebopAdaptorConnect(t *testing.T) {
 	a := initTestBebopAdaptor()
-	gobot.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, len(a.Connect()), 0)
 
-	a.connect = func(a *BebopAdaptor) (error) {
+	a.connect = func(a *BebopAdaptor) error {
 		return errors.New("connection error")
 	}
-	gobot.Assert(t, a.Connect()[0], errors.New("connection error"))
+	gobottest.Assert(t, a.Connect()[0], errors.New("connection error"))
 }
 
 func TestBebopAdaptorFinalize(t *testing.T) {
 	a := initTestBebopAdaptor()
 	a.Connect()
-	gobot.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, len(a.Finalize()), 0)
 }

--- a/platforms/chip/chip_adaptor_test.go
+++ b/platforms/chip/chip_adaptor_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 	"github.com/hybridgroup/gobot/sysfs"
 )
 
@@ -54,13 +54,13 @@ func TestChipAdaptorDigitalIO(t *testing.T) {
 	sysfs.SetFilesystem(fs)
 
 	a.DigitalWrite("XIO-P0", 1)
-	gobot.Assert(t, fs.Files["/sys/class/gpio/gpio408/value"].Contents, "1")
+	gobottest.Assert(t, fs.Files["/sys/class/gpio/gpio408/value"].Contents, "1")
 
 	fs.Files["/sys/class/gpio/gpio415/value"].Contents = "1"
 	i, _ := a.DigitalRead("XIO-P7")
-	gobot.Assert(t, i, 1)
+	gobottest.Assert(t, i, 1)
 
-	gobot.Assert(t, a.DigitalWrite("XIO-P10", 1), errors.New("Not a valid pin"))
+	gobottest.Assert(t, a.DigitalWrite("XIO-P10", 1), errors.New("Not a valid pin"))
 }
 
 func TestChipAdaptorI2c(t *testing.T) {
@@ -75,7 +75,7 @@ func TestChipAdaptorI2c(t *testing.T) {
 
 	a.I2cWrite(0xff, []byte{0x00, 0x01})
 	data, _ := a.I2cRead(0xff, 2)
-	gobot.Assert(t, data, []byte{0x00, 0x01})
+	gobottest.Assert(t, data, []byte{0x00, 0x01})
 
-	gobot.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, len(a.Finalize()), 0)
 }

--- a/platforms/digispark/digispark_adaptor_test.go
+++ b/platforms/digispark/digispark_adaptor_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 type mock struct {
@@ -64,64 +64,64 @@ func initTestDigisparkAdaptor() *DigisparkAdaptor {
 
 func TestDigisparkAdaptor(t *testing.T) {
 	a := NewDigisparkAdaptor("bot")
-	gobot.Assert(t, a.Name(), "bot")
+	gobottest.Assert(t, a.Name(), "bot")
 }
 
 func TestDigisparkAdaptorConnect(t *testing.T) {
 	a := NewDigisparkAdaptor("bot")
-	gobot.Assert(t, a.Connect()[0], ErrConnection)
+	gobottest.Assert(t, a.Connect()[0], ErrConnection)
 
 	a = initTestDigisparkAdaptor()
-	gobot.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, len(a.Connect()), 0)
 }
 
 func TestDigisparkAdaptorFinalize(t *testing.T) {
 	a := initTestDigisparkAdaptor()
-	gobot.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, len(a.Finalize()), 0)
 }
 
 func TestDigisparkAdaptorDigitalWrite(t *testing.T) {
 	a := initTestDigisparkAdaptor()
 	err := a.DigitalWrite("0", uint8(1))
-	gobot.Assert(t, err, nil)
-	gobot.Assert(t, a.littleWire.(*mock).pin, uint8(0))
-	gobot.Assert(t, a.littleWire.(*mock).state, uint8(1))
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, a.littleWire.(*mock).pin, uint8(0))
+	gobottest.Assert(t, a.littleWire.(*mock).state, uint8(1))
 
 	err = a.DigitalWrite("?", uint8(1))
-	gobot.Refute(t, err, nil)
+	gobottest.Refute(t, err, nil)
 
 	errorFunc = func() error { return errors.New("pin mode error") }
 	err = a.DigitalWrite("0", uint8(1))
-	gobot.Assert(t, err, errors.New("pin mode error"))
+	gobottest.Assert(t, err, errors.New("pin mode error"))
 }
 
 func TestDigisparkAdaptorServoWrite(t *testing.T) {
 	a := initTestDigisparkAdaptor()
 	err := a.ServoWrite("2", uint8(80))
-	gobot.Assert(t, err, nil)
-	gobot.Assert(t, a.littleWire.(*mock).locationA, uint8(80))
-	gobot.Assert(t, a.littleWire.(*mock).locationB, uint8(80))
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, a.littleWire.(*mock).locationA, uint8(80))
+	gobottest.Assert(t, a.littleWire.(*mock).locationB, uint8(80))
 
 	a = initTestDigisparkAdaptor()
 	errorFunc = func() error { return errors.New("servo error") }
 	err = a.ServoWrite("2", uint8(80))
-	gobot.Assert(t, err, errors.New("servo error"))
+	gobottest.Assert(t, err, errors.New("servo error"))
 }
 
 func TestDigisparkAdaptorPwmWrite(t *testing.T) {
 	a := initTestDigisparkAdaptor()
 	err := a.PwmWrite("1", uint8(100))
-	gobot.Assert(t, err, nil)
-	gobot.Assert(t, a.littleWire.(*mock).pwmChannelA, uint8(100))
-	gobot.Assert(t, a.littleWire.(*mock).pwmChannelB, uint8(100))
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, a.littleWire.(*mock).pwmChannelA, uint8(100))
+	gobottest.Assert(t, a.littleWire.(*mock).pwmChannelB, uint8(100))
 
 	a = initTestDigisparkAdaptor()
 	pwmInitErrorFunc = func() error { return errors.New("pwminit error") }
 	err = a.PwmWrite("1", uint8(100))
-	gobot.Assert(t, err, errors.New("pwminit error"))
+	gobottest.Assert(t, err, errors.New("pwminit error"))
 
 	a = initTestDigisparkAdaptor()
 	errorFunc = func() error { return errors.New("pwm error") }
 	err = a.PwmWrite("1", uint8(100))
-	gobot.Assert(t, err, errors.New("pwm error"))
+	gobottest.Assert(t, err, errors.New("pwm error"))
 }

--- a/platforms/firmata/client/client_test.go
+++ b/platforms/firmata/client/client_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 type readWriteCloser struct{}
@@ -172,7 +173,7 @@ func TestProcess(t *testing.T) {
 	for _, test := range tests {
 		test.init()
 		gobot.Once(b.Event(test.event), func(data interface{}) {
-			gobot.Assert(t, data, test.expected)
+			gobottest.Assert(t, data, test.expected)
 			sem <- true
 		})
 
@@ -215,5 +216,5 @@ func TestConnect(t *testing.T) {
 		response = testProtocolResponse()
 	})
 
-	gobot.Assert(t, b.Connect(readWriteCloser{}), nil)
+	gobottest.Assert(t, b.Connect(readWriteCloser{}), nil)
 }

--- a/platforms/firmata/firmata_adaptor_test.go
+++ b/platforms/firmata/firmata_adaptor_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 	"github.com/hybridgroup/gobot/platforms/firmata/client"
 )
 
@@ -81,17 +82,17 @@ func initTestFirmataAdaptor() *FirmataAdaptor {
 
 func TestFirmataAdaptor(t *testing.T) {
 	a := initTestFirmataAdaptor()
-	gobot.Assert(t, a.Name(), "board")
-	gobot.Assert(t, a.Port(), "/dev/null")
+	gobottest.Assert(t, a.Name(), "board")
+	gobottest.Assert(t, a.Port(), "/dev/null")
 }
 
 func TestFirmataAdaptorFinalize(t *testing.T) {
 	a := initTestFirmataAdaptor()
-	gobot.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, len(a.Finalize()), 0)
 
 	a = initTestFirmataAdaptor()
 	a.board.(*mockFirmataBoard).disconnectError = errors.New("close error")
-	gobot.Assert(t, a.Finalize()[0], errors.New("close error"))
+	gobottest.Assert(t, a.Finalize()[0], errors.New("close error"))
 }
 
 func TestFirmataAdaptorConnect(t *testing.T) {
@@ -101,18 +102,18 @@ func TestFirmataAdaptorConnect(t *testing.T) {
 	a := NewFirmataAdaptor("board", "/dev/null")
 	a.openSP = openSP
 	a.board = newMockFirmataBoard()
-	gobot.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, len(a.Connect()), 0)
 
 	a = NewFirmataAdaptor("board", "/dev/null")
 	a.board = newMockFirmataBoard()
 	a.openSP = func(port string) (io.ReadWriteCloser, error) {
 		return nil, errors.New("connect error")
 	}
-	gobot.Assert(t, a.Connect()[0], errors.New("connect error"))
+	gobottest.Assert(t, a.Connect()[0], errors.New("connect error"))
 
 	a = NewFirmataAdaptor("board", &readWriteCloser{})
 	a.board = newMockFirmataBoard()
-	gobot.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, len(a.Connect()), 0)
 
 }
 
@@ -134,15 +135,15 @@ func TestFirmataAdaptorDigitalWrite(t *testing.T) {
 func TestFirmataAdaptorDigitalRead(t *testing.T) {
 	a := initTestFirmataAdaptor()
 	val, err := a.DigitalRead("1")
-	gobot.Assert(t, err, nil)
-	gobot.Assert(t, val, 1)
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, val, 1)
 }
 
 func TestFirmataAdaptorAnalogRead(t *testing.T) {
 	a := initTestFirmataAdaptor()
 	val, err := a.AnalogRead("1")
-	gobot.Assert(t, val, 133)
-	gobot.Assert(t, err, nil)
+	gobottest.Assert(t, val, 133)
+	gobottest.Assert(t, err, nil)
 }
 
 func TestFirmataAdaptorI2cStart(t *testing.T) {
@@ -158,8 +159,8 @@ func TestFirmataAdaptorI2cRead(t *testing.T) {
 		gobot.Publish(a.board.Event("I2cReply"), i2cReply)
 	}()
 	data, err := a.I2cRead(0x00, 1)
-	gobot.Assert(t, err, nil)
-	gobot.Assert(t, data, i)
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, data, i)
 }
 func TestFirmataAdaptorI2cWrite(t *testing.T) {
 	a := initTestFirmataAdaptor()

--- a/platforms/gpio/analog_sensor_driver_test.go
+++ b/platforms/gpio/analog_sensor_driver_test.go
@@ -6,15 +6,16 @@ import (
 	"time"
 
 	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func TestAnalogSensorDriver(t *testing.T) {
 	d := NewAnalogSensorDriver(newGpioTestAdaptor("adaptor"), "bot", "1")
-	gobot.Assert(t, d.Name(), "bot")
-	gobot.Assert(t, d.Connection().Name(), "adaptor")
+	gobottest.Assert(t, d.Name(), "bot")
+	gobottest.Assert(t, d.Connection().Name(), "adaptor")
 
 	d = NewAnalogSensorDriver(newGpioTestAdaptor("adaptor"), "bot", "1", 30*time.Second)
-	gobot.Assert(t, d.interval, 30*time.Second)
+	gobottest.Assert(t, d.interval, 30*time.Second)
 
 	testAdaptorAnalogRead = func() (val int, err error) {
 		val = 100
@@ -22,8 +23,8 @@ func TestAnalogSensorDriver(t *testing.T) {
 	}
 	ret := d.Command("Read")(nil).(map[string]interface{})
 
-	gobot.Assert(t, ret["val"].(int), 100)
-	gobot.Assert(t, ret["err"], nil)
+	gobottest.Assert(t, ret["val"].(int), 100)
+	gobottest.Assert(t, ret["err"], nil)
 }
 
 func TestAnalogSensorDriverStart(t *testing.T) {
@@ -35,11 +36,11 @@ func TestAnalogSensorDriverStart(t *testing.T) {
 		val = 0
 		return
 	}
-	gobot.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, len(d.Start()), 0)
 
 	// data was received
 	gobot.Once(d.Event(Data), func(data interface{}) {
-		gobot.Assert(t, data.(int), 100)
+		gobottest.Assert(t, data.(int), 100)
 		sem <- true
 	})
 
@@ -56,7 +57,7 @@ func TestAnalogSensorDriverStart(t *testing.T) {
 
 	// read error
 	gobot.Once(d.Event(Error), func(data interface{}) {
-		gobot.Assert(t, data.(error).Error(), "read error")
+		gobottest.Assert(t, data.(error).Error(), "read error")
 		sem <- true
 	})
 
@@ -95,5 +96,5 @@ func TestAnalogSensorDriverHalt(t *testing.T) {
 	go func() {
 		<-d.halt
 	}()
-	gobot.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, len(d.Halt()), 0)
 }

--- a/platforms/gpio/button_driver_test.go
+++ b/platforms/gpio/button_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 const BUTTON_TEST_DELAY = 50
@@ -19,22 +20,22 @@ func TestButtonDriverHalt(t *testing.T) {
 	go func() {
 		<-d.halt
 	}()
-	gobot.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, len(d.Halt()), 0)
 }
 
 func TestButtonDriver(t *testing.T) {
 	d := NewButtonDriver(newGpioTestAdaptor("adaptor"), "bot", "1")
-	gobot.Assert(t, d.Name(), "bot")
-	gobot.Assert(t, d.Connection().Name(), "adaptor")
+	gobottest.Assert(t, d.Name(), "bot")
+	gobottest.Assert(t, d.Connection().Name(), "adaptor")
 
 	d = NewButtonDriver(newGpioTestAdaptor("adaptor"), "bot", "1", 30*time.Second)
-	gobot.Assert(t, d.interval, 30 * time.Second)
+	gobottest.Assert(t, d.interval, 30 * time.Second)
 }
 
 func TestButtonDriverStart(t *testing.T) {
 	sem := make(chan bool, 0)
 	d := initTestButtonDriver()
-	gobot.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, len(d.Start()), 0)
 
 	testAdaptorDigitalRead = func() (val int, err error) {
 		val = 1
@@ -42,7 +43,7 @@ func TestButtonDriverStart(t *testing.T) {
 	}
 
 	gobot.Once(d.Event(Push), func(data interface{}) {
-		gobot.Assert(t, d.Active, true)
+		gobottest.Assert(t, d.Active, true)
 		sem <- true
 	})
 
@@ -58,7 +59,7 @@ func TestButtonDriverStart(t *testing.T) {
 	}
 
 	gobot.Once(d.Event(Release), func(data interface{}) {
-		gobot.Assert(t, d.Active, false)
+		gobottest.Assert(t, d.Active, false)
 		sem <- true
 	})
 

--- a/platforms/gpio/direct_pin_driver_test.go
+++ b/platforms/gpio/direct_pin_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func initTestDirectPinDriver(conn gobot.Connection) *DirectPinDriver {
@@ -33,79 +34,79 @@ func TestDirectPinDriver(t *testing.T) {
 	var err interface{}
 
 	d := initTestDirectPinDriver(newGpioTestAdaptor("adaptor"))
-	gobot.Assert(t, d.Name(), "bot")
-	gobot.Assert(t, d.Pin(), "1")
-	gobot.Assert(t, d.Connection().Name(), "adaptor")
+	gobottest.Assert(t, d.Name(), "bot")
+	gobottest.Assert(t, d.Pin(), "1")
+	gobottest.Assert(t, d.Connection().Name(), "adaptor")
 
 	ret = d.Command("DigitalRead")(nil).(map[string]interface{})
 
-	gobot.Assert(t, ret["val"].(int), 1)
-	gobot.Assert(t, ret["err"], nil)
+	gobottest.Assert(t, ret["val"].(int), 1)
+	gobottest.Assert(t, ret["err"], nil)
 
 	err = d.Command("DigitalWrite")(map[string]interface{}{"level": "1"})
-	gobot.Assert(t, err.(error), errors.New("write error"))
+	gobottest.Assert(t, err.(error), errors.New("write error"))
 
 	ret = d.Command("AnalogRead")(nil).(map[string]interface{})
 
-	gobot.Assert(t, ret["val"].(int), 80)
-	gobot.Assert(t, ret["err"], nil)
+	gobottest.Assert(t, ret["val"].(int), 80)
+	gobottest.Assert(t, ret["err"], nil)
 
 	err = d.Command("PwmWrite")(map[string]interface{}{"level": "1"})
-	gobot.Assert(t, err.(error), errors.New("write error"))
+	gobottest.Assert(t, err.(error), errors.New("write error"))
 
 	err = d.Command("ServoWrite")(map[string]interface{}{"level": "1"})
-	gobot.Assert(t, err.(error), errors.New("write error"))
+	gobottest.Assert(t, err.(error), errors.New("write error"))
 }
 
 func TestDirectPinDriverStart(t *testing.T) {
 	d := initTestDirectPinDriver(newGpioTestAdaptor("adaptor"))
-	gobot.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, len(d.Start()), 0)
 }
 
 func TestDirectPinDriverHalt(t *testing.T) {
 	d := initTestDirectPinDriver(newGpioTestAdaptor("adaptor"))
-	gobot.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, len(d.Halt()), 0)
 }
 
 func TestDirectPinDriverDigitalWrite(t *testing.T) {
 	d := initTestDirectPinDriver(newGpioTestAdaptor("adaptor"))
-	gobot.Refute(t, d.DigitalWrite(1), nil)
+	gobottest.Refute(t, d.DigitalWrite(1), nil)
 
 	d = initTestDirectPinDriver(&gpioTestBareAdaptor{})
-	gobot.Assert(t, d.DigitalWrite(1), ErrDigitalWriteUnsupported)
+	gobottest.Assert(t, d.DigitalWrite(1), ErrDigitalWriteUnsupported)
 }
 
 func TestDirectPinDriverDigitalRead(t *testing.T) {
 	d := initTestDirectPinDriver(newGpioTestAdaptor("adaptor"))
 	ret, err := d.DigitalRead()
-	gobot.Assert(t, ret, 1)
+	gobottest.Assert(t, ret, 1)
 
 	d = initTestDirectPinDriver(&gpioTestBareAdaptor{})
 	ret, err = d.DigitalRead()
-	gobot.Assert(t, err, ErrDigitalReadUnsupported)
+	gobottest.Assert(t, err, ErrDigitalReadUnsupported)
 }
 
 func TestDirectPinDriverAnalogRead(t *testing.T) {
 	d := initTestDirectPinDriver(newGpioTestAdaptor("adaptor"))
 	ret, err := d.AnalogRead()
-	gobot.Assert(t, ret, 80)
+	gobottest.Assert(t, ret, 80)
 
 	d = initTestDirectPinDriver(&gpioTestBareAdaptor{})
 	ret, err = d.AnalogRead()
-	gobot.Assert(t, err, ErrAnalogReadUnsupported)
+	gobottest.Assert(t, err, ErrAnalogReadUnsupported)
 }
 
 func TestDirectPinDriverPwmWrite(t *testing.T) {
 	d := initTestDirectPinDriver(newGpioTestAdaptor("adaptor"))
-	gobot.Refute(t, d.PwmWrite(1), nil)
+	gobottest.Refute(t, d.PwmWrite(1), nil)
 
 	d = initTestDirectPinDriver(&gpioTestBareAdaptor{})
-	gobot.Assert(t, d.PwmWrite(1), ErrPwmWriteUnsupported)
+	gobottest.Assert(t, d.PwmWrite(1), ErrPwmWriteUnsupported)
 }
 func TestDirectPinDriverDigitalWrie(t *testing.T) {
 	d := initTestDirectPinDriver(newGpioTestAdaptor("adaptor"))
-	gobot.Refute(t, d.ServoWrite(1), nil)
+	gobottest.Refute(t, d.ServoWrite(1), nil)
 
 	d = initTestDirectPinDriver(&gpioTestBareAdaptor{})
-	gobot.Assert(t, d.ServoWrite(1), ErrServoWriteUnsupported)
+	gobottest.Assert(t, d.ServoWrite(1), ErrServoWriteUnsupported)
 }

--- a/platforms/gpio/led_driver_test.go
+++ b/platforms/gpio/led_driver_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func initTestLedDriver(conn DigitalWriter) *LedDriver {
@@ -22,9 +22,9 @@ func TestLedDriver(t *testing.T) {
 
 	d := initTestLedDriver(newGpioTestAdaptor("adaptor"))
 
-	gobot.Assert(t, d.Name(), "bot")
-	gobot.Assert(t, d.Pin(), "1")
-	gobot.Assert(t, d.Connection().Name(), "adaptor")
+	gobottest.Assert(t, d.Name(), "bot")
+	gobottest.Assert(t, d.Pin(), "1")
+	gobottest.Assert(t, d.Connection().Name(), "adaptor")
 
 	testAdaptorDigitalWrite = func() (err error) {
 		return errors.New("write error")
@@ -34,46 +34,46 @@ func TestLedDriver(t *testing.T) {
 	}
 
 	err = d.Command("Toggle")(nil)
-	gobot.Assert(t, err.(error), errors.New("write error"))
+	gobottest.Assert(t, err.(error), errors.New("write error"))
 
 	err = d.Command("On")(nil)
-	gobot.Assert(t, err.(error), errors.New("write error"))
+	gobottest.Assert(t, err.(error), errors.New("write error"))
 
 	err = d.Command("Off")(nil)
-	gobot.Assert(t, err.(error), errors.New("write error"))
+	gobottest.Assert(t, err.(error), errors.New("write error"))
 
 	err = d.Command("Brightness")(map[string]interface{}{"level": 100.0})
-	gobot.Assert(t, err.(error), errors.New("pwm error"))
+	gobottest.Assert(t, err.(error), errors.New("pwm error"))
 
 }
 
 func TestLedDriverStart(t *testing.T) {
 	d := initTestLedDriver(newGpioTestAdaptor("adaptor"))
-	gobot.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, len(d.Start()), 0)
 }
 
 func TestLedDriverHalt(t *testing.T) {
 	d := initTestLedDriver(newGpioTestAdaptor("adaptor"))
-	gobot.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, len(d.Halt()), 0)
 }
 
 func TestLedDriverToggle(t *testing.T) {
 	d := initTestLedDriver(newGpioTestAdaptor("adaptor"))
 	d.Off()
 	d.Toggle()
-	gobot.Assert(t, d.State(), true)
+	gobottest.Assert(t, d.State(), true)
 	d.Toggle()
-	gobot.Assert(t, d.State(), false)
+	gobottest.Assert(t, d.State(), false)
 }
 
 func TestLedDriverBrightness(t *testing.T) {
 	d := initTestLedDriver(&gpioTestDigitalWriter{})
-	gobot.Assert(t, d.Brightness(150), ErrPwmWriteUnsupported)
+	gobottest.Assert(t, d.Brightness(150), ErrPwmWriteUnsupported)
 
 	d = initTestLedDriver(newGpioTestAdaptor("adaptor"))
 	testAdaptorPwmWrite = func() (err error) {
 		err = errors.New("pwm error")
 		return
 	}
-	gobot.Assert(t, d.Brightness(150), errors.New("pwm error"))
+	gobottest.Assert(t, d.Brightness(150), errors.New("pwm error"))
 }

--- a/platforms/gpio/makey_button_driver_test.go
+++ b/platforms/gpio/makey_button_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 const MAKEY_TEST_DELAY = 30
@@ -19,22 +20,22 @@ func TestMakeyButtonDriverHalt(t *testing.T) {
 	go func() {
 		<-d.halt
 	}()
-	gobot.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, len(d.Halt()), 0)
 }
 
 func TestMakeyButtonDriver(t *testing.T) {
 	d := NewMakeyButtonDriver(newGpioTestAdaptor("adaptor"), "bot", "1")
-	gobot.Assert(t, d.Name(), "bot")
-	gobot.Assert(t, d.Connection().Name(), "adaptor")
+	gobottest.Assert(t, d.Name(), "bot")
+	gobottest.Assert(t, d.Connection().Name(), "adaptor")
 
 	d = NewMakeyButtonDriver(newGpioTestAdaptor("adaptor"), "bot", "1", 30*time.Second)
-	gobot.Assert(t, d.interval, MAKEY_TEST_DELAY * time.Second)
+	gobottest.Assert(t, d.interval, MAKEY_TEST_DELAY*time.Second)
 }
 
 func TestMakeyButtonDriverStart(t *testing.T) {
 	sem := make(chan bool, 0)
 	d := initTestMakeyButtonDriver()
-	gobot.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, len(d.Start()), 0)
 
 	testAdaptorDigitalRead = func() (val int, err error) {
 		val = 0
@@ -42,7 +43,7 @@ func TestMakeyButtonDriverStart(t *testing.T) {
 	}
 
 	gobot.Once(d.Event(Push), func(data interface{}) {
-		gobot.Assert(t, d.Active, true)
+		gobottest.Assert(t, d.Active, true)
 		sem <- true
 	})
 
@@ -58,7 +59,7 @@ func TestMakeyButtonDriverStart(t *testing.T) {
 	}
 
 	gobot.Once(d.Event(Release), func(data interface{}) {
-		gobot.Assert(t, d.Active, false)
+		gobottest.Assert(t, d.Active, false)
 		sem <- true
 	})
 

--- a/platforms/gpio/motor_driver_test.go
+++ b/platforms/gpio/motor_driver_test.go
@@ -3,7 +3,7 @@ package gpio
 import (
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func initTestMotorDriver() *MotorDriver {
@@ -12,65 +12,65 @@ func initTestMotorDriver() *MotorDriver {
 
 func TestMotorDriver(t *testing.T) {
 	d := NewMotorDriver(newGpioTestAdaptor("adaptor"), "bot", "1")
-	gobot.Assert(t, d.Name(), "bot")
-	gobot.Assert(t, d.Connection().Name(), "adaptor")
+	gobottest.Assert(t, d.Name(), "bot")
+	gobottest.Assert(t, d.Connection().Name(), "adaptor")
 
 }
 func TestMotorDriverStart(t *testing.T) {
 	d := initTestMotorDriver()
-	gobot.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, len(d.Start()), 0)
 }
 
 func TestMotorDriverHalt(t *testing.T) {
 	d := initTestMotorDriver()
-	gobot.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, len(d.Halt()), 0)
 }
 
 func TestMotorDriverIsOn(t *testing.T) {
 	d := initTestMotorDriver()
 	d.CurrentMode = "digital"
 	d.CurrentState = 1
-	gobot.Assert(t, d.IsOn(), true)
+	gobottest.Assert(t, d.IsOn(), true)
 	d.CurrentMode = "analog"
 	d.CurrentSpeed = 100
-	gobot.Assert(t, d.IsOn(), true)
+	gobottest.Assert(t, d.IsOn(), true)
 }
 
 func TestMotorDriverIsOff(t *testing.T) {
 	d := initTestMotorDriver()
 	d.Off()
-	gobot.Assert(t, d.IsOff(), true)
+	gobottest.Assert(t, d.IsOff(), true)
 }
 
 func TestMotorDriverOn(t *testing.T) {
 	d := initTestMotorDriver()
 	d.CurrentMode = "digital"
 	d.On()
-	gobot.Assert(t, d.CurrentState, uint8(1))
+	gobottest.Assert(t, d.CurrentState, uint8(1))
 	d.CurrentMode = "analog"
 	d.CurrentSpeed = 0
 	d.On()
-	gobot.Assert(t, d.CurrentSpeed, uint8(255))
+	gobottest.Assert(t, d.CurrentSpeed, uint8(255))
 }
 
 func TestMotorDriverOff(t *testing.T) {
 	d := initTestMotorDriver()
 	d.CurrentMode = "digital"
 	d.Off()
-	gobot.Assert(t, d.CurrentState, uint8(0))
+	gobottest.Assert(t, d.CurrentState, uint8(0))
 	d.CurrentMode = "analog"
 	d.CurrentSpeed = 100
 	d.Off()
-	gobot.Assert(t, d.CurrentSpeed, uint8(0))
+	gobottest.Assert(t, d.CurrentSpeed, uint8(0))
 }
 
 func TestMotorDriverToggle(t *testing.T) {
 	d := initTestMotorDriver()
 	d.Off()
 	d.Toggle()
-	gobot.Assert(t, d.IsOn(), true)
+	gobottest.Assert(t, d.IsOn(), true)
 	d.Toggle()
-	gobot.Assert(t, d.IsOn(), false)
+	gobottest.Assert(t, d.IsOn(), false)
 }
 
 func TestMotorDriverMin(t *testing.T) {
@@ -91,14 +91,14 @@ func TestMotorDriverSpeed(t *testing.T) {
 func TestMotorDriverForward(t *testing.T) {
 	d := initTestMotorDriver()
 	d.Forward(100)
-	gobot.Assert(t, d.CurrentSpeed, uint8(100))
-	gobot.Assert(t, d.CurrentDirection, "forward")
+	gobottest.Assert(t, d.CurrentSpeed, uint8(100))
+	gobottest.Assert(t, d.CurrentDirection, "forward")
 }
 func TestMotorDriverBackward(t *testing.T) {
 	d := initTestMotorDriver()
 	d.Backward(100)
-	gobot.Assert(t, d.CurrentSpeed, uint8(100))
-	gobot.Assert(t, d.CurrentDirection, "backward")
+	gobottest.Assert(t, d.CurrentSpeed, uint8(100))
+	gobottest.Assert(t, d.CurrentDirection, "backward")
 }
 
 func TestMotorDriverDirection(t *testing.T) {

--- a/platforms/gpio/servo_driver_test.go
+++ b/platforms/gpio/servo_driver_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func initTestServoDriver() *ServoDriver {
@@ -16,60 +16,60 @@ func TestServoDriver(t *testing.T) {
 
 	d := initTestServoDriver()
 
-	gobot.Assert(t, d.Name(), "bot")
-	gobot.Assert(t, d.Pin(), "1")
-	gobot.Assert(t, d.Connection().Name(), "adaptor")
+	gobottest.Assert(t, d.Name(), "bot")
+	gobottest.Assert(t, d.Pin(), "1")
+	gobottest.Assert(t, d.Connection().Name(), "adaptor")
 
 	testAdaptorServoWrite = func() (err error) {
 		return errors.New("pwm error")
 	}
 
 	err = d.Command("Min")(nil)
-	gobot.Assert(t, err.(error), errors.New("pwm error"))
+	gobottest.Assert(t, err.(error), errors.New("pwm error"))
 
 	err = d.Command("Center")(nil)
-	gobot.Assert(t, err.(error), errors.New("pwm error"))
+	gobottest.Assert(t, err.(error), errors.New("pwm error"))
 
 	err = d.Command("Max")(nil)
-	gobot.Assert(t, err.(error), errors.New("pwm error"))
+	gobottest.Assert(t, err.(error), errors.New("pwm error"))
 
 	err = d.Command("Move")(map[string]interface{}{"angle": 100.0})
-	gobot.Assert(t, err.(error), errors.New("pwm error"))
+	gobottest.Assert(t, err.(error), errors.New("pwm error"))
 
 }
 
 func TestServoDriverStart(t *testing.T) {
 	d := initTestServoDriver()
-	gobot.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, len(d.Start()), 0)
 }
 
 func TestServoDriverHalt(t *testing.T) {
 	d := initTestServoDriver()
-	gobot.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, len(d.Halt()), 0)
 }
 
 func TestServoDriverMove(t *testing.T) {
 	d := initTestServoDriver()
 	d.Move(100)
-	gobot.Assert(t, d.CurrentAngle, uint8(100))
+	gobottest.Assert(t, d.CurrentAngle, uint8(100))
 	err := d.Move(200)
-	gobot.Assert(t, err, ErrServoOutOfRange)
+	gobottest.Assert(t, err, ErrServoOutOfRange)
 }
 
 func TestServoDriverMin(t *testing.T) {
 	d := initTestServoDriver()
 	d.Min()
-	gobot.Assert(t, d.CurrentAngle, uint8(0))
+	gobottest.Assert(t, d.CurrentAngle, uint8(0))
 }
 
 func TestServoDriverMax(t *testing.T) {
 	d := initTestServoDriver()
 	d.Max()
-	gobot.Assert(t, d.CurrentAngle, uint8(180))
+	gobottest.Assert(t, d.CurrentAngle, uint8(180))
 }
 
 func TestServoDriverCenter(t *testing.T) {
 	d := initTestServoDriver()
 	d.Center()
-	gobot.Assert(t, d.CurrentAngle, uint8(90))
+	gobottest.Assert(t, d.CurrentAngle, uint8(90))
 }

--- a/platforms/i2c/blinkm_driver_test.go
+++ b/platforms/i2c/blinkm_driver_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 // --------- HELPERS
@@ -34,14 +34,14 @@ func TestNewBlinkMDriverCommands_Rgb(t *testing.T) {
 	blinkM := initTestBlinkMDriver()
 
 	result := blinkM.Command("Rgb")(rgb)
-	gobot.Assert(t, result, nil)
+	gobottest.Assert(t, result, nil)
 }
 
 func TestNewBlinkMDriverCommands_Fade(t *testing.T) {
 	blinkM := initTestBlinkMDriver()
 
 	result := blinkM.Command("Fade")(rgb)
-	gobot.Assert(t, result, nil)
+	gobottest.Assert(t, result, nil)
 }
 
 func TestNewBlinkMDriverCommands_FirmwareVersion(t *testing.T) {
@@ -57,7 +57,7 @@ func TestNewBlinkMDriverCommands_FirmwareVersion(t *testing.T) {
 	result := blinkM.Command("FirmwareVersion")(param)
 
 	version, _ := blinkM.FirmwareVersion()
-	gobot.Assert(t, result.(map[string]interface{})["version"].(string), version)
+	gobottest.Assert(t, result.(map[string]interface{})["version"].(string), version)
 
 	// When len(data) is not 2
 	adaptor.i2cReadImpl = func() ([]byte, error) {
@@ -66,7 +66,7 @@ func TestNewBlinkMDriverCommands_FirmwareVersion(t *testing.T) {
 	result = blinkM.Command("FirmwareVersion")(param)
 
 	version, _ = blinkM.FirmwareVersion()
-	gobot.Assert(t, result.(map[string]interface{})["version"].(string), version)
+	gobottest.Assert(t, result.(map[string]interface{})["version"].(string), version)
 }
 
 func TestNewBlinkMDriverCommands_Color(t *testing.T) {
@@ -77,39 +77,39 @@ func TestNewBlinkMDriverCommands_Color(t *testing.T) {
 	result := blinkM.Command("Color")(param)
 
 	color, _ := blinkM.Color()
-	gobot.Assert(t, result.(map[string]interface{})["color"].([]byte), color)
+	gobottest.Assert(t, result.(map[string]interface{})["color"].([]byte), color)
 }
 
 // Methods
 func TestBlinkMDriver(t *testing.T) {
 	blinkM := initTestBlinkMDriver()
 
-	gobot.Assert(t, blinkM.Name(), "bot")
-	gobot.Assert(t, blinkM.Connection().Name(), "adaptor")
+	gobottest.Assert(t, blinkM.Name(), "bot")
+	gobottest.Assert(t, blinkM.Connection().Name(), "adaptor")
 }
 
 func TestBlinkMDriverStart(t *testing.T) {
 	blinkM, adaptor := initTestBlinkDriverWithStubbedAdaptor()
 
-	gobot.Assert(t, len(blinkM.Start()), 0)
+	gobottest.Assert(t, len(blinkM.Start()), 0)
 
 	adaptor.i2cStartImpl = func() error {
 		return errors.New("start error")
 	}
 
-	gobot.Assert(t, blinkM.Start()[0], errors.New("start error"))
+	gobottest.Assert(t, blinkM.Start()[0], errors.New("start error"))
 	adaptor.i2cStartImpl = func() error {
 		return nil
 	}
 	adaptor.i2cWriteImpl = func() error {
 		return errors.New("write error")
 	}
-	gobot.Assert(t, blinkM.Start()[0], errors.New("write error"))
+	gobottest.Assert(t, blinkM.Start()[0], errors.New("write error"))
 }
 
 func TestBlinkMDriverHalt(t *testing.T) {
 	blinkM := initTestBlinkMDriver()
-	gobot.Assert(t, len(blinkM.Halt()), 0)
+	gobottest.Assert(t, len(blinkM.Halt()), 0)
 }
 
 func TestBlinkMDriverFirmwareVersion(t *testing.T) {
@@ -121,7 +121,7 @@ func TestBlinkMDriverFirmwareVersion(t *testing.T) {
 	}
 
 	version, _ := blinkM.FirmwareVersion()
-	gobot.Assert(t, version, "99.1")
+	gobottest.Assert(t, version, "99.1")
 
 	// when len(data) is not 2
 	adaptor.i2cReadImpl = func() ([]byte, error) {
@@ -129,14 +129,14 @@ func TestBlinkMDriverFirmwareVersion(t *testing.T) {
 	}
 
 	version, _ = blinkM.FirmwareVersion()
-	gobot.Assert(t, version, "")
+	gobottest.Assert(t, version, "")
 
 	adaptor.i2cWriteImpl = func() error {
 		return errors.New("write error")
 	}
 
 	version, err := blinkM.FirmwareVersion()
-	gobot.Assert(t, err, errors.New("write error"))
+	gobottest.Assert(t, err, errors.New("write error"))
 }
 
 func TestBlinkMDriverColor(t *testing.T) {
@@ -148,7 +148,7 @@ func TestBlinkMDriverColor(t *testing.T) {
 	}
 
 	color, _ := blinkM.Color()
-	gobot.Assert(t, color, []byte{99, 1, 2})
+	gobottest.Assert(t, color, []byte{99, 1, 2})
 
 	// when len(data) is not 3
 	adaptor.i2cReadImpl = func() ([]byte, error) {
@@ -156,14 +156,14 @@ func TestBlinkMDriverColor(t *testing.T) {
 	}
 
 	color, _ = blinkM.Color()
-	gobot.Assert(t, color, []byte{})
+	gobottest.Assert(t, color, []byte{})
 
 	adaptor.i2cWriteImpl = func() error {
 		return errors.New("write error")
 	}
 
 	color, err := blinkM.Color()
-	gobot.Assert(t, err, errors.New("write error"))
+	gobottest.Assert(t, err, errors.New("write error"))
 
 }
 
@@ -175,7 +175,7 @@ func TestBlinkMDriverFade(t *testing.T) {
 	}
 
 	err := blinkM.Fade(100, 100, 100)
-	gobot.Assert(t, err, errors.New("write error"))
+	gobottest.Assert(t, err, errors.New("write error"))
 
 }
 
@@ -187,6 +187,6 @@ func TestBlinkMDriverRGB(t *testing.T) {
 	}
 
 	err := blinkM.Rgb(100, 100, 100)
-	gobot.Assert(t, err, errors.New("write error"))
+	gobottest.Assert(t, err, errors.New("write error"))
 
 }

--- a/platforms/i2c/hmc6352_driver_test.go
+++ b/platforms/i2c/hmc6352_driver_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 // --------- HELPERS
@@ -29,34 +29,34 @@ func TestNewHMC6352Driver(t *testing.T) {
 	}
 
 	b := NewHMC6352Driver(newI2cTestAdaptor("adaptor"), "bot")
-	gobot.Assert(t, b.Name(), "bot")
-	gobot.Assert(t, b.Connection().Name(), "adaptor")
+	gobottest.Assert(t, b.Name(), "bot")
+	gobottest.Assert(t, b.Connection().Name(), "adaptor")
 }
 
 // Methods
 func TestHMC6352DriverStart(t *testing.T) {
 	hmc, adaptor := initTestHMC6352DriverWithStubbedAdaptor()
 
-	gobot.Assert(t, len(hmc.Start()), 0)
+	gobottest.Assert(t, len(hmc.Start()), 0)
 
 	adaptor.i2cWriteImpl = func() error {
 		return errors.New("write error")
 	}
 	err := hmc.Start()
-	gobot.Assert(t, err[0], errors.New("write error"))
+	gobottest.Assert(t, err[0], errors.New("write error"))
 
 	adaptor.i2cStartImpl = func() error {
 		return errors.New("start error")
 	}
 	err = hmc.Start()
-	gobot.Assert(t, err[0], errors.New("start error"))
+	gobottest.Assert(t, err[0], errors.New("start error"))
 
 }
 
 func TestHMC6352DriverHalt(t *testing.T) {
 	hmc := initTestHMC6352Driver()
 
-	gobot.Assert(t, len(hmc.Halt()), 0)
+	gobottest.Assert(t, len(hmc.Halt()), 0)
 }
 
 func TestHMC6352DriverHeading(t *testing.T) {
@@ -68,7 +68,7 @@ func TestHMC6352DriverHeading(t *testing.T) {
 	}
 
 	heading, _ := hmc.Heading()
-	gobot.Assert(t, heading, uint16(2534))
+	gobottest.Assert(t, heading, uint16(2534))
 
 	// when len(data) is not 2
 	hmc, adaptor = initTestHMC6352DriverWithStubbedAdaptor()
@@ -78,8 +78,8 @@ func TestHMC6352DriverHeading(t *testing.T) {
 	}
 
 	heading, err := hmc.Heading()
-	gobot.Assert(t, heading, uint16(0))
-	gobot.Assert(t, err, ErrNotEnoughBytes)
+	gobottest.Assert(t, heading, uint16(0))
+	gobottest.Assert(t, err, ErrNotEnoughBytes)
 
 	// when read error
 	hmc, adaptor = initTestHMC6352DriverWithStubbedAdaptor()
@@ -89,8 +89,8 @@ func TestHMC6352DriverHeading(t *testing.T) {
 	}
 
 	heading, err = hmc.Heading()
-	gobot.Assert(t, heading, uint16(0))
-	gobot.Assert(t, err, errors.New("read error"))
+	gobottest.Assert(t, heading, uint16(0))
+	gobottest.Assert(t, err, errors.New("read error"))
 
 	// when write error
 	hmc, adaptor = initTestHMC6352DriverWithStubbedAdaptor()
@@ -100,6 +100,6 @@ func TestHMC6352DriverHeading(t *testing.T) {
 	}
 
 	heading, err = hmc.Heading()
-	gobot.Assert(t, heading, uint16(0))
-	gobot.Assert(t, err, errors.New("write error"))
+	gobottest.Assert(t, heading, uint16(0))
+	gobottest.Assert(t, err, errors.New("write error"))
 }

--- a/platforms/i2c/lidarlite_driver_test.go
+++ b/platforms/i2c/lidarlite_driver_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 // --------- HELPERS
@@ -29,28 +29,28 @@ func TestNewLIDARLiteDriver(t *testing.T) {
 	}
 
 	b := NewLIDARLiteDriver(newI2cTestAdaptor("adaptor"), "bot")
-	gobot.Assert(t, b.Name(), "bot")
-	gobot.Assert(t, b.Connection().Name(), "adaptor")
+	gobottest.Assert(t, b.Name(), "bot")
+	gobottest.Assert(t, b.Connection().Name(), "adaptor")
 }
 
 // Methods
 func TestLIDARLiteDriverStart(t *testing.T) {
 	hmc, adaptor := initTestLIDARLiteDriverWithStubbedAdaptor()
 
-	gobot.Assert(t, len(hmc.Start()), 0)
+	gobottest.Assert(t, len(hmc.Start()), 0)
 
 	adaptor.i2cStartImpl = func() error {
 		return errors.New("start error")
 	}
 	err := hmc.Start()
-	gobot.Assert(t, err[0], errors.New("start error"))
+	gobottest.Assert(t, err[0], errors.New("start error"))
 
 }
 
 func TestLIDARLiteDriverHalt(t *testing.T) {
 	hmc := initTestLIDARLiteDriver()
 
-	gobot.Assert(t, len(hmc.Halt()), 0)
+	gobottest.Assert(t, len(hmc.Halt()), 0)
 }
 
 func TestLIDARLiteDriverDistance(t *testing.T) {
@@ -68,8 +68,8 @@ func TestLIDARLiteDriverDistance(t *testing.T) {
 
 	distance, err := hmc.Distance()
 
-	gobot.Assert(t, err, nil)
-	gobot.Assert(t, distance, int(25345))
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, distance, int(25345))
 
 	// when insufficient bytes have been read
 	hmc, adaptor = initTestLIDARLiteDriverWithStubbedAdaptor()
@@ -79,8 +79,8 @@ func TestLIDARLiteDriverDistance(t *testing.T) {
 	}
 
 	distance, err = hmc.Distance()
-	gobot.Assert(t, distance, int(0))
-	gobot.Assert(t, err, ErrNotEnoughBytes)
+	gobottest.Assert(t, distance, int(0))
+	gobottest.Assert(t, err, ErrNotEnoughBytes)
 
 	// when read error
 	hmc, adaptor = initTestLIDARLiteDriverWithStubbedAdaptor()
@@ -90,8 +90,8 @@ func TestLIDARLiteDriverDistance(t *testing.T) {
 	}
 
 	distance, err = hmc.Distance()
-	gobot.Assert(t, distance, int(0))
-	gobot.Assert(t, err, errors.New("read error"))
+	gobottest.Assert(t, distance, int(0))
+	gobottest.Assert(t, err, errors.New("read error"))
 
 	// when write error
 	hmc, adaptor = initTestLIDARLiteDriverWithStubbedAdaptor()
@@ -101,6 +101,6 @@ func TestLIDARLiteDriverDistance(t *testing.T) {
 	}
 
 	distance, err = hmc.Distance()
-	gobot.Assert(t, distance, int(0))
-	gobot.Assert(t, err, errors.New("write error"))
+	gobottest.Assert(t, distance, int(0))
+	gobottest.Assert(t, err, errors.New("write error"))
 }

--- a/platforms/i2c/mcp23017_driver_test.go
+++ b/platforms/i2c/mcp23017_driver_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func initTestMCP23017Driver(b uint8) (driver *MCP23017Driver) {
@@ -28,32 +28,32 @@ func TestNewMCP23017Driver(t *testing.T) {
 	}
 
 	b := NewMCP23017Driver(newI2cTestAdaptor("adaptor"), "bot", MCP23017Config{}, 0x20)
-	gobot.Assert(t, b.Name(), "bot")
-	gobot.Assert(t, b.Connection().Name(), "adaptor")
+	gobottest.Assert(t, b.Name(), "bot")
+	gobottest.Assert(t, b.Connection().Name(), "adaptor")
 }
 
 func TestMCP23017DriverStart(t *testing.T) {
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
 
-	gobot.Assert(t, len(mcp.Start()), 0)
+	gobottest.Assert(t, len(mcp.Start()), 0)
 
 	adaptor.i2cWriteImpl = func() error {
 		return errors.New("write error")
 	}
 	err := mcp.Start()
-	gobot.Assert(t, err[0], errors.New("write error"))
+	gobottest.Assert(t, err[0], errors.New("write error"))
 
 	adaptor.i2cStartImpl = func() error {
 		return errors.New("start error")
 	}
 	err = mcp.Start()
-	gobot.Assert(t, err[0], errors.New("start error"))
+	gobottest.Assert(t, err[0], errors.New("start error"))
 }
 
 func TestMCP23017DriverHalt(t *testing.T) {
 	mcp := initTestMCP23017Driver(0)
 
-	gobot.Assert(t, len(mcp.Halt()), 0)
+	gobottest.Assert(t, len(mcp.Halt()), 0)
 }
 
 func TestMCP23017DriverWriteGPIO(t *testing.T) {
@@ -65,7 +65,7 @@ func TestMCP23017DriverWriteGPIO(t *testing.T) {
 		return nil
 	}
 	err := mcp.WriteGPIO(7, 0, "A")
-	gobot.Assert(t, err, nil)
+	gobottest.Assert(t, err, nil)
 
 	// write error
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
@@ -76,7 +76,7 @@ func TestMCP23017DriverWriteGPIO(t *testing.T) {
 		return errors.New("write error")
 	}
 	err = mcp.WriteGPIO(7, 0, "A")
-	gobot.Assert(t, err, errors.New("write error"))
+	gobottest.Assert(t, err, errors.New("write error"))
 }
 
 func TestMCP23017DriverReadGPIO(t *testing.T) {
@@ -85,7 +85,7 @@ func TestMCP23017DriverReadGPIO(t *testing.T) {
 		return []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128}, nil
 	}
 	val, _ := mcp.ReadGPIO(7, "A")
-	gobot.Assert(t, val, true)
+	gobottest.Assert(t, val, true)
 
 	// read error
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
@@ -93,7 +93,7 @@ func TestMCP23017DriverReadGPIO(t *testing.T) {
 		return nil, errors.New("read error")
 	}
 	_, err := mcp.ReadGPIO(7, "A")
-	gobot.Assert(t, err, errors.New("read error"))
+	gobottest.Assert(t, err, errors.New("read error"))
 }
 
 func TestMCP23017DriverSetPullUp(t *testing.T) {
@@ -105,7 +105,7 @@ func TestMCP23017DriverSetPullUp(t *testing.T) {
 		return nil
 	}
 	err := mcp.SetPullUp(7, 0, "A")
-	gobot.Assert(t, err, nil)
+	gobottest.Assert(t, err, nil)
 
 	// write error
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
@@ -116,7 +116,7 @@ func TestMCP23017DriverSetPullUp(t *testing.T) {
 		return errors.New("write error")
 	}
 	err = mcp.SetPullUp(7, 0, "A")
-	gobot.Assert(t, err, errors.New("write error"))
+	gobottest.Assert(t, err, errors.New("write error"))
 }
 
 func TestMCP23017DriverSetGPIOPolarity(t *testing.T) {
@@ -128,7 +128,7 @@ func TestMCP23017DriverSetGPIOPolarity(t *testing.T) {
 		return nil
 	}
 	err := mcp.SetGPIOPolarity(7, 0, "A")
-	gobot.Assert(t, err, nil)
+	gobottest.Assert(t, err, nil)
 
 	// write error
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
@@ -139,7 +139,7 @@ func TestMCP23017DriverSetGPIOPolarity(t *testing.T) {
 		return errors.New("write error")
 	}
 	err = mcp.SetGPIOPolarity(7, 0, "A")
-	gobot.Assert(t, err, errors.New("write error"))
+	gobottest.Assert(t, err, errors.New("write error"))
 
 }
 
@@ -154,7 +154,7 @@ func TestMCP23017DriverWrite(t *testing.T) {
 		return nil
 	}
 	err := mcp.write(port.IODIR, uint8(7), 0)
-	gobot.Assert(t, err, nil)
+	gobottest.Assert(t, err, nil)
 
 	// set bit
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
@@ -166,7 +166,7 @@ func TestMCP23017DriverWrite(t *testing.T) {
 		return nil
 	}
 	err = mcp.write(port.IODIR, uint8(7), 1)
-	gobot.Assert(t, err, nil)
+	gobottest.Assert(t, err, nil)
 
 	// write error
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
@@ -177,7 +177,7 @@ func TestMCP23017DriverWrite(t *testing.T) {
 		return errors.New("write error")
 	}
 	err = mcp.write(port.IODIR, uint8(7), 0)
-	gobot.Assert(t, err, errors.New("write error"))
+	gobottest.Assert(t, err, errors.New("write error"))
 
 	// read error
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
@@ -185,7 +185,7 @@ func TestMCP23017DriverWrite(t *testing.T) {
 		return []byte{}, errors.New("read error")
 	}
 	err = mcp.write(port.IODIR, uint8(7), 0)
-	gobot.Assert(t, err, errors.New("read error"))
+	gobottest.Assert(t, err, errors.New("read error"))
 }
 
 func TestMCP23017DriverReadPort(t *testing.T) {
@@ -197,7 +197,7 @@ func TestMCP23017DriverReadPort(t *testing.T) {
 		return []byte{255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, nil
 	}
 	val, _ := mcp.read(port.IODIR)
-	gobot.Assert(t, val, uint8(255))
+	gobottest.Assert(t, val, uint8(255))
 
 	// read error
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
@@ -206,8 +206,8 @@ func TestMCP23017DriverReadPort(t *testing.T) {
 	}
 
 	val, err := mcp.read(port.IODIR)
-	gobot.Assert(t, val, uint8(0))
-	gobot.Assert(t, err, errors.New("read error"))
+	gobottest.Assert(t, val, uint8(0))
+	gobottest.Assert(t, err, errors.New("read error"))
 
 	// debug
 	Debug = true
@@ -220,7 +220,7 @@ func TestMCP23017DriverReadPort(t *testing.T) {
 	}
 
 	val, _ = mcp.read(port.IODIR)
-	gobot.Assert(t, val, uint8(255))
+	gobottest.Assert(t, val, uint8(255))
 	Debug = false
 	log.SetOutput(os.Stdout)
 }
@@ -230,35 +230,35 @@ func TestMCP23017DriverGetPort(t *testing.T) {
 	mcp := initTestMCP23017Driver(0)
 	expectedPort := getBank(0).PortA
 	actualPort := mcp.getPort("A")
-	gobot.Assert(t, expectedPort, actualPort)
+	gobottest.Assert(t, expectedPort, actualPort)
 
 	// port b
 	mcp = initTestMCP23017Driver(0)
 	expectedPort = getBank(0).PortB
 	actualPort = mcp.getPort("B")
-	gobot.Assert(t, expectedPort, actualPort)
+	gobottest.Assert(t, expectedPort, actualPort)
 
 	// default
 	mcp = initTestMCP23017Driver(0)
 	expectedPort = getBank(0).PortA
 	actualPort = mcp.getPort("")
-	gobot.Assert(t, expectedPort, actualPort)
+	gobottest.Assert(t, expectedPort, actualPort)
 
 	// port a bank 1
 	mcp = initTestMCP23017Driver(1)
 	expectedPort = getBank(1).PortA
 	actualPort = mcp.getPort("")
-	gobot.Assert(t, expectedPort, actualPort)
+	gobottest.Assert(t, expectedPort, actualPort)
 }
 
 func TestSetBit(t *testing.T) {
 	var expectedVal uint8 = 129
 	actualVal := setBit(1, 7)
-	gobot.Assert(t, expectedVal, actualVal)
+	gobottest.Assert(t, expectedVal, actualVal)
 }
 
 func TestClearBit(t *testing.T) {
 	var expectedVal uint8 = 0
 	actualVal := clearBit(128, 7)
-	gobot.Assert(t, expectedVal, actualVal)
+	gobottest.Assert(t, expectedVal, actualVal)
 }

--- a/platforms/i2c/mpl115a2_driver_test.go
+++ b/platforms/i2c/mpl115a2_driver_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 // --------- HELPERS
@@ -33,12 +33,12 @@ func TestNewMPL115A2Driver(t *testing.T) {
 func TestMPL115A2Driver(t *testing.T) {
 	mpl := initTestMPL115A2Driver()
 
-	gobot.Assert(t, mpl.Name(), "bot")
-	gobot.Assert(t, mpl.Connection().Name(), "adaptor")
-	gobot.Assert(t, mpl.interval, 10*time.Millisecond)
+	gobottest.Assert(t, mpl.Name(), "bot")
+	gobottest.Assert(t, mpl.Connection().Name(), "adaptor")
+	gobottest.Assert(t, mpl.interval, 10*time.Millisecond)
 
 	mpl = NewMPL115A2Driver(newI2cTestAdaptor("adaptor"), "bot", 100*time.Millisecond)
-	gobot.Assert(t, mpl.interval, 100*time.Millisecond)
+	gobottest.Assert(t, mpl.interval, 100*time.Millisecond)
 }
 
 func TestMPL115A2DriverStart(t *testing.T) {
@@ -47,14 +47,14 @@ func TestMPL115A2DriverStart(t *testing.T) {
 	adaptor.i2cReadImpl = func() ([]byte, error) {
 		return []byte{0x00, 0x01, 0x02, 0x04}, nil
 	}
-	gobot.Assert(t, len(mpl.Start()), 0)
+	gobottest.Assert(t, len(mpl.Start()), 0)
 	<-time.After(100 * time.Millisecond)
-	gobot.Assert(t, mpl.Pressure, float32(50.007942))
-	gobot.Assert(t, mpl.Temperature, float32(116.58878))
+	gobottest.Assert(t, mpl.Pressure, float32(50.007942))
+	gobottest.Assert(t, mpl.Temperature, float32(116.58878))
 }
 
 func TestMPL115A2DriverHalt(t *testing.T) {
 	mpl := initTestMPL115A2Driver()
 
-	gobot.Assert(t, len(mpl.Halt()), 0)
+	gobottest.Assert(t, len(mpl.Halt()), 0)
 }

--- a/platforms/i2c/mpu6050_driver_test.go
+++ b/platforms/i2c/mpu6050_driver_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 // --------- HELPERS
@@ -31,23 +31,23 @@ func TestNewMPU6050Driver(t *testing.T) {
 
 func TestMPU6050Driver(t *testing.T) {
 	mpu := initTestMPU6050Driver()
-	gobot.Assert(t, mpu.Name(), "bot")
-	gobot.Assert(t, mpu.Connection().Name(), "adaptor")
-	gobot.Assert(t, mpu.interval, 10*time.Millisecond)
+	gobottest.Assert(t, mpu.Name(), "bot")
+	gobottest.Assert(t, mpu.Connection().Name(), "adaptor")
+	gobottest.Assert(t, mpu.interval, 10*time.Millisecond)
 
 	mpu = NewMPU6050Driver(newI2cTestAdaptor("adaptor"), "bot", 100*time.Millisecond)
-	gobot.Assert(t, mpu.interval, 100*time.Millisecond)
+	gobottest.Assert(t, mpu.interval, 100*time.Millisecond)
 }
 
 // Methods
 func TestMPU6050DriverStart(t *testing.T) {
 	mpu := initTestMPU6050Driver()
 
-	gobot.Assert(t, len(mpu.Start()), 0)
+	gobottest.Assert(t, len(mpu.Start()), 0)
 }
 
 func TestMPU6050DriverHalt(t *testing.T) {
 	mpu := initTestMPU6050Driver()
 
-	gobot.Assert(t, len(mpu.Halt()), 0)
+	gobottest.Assert(t, len(mpu.Halt()), 0)
 }

--- a/platforms/i2c/wiichuck_driver_test.go
+++ b/platforms/i2c/wiichuck_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 // --------- HELPERS
@@ -31,12 +32,12 @@ func TestNewWiichuckDriver(t *testing.T) {
 
 func TestWiichuckDriver(t *testing.T) {
 	wii := initTestWiichuckDriver()
-	gobot.Assert(t, wii.Name(), "bot")
-	gobot.Assert(t, wii.Connection().Name(), "adaptor")
-	gobot.Assert(t, wii.interval, 10*time.Millisecond)
+	gobottest.Assert(t, wii.Name(), "bot")
+	gobottest.Assert(t, wii.Connection().Name(), "adaptor")
+	gobottest.Assert(t, wii.interval, 10*time.Millisecond)
 
 	wii = NewWiichuckDriver(newI2cTestAdaptor("adaptor"), "bot", 100*time.Millisecond)
-	gobot.Assert(t, wii.interval, 100*time.Millisecond)
+	gobottest.Assert(t, wii.interval, 100*time.Millisecond)
 }
 func TestWiichuckDriverStart(t *testing.T) {
 	sem := make(chan bool)
@@ -49,7 +50,7 @@ func TestWiichuckDriverStart(t *testing.T) {
 	numberOfCyclesForEvery := 3
 
 	wii.interval = 1 * time.Millisecond
-	gobot.Assert(t, len(wii.Start()), 0)
+	gobottest.Assert(t, len(wii.Start()), 0)
 
 	go func() {
 		for {
@@ -72,7 +73,7 @@ func TestWiichuckDriverStart(t *testing.T) {
 func TestWiichuckDriverHalt(t *testing.T) {
 	wii := initTestWiichuckDriver()
 
-	gobot.Assert(t, len(wii.Halt()), 0)
+	gobottest.Assert(t, len(wii.Halt()), 0)
 }
 
 func TestWiichuckDriverUpdate(t *testing.T) {
@@ -83,20 +84,20 @@ func TestWiichuckDriverUpdate(t *testing.T) {
 	wii.update(decryptedValue)
 
 	// - This should be done by WiichuckDriver.parse
-	gobot.Assert(t, wii.data["sx"], float64(45))
-	gobot.Assert(t, wii.data["sy"], float64(44))
-	gobot.Assert(t, wii.data["z"], float64(0))
-	gobot.Assert(t, wii.data["c"], float64(0))
+	gobottest.Assert(t, wii.data["sx"], float64(45))
+	gobottest.Assert(t, wii.data["sy"], float64(44))
+	gobottest.Assert(t, wii.data["z"], float64(0))
+	gobottest.Assert(t, wii.data["c"], float64(0))
 
 	// - This should be done by WiichuckDriver.adjustOrigins
-	gobot.Assert(t, wii.joystick["sx_origin"], float64(45))
-	gobot.Assert(t, wii.joystick["sy_origin"], float64(44))
+	gobottest.Assert(t, wii.joystick["sx_origin"], float64(45))
+	gobottest.Assert(t, wii.joystick["sy_origin"], float64(44))
 
 	// - This should be done by WiichuckDriver.updateButtons
 	chann := make(chan bool)
 
 	gobot.On(wii.Event(C), func(data interface{}) {
-		gobot.Assert(t, data, true)
+		gobottest.Assert(t, data, true)
 		chann <- true
 	})
 
@@ -109,7 +110,7 @@ func TestWiichuckDriverUpdate(t *testing.T) {
 	}
 
 	gobot.On(wii.Event(Z), func(data interface{}) {
-		gobot.Assert(t, data, true)
+		gobottest.Assert(t, data, true)
 		chann <- true
 	})
 
@@ -128,7 +129,7 @@ func TestWiichuckDriverUpdate(t *testing.T) {
 	}
 
 	gobot.On(wii.Event(Joystick), func(data interface{}) {
-		gobot.Assert(t, data, expectedData)
+		gobottest.Assert(t, data, expectedData)
 		chann <- true
 	})
 
@@ -146,106 +147,106 @@ func TestWiichuckDriverUpdate(t *testing.T) {
 
 	wii.update(encryptedValue)
 
-	gobot.Assert(t, wii.data["sx"], float64(0))
-	gobot.Assert(t, wii.data["sy"], float64(0))
-	gobot.Assert(t, wii.data["z"], float64(0))
-	gobot.Assert(t, wii.data["c"], float64(0))
+	gobottest.Assert(t, wii.data["sx"], float64(0))
+	gobottest.Assert(t, wii.data["sy"], float64(0))
+	gobottest.Assert(t, wii.data["z"], float64(0))
+	gobottest.Assert(t, wii.data["c"], float64(0))
 
-	gobot.Assert(t, wii.joystick["sx_origin"], float64(-1))
-	gobot.Assert(t, wii.joystick["sy_origin"], float64(-1))
+	gobottest.Assert(t, wii.joystick["sx_origin"], float64(-1))
+	gobottest.Assert(t, wii.joystick["sy_origin"], float64(-1))
 }
 
 func TestWiichuckDriverSetJoystickDefaultValue(t *testing.T) {
 	wii := initTestWiichuckDriver()
 
-	gobot.Assert(t, wii.joystick["sy_origin"], float64(-1))
+	gobottest.Assert(t, wii.joystick["sy_origin"], float64(-1))
 
 	wii.setJoystickDefaultValue("sy_origin", float64(2))
 
-	gobot.Assert(t, wii.joystick["sy_origin"], float64(2))
+	gobottest.Assert(t, wii.joystick["sy_origin"], float64(2))
 
 	// when current default value is not -1 it keeps the current value
 
 	wii.setJoystickDefaultValue("sy_origin", float64(20))
 
-	gobot.Assert(t, wii.joystick["sy_origin"], float64(2))
+	gobottest.Assert(t, wii.joystick["sy_origin"], float64(2))
 
 }
 
 func TestWiichuckDriverCalculateJoystickValue(t *testing.T) {
 	wii := initTestWiichuckDriver()
 
-	gobot.Assert(t, wii.calculateJoystickValue(float64(20), float64(5)), float64(15))
-	gobot.Assert(t, wii.calculateJoystickValue(float64(1), float64(2)), float64(-1))
-	gobot.Assert(t, wii.calculateJoystickValue(float64(10), float64(5)), float64(5))
-	gobot.Assert(t, wii.calculateJoystickValue(float64(5), float64(10)), float64(-5))
+	gobottest.Assert(t, wii.calculateJoystickValue(float64(20), float64(5)), float64(15))
+	gobottest.Assert(t, wii.calculateJoystickValue(float64(1), float64(2)), float64(-1))
+	gobottest.Assert(t, wii.calculateJoystickValue(float64(10), float64(5)), float64(5))
+	gobottest.Assert(t, wii.calculateJoystickValue(float64(5), float64(10)), float64(-5))
 }
 
 func TestWiichuckDriverIsEncrypted(t *testing.T) {
 	wii := initTestWiichuckDriver()
 
 	encryptedValue := []byte{1, 1, 2, 2, 3, 3}
-	gobot.Assert(t, wii.isEncrypted(encryptedValue), true)
+	gobottest.Assert(t, wii.isEncrypted(encryptedValue), true)
 
 	encryptedValue = []byte{42, 42, 24, 24, 30, 30}
-	gobot.Assert(t, wii.isEncrypted(encryptedValue), true)
+	gobottest.Assert(t, wii.isEncrypted(encryptedValue), true)
 
 	decryptedValue := []byte{1, 2, 3, 4, 5, 6}
-	gobot.Assert(t, wii.isEncrypted(decryptedValue), false)
+	gobottest.Assert(t, wii.isEncrypted(decryptedValue), false)
 
 	decryptedValue = []byte{1, 1, 2, 2, 5, 6}
-	gobot.Assert(t, wii.isEncrypted(decryptedValue), false)
+	gobottest.Assert(t, wii.isEncrypted(decryptedValue), false)
 
 	decryptedValue = []byte{1, 1, 2, 3, 3, 3}
-	gobot.Assert(t, wii.isEncrypted(decryptedValue), false)
+	gobottest.Assert(t, wii.isEncrypted(decryptedValue), false)
 }
 
 func TestWiichuckDriverDecode(t *testing.T) {
 	wii := initTestWiichuckDriver()
 
-	gobot.Assert(t, wii.decode(byte(0)), float64(46))
-	gobot.Assert(t, wii.decode(byte(100)), float64(138))
-	gobot.Assert(t, wii.decode(byte(200)), float64(246))
-	gobot.Assert(t, wii.decode(byte(254)), float64(0))
+	gobottest.Assert(t, wii.decode(byte(0)), float64(46))
+	gobottest.Assert(t, wii.decode(byte(100)), float64(138))
+	gobottest.Assert(t, wii.decode(byte(200)), float64(246))
+	gobottest.Assert(t, wii.decode(byte(254)), float64(0))
 }
 
 func TestWiichuckDriverParse(t *testing.T) {
 	wii := initTestWiichuckDriver()
 
-	gobot.Assert(t, wii.data["sx"], float64(0))
-	gobot.Assert(t, wii.data["sy"], float64(0))
-	gobot.Assert(t, wii.data["z"], float64(0))
-	gobot.Assert(t, wii.data["c"], float64(0))
+	gobottest.Assert(t, wii.data["sx"], float64(0))
+	gobottest.Assert(t, wii.data["sy"], float64(0))
+	gobottest.Assert(t, wii.data["z"], float64(0))
+	gobottest.Assert(t, wii.data["c"], float64(0))
 
 	// First pass
 	wii.parse([]byte{12, 23, 34, 45, 56, 67})
 
-	gobot.Assert(t, wii.data["sx"], float64(50))
-	gobot.Assert(t, wii.data["sy"], float64(23))
-	gobot.Assert(t, wii.data["z"], float64(1))
-	gobot.Assert(t, wii.data["c"], float64(2))
+	gobottest.Assert(t, wii.data["sx"], float64(50))
+	gobottest.Assert(t, wii.data["sy"], float64(23))
+	gobottest.Assert(t, wii.data["z"], float64(1))
+	gobottest.Assert(t, wii.data["c"], float64(2))
 
 	// Second pass
 	wii.parse([]byte{70, 81, 92, 103, 204, 205})
 
-	gobot.Assert(t, wii.data["sx"], float64(104))
-	gobot.Assert(t, wii.data["sy"], float64(93))
-	gobot.Assert(t, wii.data["z"], float64(1))
-	gobot.Assert(t, wii.data["c"], float64(0))
+	gobottest.Assert(t, wii.data["sx"], float64(104))
+	gobottest.Assert(t, wii.data["sy"], float64(93))
+	gobottest.Assert(t, wii.data["z"], float64(1))
+	gobottest.Assert(t, wii.data["c"], float64(0))
 }
 
 func TestWiichuckDriverAdjustOrigins(t *testing.T) {
 	wii := initTestWiichuckDriver()
 
-	gobot.Assert(t, wii.joystick["sy_origin"], float64(-1))
-	gobot.Assert(t, wii.joystick["sx_origin"], float64(-1))
+	gobottest.Assert(t, wii.joystick["sy_origin"], float64(-1))
+	gobottest.Assert(t, wii.joystick["sx_origin"], float64(-1))
 
 	// First pass
 	wii.parse([]byte{1, 2, 3, 4, 5, 6})
 	wii.adjustOrigins()
 
-	gobot.Assert(t, wii.joystick["sy_origin"], float64(44))
-	gobot.Assert(t, wii.joystick["sx_origin"], float64(45))
+	gobottest.Assert(t, wii.joystick["sy_origin"], float64(44))
+	gobottest.Assert(t, wii.joystick["sx_origin"], float64(45))
 
 	// Second pass
 	wii = initTestWiichuckDriver()
@@ -253,8 +254,8 @@ func TestWiichuckDriverAdjustOrigins(t *testing.T) {
 	wii.parse([]byte{61, 72, 83, 94, 105, 206})
 	wii.adjustOrigins()
 
-	gobot.Assert(t, wii.joystick["sy_origin"], float64(118))
-	gobot.Assert(t, wii.joystick["sx_origin"], float64(65))
+	gobottest.Assert(t, wii.joystick["sy_origin"], float64(118))
+	gobottest.Assert(t, wii.joystick["sx_origin"], float64(65))
 }
 
 func TestWiichuckDriverUpdateButtons(t *testing.T) {
@@ -265,7 +266,7 @@ func TestWiichuckDriverUpdateButtons(t *testing.T) {
 	wii.data["c"] = 0
 
 	gobot.On(wii.Event(C), func(data interface{}) {
-		gobot.Assert(t, true, data)
+		gobottest.Assert(t, true, data)
 		chann <- true
 	})
 
@@ -283,7 +284,7 @@ func TestWiichuckDriverUpdateButtons(t *testing.T) {
 	wii.data["z"] = 0
 
 	gobot.On(wii.Event(Z), func(data interface{}) {
-		gobot.Assert(t, true, data)
+		gobottest.Assert(t, true, data)
 		chann <- true
 	})
 
@@ -312,7 +313,7 @@ func TestWiichuckDriverUpdateJoystick(t *testing.T) {
 	}
 
 	gobot.On(wii.Event(Joystick), func(data interface{}) {
-		gobot.Assert(t, data, expectedData)
+		gobottest.Assert(t, data, expectedData)
 		chann <- true
 	})
 
@@ -338,7 +339,7 @@ func TestWiichuckDriverUpdateJoystick(t *testing.T) {
 	}
 
 	gobot.On(wii.Event(Joystick), func(data interface{}) {
-		gobot.Assert(t, data, expectedData)
+		gobottest.Assert(t, data, expectedData)
 		chann <- true
 	})
 

--- a/platforms/intel-iot/edison/edison_adaptor_test.go
+++ b/platforms/intel-iot/edison/edison_adaptor_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 	"github.com/hybridgroup/gobot/sysfs"
 )
 
@@ -113,15 +113,15 @@ func initTestEdisonAdaptor() (*EdisonAdaptor, *sysfs.MockFilesystem) {
 
 func TestEdisonAdaptor(t *testing.T) {
 	a, _ := initTestEdisonAdaptor()
-	gobot.Assert(t, a.Name(), "myAdaptor")
+	gobottest.Assert(t, a.Name(), "myAdaptor")
 }
 func TestEdisonAdaptorConnect(t *testing.T) {
 	a, _ := initTestEdisonAdaptor()
-	gobot.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, len(a.Connect()), 0)
 
 	a = NewEdisonAdaptor("myAdaptor")
 	sysfs.SetFilesystem(sysfs.NewMockFilesystem([]string{}))
-	gobot.Refute(t, len(a.Connect()), 0)
+	gobottest.Refute(t, len(a.Connect()), 0)
 }
 
 func TestEdisonAdaptorFinalize(t *testing.T) {
@@ -132,23 +132,23 @@ func TestEdisonAdaptorFinalize(t *testing.T) {
 	sysfs.SetSyscall(&sysfs.MockSyscall{})
 	a.I2cStart(0xff)
 
-	gobot.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, len(a.Finalize()), 0)
 
 	closeErr = errors.New("close error")
 	sysfs.SetFilesystem(sysfs.NewMockFilesystem([]string{}))
-	gobot.Refute(t, len(a.Finalize()), 0)
+	gobottest.Refute(t, len(a.Finalize()), 0)
 }
 
 func TestEdisonAdaptorDigitalIO(t *testing.T) {
 	a, fs := initTestEdisonAdaptor()
 
 	a.DigitalWrite("13", 1)
-	gobot.Assert(t, fs.Files["/sys/class/gpio/gpio40/value"].Contents, "1")
+	gobottest.Assert(t, fs.Files["/sys/class/gpio/gpio40/value"].Contents, "1")
 
 	a.DigitalWrite("2", 0)
 	i, err := a.DigitalRead("2")
-	gobot.Assert(t, err, nil)
-	gobot.Assert(t, i, 0)
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, i, 0)
 }
 
 func TestEdisonAdaptorI2c(t *testing.T) {
@@ -161,18 +161,18 @@ func TestEdisonAdaptorI2c(t *testing.T) {
 	a.I2cWrite(0xff, []byte{0x00, 0x01})
 
 	data, _ := a.I2cRead(0xff, 2)
-	gobot.Assert(t, data, []byte{0x00, 0x01})
+	gobottest.Assert(t, data, []byte{0x00, 0x01})
 }
 
 func TestEdisonAdaptorPwm(t *testing.T) {
 	a, fs := initTestEdisonAdaptor()
 
 	err := a.PwmWrite("5", 100)
-	gobot.Assert(t, err, nil)
-	gobot.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm1/duty_cycle"].Contents, "1960")
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm1/duty_cycle"].Contents, "1960")
 
 	err = a.PwmWrite("7", 100)
-	gobot.Assert(t, err, errors.New("Not a PWM pin"))
+	gobottest.Assert(t, err, errors.New("Not a PWM pin"))
 }
 
 func TestEdisonAdaptorAnalog(t *testing.T) {
@@ -180,5 +180,5 @@ func TestEdisonAdaptorAnalog(t *testing.T) {
 
 	fs.Files["/sys/bus/iio/devices/iio:device1/in_voltage0_raw"].Contents = "1000\n"
 	i, _ := a.AnalogRead("0")
-	gobot.Assert(t, i, 250)
+	gobottest.Assert(t, i, 250)
 }

--- a/platforms/joystick/joystick_adaptor_test.go
+++ b/platforms/joystick/joystick_adaptor_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func initTestJoystickAdaptor() *JoystickAdaptor {
@@ -18,14 +18,14 @@ func initTestJoystickAdaptor() *JoystickAdaptor {
 
 func TestJoystickAdaptorConnect(t *testing.T) {
 	a := initTestJoystickAdaptor()
-	gobot.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, len(a.Connect()), 0)
 
 	a = NewJoystickAdaptor("bot")
-	gobot.Assert(t, a.Connect()[0], errors.New("No joystick available"))
+	gobottest.Assert(t, a.Connect()[0], errors.New("No joystick available"))
 }
 
 func TestJoystickAdaptorFinalize(t *testing.T) {
 	a := initTestJoystickAdaptor()
 	a.Connect()
-	gobot.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, len(a.Finalize()), 0)
 }

--- a/platforms/joystick/joystick_driver_test.go
+++ b/platforms/joystick/joystick_driver_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/veandco/go-sdl2/sdl"
 	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
+	"github.com/veandco/go-sdl2/sdl"
 )
 
 func initTestJoystickDriver() *JoystickDriver {
@@ -25,7 +26,7 @@ func initTestJoystickDriver() *JoystickDriver {
 func TestJoystickDriverStart(t *testing.T) {
 	d := initTestJoystickDriver()
 	d.interval = 1 * time.Millisecond
-	gobot.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, len(d.Start()), 0)
 	<-time.After(2 * time.Millisecond)
 }
 
@@ -34,7 +35,7 @@ func TestJoystickDriverHalt(t *testing.T) {
 	go func() {
 		<-d.halt
 	}()
-	gobot.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, len(d.Halt()), 0)
 }
 
 func TestJoystickDriverHandleEvent(t *testing.T) {
@@ -44,7 +45,7 @@ func TestJoystickDriverHandleEvent(t *testing.T) {
 
 	// left x stick
 	gobot.On(d.Event("left_x"), func(data interface{}) {
-		gobot.Assert(t, int16(100), data.(int16))
+		gobottest.Assert(t, int16(100), data.(int16))
 		sem <- true
 	})
 	d.handleEvent(&sdl.JoyAxisEvent{
@@ -109,7 +110,7 @@ func TestJoystickDriverHandleEvent(t *testing.T) {
 		Value: 4,
 	})
 
-	gobot.Assert(t, err.Error(), "Unknown Hat: 99 4")
+	gobottest.Assert(t, err.Error(), "Unknown Hat: 99 4")
 
 	err = d.handleEvent(&sdl.JoyAxisEvent{
 		Which: 0,
@@ -117,7 +118,7 @@ func TestJoystickDriverHandleEvent(t *testing.T) {
 		Value: 100,
 	})
 
-	gobot.Assert(t, err.Error(), "Unknown Axis: 99")
+	gobottest.Assert(t, err.Error(), "Unknown Axis: 99")
 
 	err = d.handleEvent(&sdl.JoyButtonEvent{
 		Which:  0,
@@ -125,5 +126,5 @@ func TestJoystickDriverHandleEvent(t *testing.T) {
 		State:  0,
 	})
 
-	gobot.Assert(t, err.Error(), "Unknown Button: 99")
+	gobottest.Assert(t, err.Error(), "Unknown Button: 99")
 }

--- a/platforms/keyboard/keyboard_driver_test.go
+++ b/platforms/keyboard/keyboard_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func initTestKeyboardDriver() *KeyboardDriver {
@@ -19,16 +20,16 @@ func initTestKeyboardDriver() *KeyboardDriver {
 
 func TestKeyboardDriver(t *testing.T) {
 	d := initTestKeyboardDriver()
-	gobot.Assert(t, d.Name(), "keyboard")
-	gobot.Assert(t, d.Connection(), (gobot.Connection)(nil))
+	gobottest.Assert(t, d.Name(), "keyboard")
+	gobottest.Assert(t, d.Connection(), (gobot.Connection)(nil))
 }
 
 func TestKeyboardDriverStart(t *testing.T) {
 	d := initTestKeyboardDriver()
-	gobot.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, len(d.Start()), 0)
 }
 
 func TestKeyboardDriverHalt(t *testing.T) {
 	d := initTestKeyboardDriver()
-	gobot.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, len(d.Halt()), 0)
 }

--- a/platforms/leap/leap_motion_adaptor_test.go
+++ b/platforms/leap/leap_motion_adaptor_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func initTestLeapMotionAdaptor() *LeapMotionAdaptor {
@@ -16,20 +16,20 @@ func initTestLeapMotionAdaptor() *LeapMotionAdaptor {
 
 func TestLeapMotionAdaptor(t *testing.T) {
 	a := NewLeapMotionAdaptor("bot", "127.0.0.1")
-	gobot.Assert(t, a.Name(), "bot")
-	gobot.Assert(t, a.Port(), "127.0.0.1")
+	gobottest.Assert(t, a.Name(), "bot")
+	gobottest.Assert(t, a.Port(), "127.0.0.1")
 }
 func TestLeapMotionAdaptorConnect(t *testing.T) {
 	a := initTestLeapMotionAdaptor()
-	gobot.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, len(a.Connect()), 0)
 
 	a.connect = func(port string) (io.ReadWriteCloser, error) {
 		return nil, errors.New("connection error")
 	}
-	gobot.Assert(t, a.Connect()[0], errors.New("connection error"))
+	gobottest.Assert(t, a.Connect()[0], errors.New("connection error"))
 }
 
 func TestLeapMotionAdaptorFinalize(t *testing.T) {
 	a := initTestLeapMotionAdaptor()
-	gobot.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, len(a.Finalize()), 0)
 }

--- a/platforms/leap/leap_motion_driver_test.go
+++ b/platforms/leap/leap_motion_driver_test.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 type NullReadWriteCloser struct{}
@@ -38,22 +38,22 @@ func initTestLeapMotionDriver() *LeapMotionDriver {
 
 func TestLeapMotionDriver(t *testing.T) {
 	d := initTestLeapMotionDriver()
-	gobot.Assert(t, d.Name(), "bot")
-	gobot.Assert(t, d.Connection().Name(), "bot")
+	gobottest.Assert(t, d.Name(), "bot")
+	gobottest.Assert(t, d.Connection().Name(), "bot")
 }
 func TestLeapMotionDriverStart(t *testing.T) {
 	d := initTestLeapMotionDriver()
-	gobot.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, len(d.Start()), 0)
 
 	d = initTestLeapMotionDriver()
 	writeError = errors.New("write error")
-	gobot.Assert(t, d.Start()[0], errors.New("write error"))
+	gobottest.Assert(t, d.Start()[0], errors.New("write error"))
 
 }
 
 func TestLeapMotionDriverHalt(t *testing.T) {
 	d := initTestLeapMotionDriver()
-	gobot.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, len(d.Halt()), 0)
 }
 
 func TestLeapMotionDriverParser(t *testing.T) {
@@ -65,8 +65,8 @@ func TestLeapMotionDriverParser(t *testing.T) {
 		t.Errorf("ParseFrame incorrectly parsed frame")
 	}
 
-	gobot.Assert(t, parsedFrame.Timestamp, 4729292670)
-	gobot.Assert(t, parsedFrame.Hands[0].X(), 117.546)
-	gobot.Assert(t, parsedFrame.Hands[0].Y(), 236.007)
-	gobot.Assert(t, parsedFrame.Hands[0].Z(), 76.3394)
+	gobottest.Assert(t, parsedFrame.Timestamp, 4729292670)
+	gobottest.Assert(t, parsedFrame.Hands[0].X(), 117.546)
+	gobottest.Assert(t, parsedFrame.Hands[0].Y(), 236.007)
+	gobottest.Assert(t, parsedFrame.Hands[0].Z(), 76.3394)
 }

--- a/platforms/mavlink/mavlink_adaptor_test.go
+++ b/platforms/mavlink/mavlink_adaptor_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 type nullReadWriteCloser struct{}
@@ -50,23 +50,23 @@ func initTestMavlinkAdaptor() *MavlinkAdaptor {
 
 func TestMavlinkAdaptor(t *testing.T) {
 	a := initTestMavlinkAdaptor()
-	gobot.Assert(t, a.Name(), "myAdaptor")
-	gobot.Assert(t, a.Port(), "/dev/null")
+	gobottest.Assert(t, a.Name(), "myAdaptor")
+	gobottest.Assert(t, a.Port(), "/dev/null")
 }
 func TestMavlinkAdaptorConnect(t *testing.T) {
 	a := initTestMavlinkAdaptor()
-	gobot.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, len(a.Connect()), 0)
 
 	a.connect = func(port string) (io.ReadWriteCloser, error) { return nil, errors.New("connect error") }
-	gobot.Assert(t, a.Connect()[0], errors.New("connect error"))
+	gobottest.Assert(t, a.Connect()[0], errors.New("connect error"))
 }
 
 func TestMavlinkAdaptorFinalize(t *testing.T) {
 	a := initTestMavlinkAdaptor()
-	gobot.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, len(a.Finalize()), 0)
 
 	testAdaptorClose = func() error {
 		return errors.New("close error")
 	}
-	gobot.Assert(t, a.Finalize()[0], errors.New("close error"))
+	gobottest.Assert(t, a.Finalize()[0], errors.New("close error"))
 }

--- a/platforms/mavlink/mavlink_driver_test.go
+++ b/platforms/mavlink/mavlink_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 	common "github.com/hybridgroup/gobot/platforms/mavlink/common"
 )
 
@@ -23,12 +24,12 @@ func TestMavlinkDriver(t *testing.T) {
 	m.connect = func(port string) (io.ReadWriteCloser, error) { return nil, nil }
 
 	d := NewMavlinkDriver(m, "myDriver")
-	gobot.Assert(t, d.Name(), "myDriver")
-	gobot.Assert(t, d.Connection().Name(), "myAdaptor")
-	gobot.Assert(t, d.interval, 10*time.Millisecond)
+	gobottest.Assert(t, d.Name(), "myDriver")
+	gobottest.Assert(t, d.Connection().Name(), "myAdaptor")
+	gobottest.Assert(t, d.interval, 10*time.Millisecond)
 
 	d = NewMavlinkDriver(m, "myDriver", 100*time.Millisecond)
-	gobot.Assert(t, d.interval, 100*time.Millisecond)
+	gobottest.Assert(t, d.interval, 100*time.Millisecond)
 
 }
 func TestMavlinkDriverStart(t *testing.T) {
@@ -51,11 +52,11 @@ func TestMavlinkDriverStart(t *testing.T) {
 		err <- data.(error)
 	})
 
-	gobot.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, len(d.Start()), 0)
 
 	select {
 	case p := <-packet:
-		gobot.Assert(t, d.SendPacket(p), nil)
+		gobottest.Assert(t, d.SendPacket(p), nil)
 
 	case <-time.After(100 * time.Millisecond):
 		t.Errorf("packet was not emitted")
@@ -74,7 +75,7 @@ func TestMavlinkDriverStart(t *testing.T) {
 	payload = []byte{0xFE, 0x09, 0x4E, 0x01, 0x01, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x03, 0x51, 0x04, 0x03, 0x1C, 0x7F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 	select {
 	case e := <-err:
-		gobot.Assert(t, e, errors.New("Unknown Message ID: 255"))
+		gobottest.Assert(t, e, errors.New("Unknown Message ID: 255"))
 	case <-time.After(100 * time.Millisecond):
 		t.Errorf("error was not emitted")
 	}
@@ -83,5 +84,5 @@ func TestMavlinkDriverStart(t *testing.T) {
 
 func TestMavlinkDriverHalt(t *testing.T) {
 	d := initTestMavlinkDriver()
-	gobot.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, len(d.Halt()), 0)
 }

--- a/platforms/mqtt/mqtt_adaptor_test.go
+++ b/platforms/mqtt/mqtt_adaptor_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func initTestMqttAdaptor() *MqttAdaptor {
@@ -13,30 +13,30 @@ func initTestMqttAdaptor() *MqttAdaptor {
 
 func TestMqttAdaptorConnect(t *testing.T) {
 	a := initTestMqttAdaptor()
-	gobot.Assert(t, a.Connect()[0].Error(), "Network Error : Unknown protocol")
+	gobottest.Assert(t, a.Connect()[0].Error(), "Network Error : Unknown protocol")
 }
 
 func TestMqttAdaptorFinalize(t *testing.T) {
 	a := initTestMqttAdaptor()
-	gobot.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, len(a.Finalize()), 0)
 }
 
 func TestMqttAdaptorCannotPublishUnlessConnected(t *testing.T) {
 	a := initTestMqttAdaptor()
 	data := []byte("o")
-	gobot.Assert(t, a.Publish("test", data), false)
+	gobottest.Assert(t, a.Publish("test", data), false)
 }
 
 func TestMqttAdaptorPublishWhenConnected(t *testing.T) {
 	a := initTestMqttAdaptor()
 	a.Connect()
 	data := []byte("o")
-	gobot.Assert(t, a.Publish("test", data), true)
+	gobottest.Assert(t, a.Publish("test", data), true)
 }
 
 func TestMqttAdaptorCannotOnUnlessConnected(t *testing.T) {
 	a := initTestMqttAdaptor()
-	gobot.Assert(t, a.On("hola", func(data []byte) {
+	gobottest.Assert(t, a.On("hola", func(data []byte) {
 		fmt.Println("hola")
 	}), false)
 }
@@ -44,7 +44,7 @@ func TestMqttAdaptorCannotOnUnlessConnected(t *testing.T) {
 func TestMqttAdaptorOnWhenConnected(t *testing.T) {
 	a := initTestMqttAdaptor()
 	a.Connect()
-	gobot.Assert(t, a.On("hola", func(data []byte) {
+	gobottest.Assert(t, a.On("hola", func(data []byte) {
 		fmt.Println("hola")
 	}), true)
 }

--- a/platforms/neurosky/neurosky_adaptor_test.go
+++ b/platforms/neurosky/neurosky_adaptor_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 type NullReadWriteCloser struct{}
@@ -36,25 +36,25 @@ func initTestNeuroskyAdaptor() *NeuroskyAdaptor {
 
 func TestNeuroskyAdaptor(t *testing.T) {
 	a := NewNeuroskyAdaptor("bot", "/dev/null")
-	gobot.Assert(t, a.Name(), "bot")
-	gobot.Assert(t, a.Port(), "/dev/null")
+	gobottest.Assert(t, a.Name(), "bot")
+	gobottest.Assert(t, a.Port(), "/dev/null")
 }
 func TestNeuroskyAdaptorConnect(t *testing.T) {
 	a := initTestNeuroskyAdaptor()
-	gobot.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, len(a.Connect()), 0)
 
 	a.connect = func(n *NeuroskyAdaptor) (io.ReadWriteCloser, error) {
 		return nil, errors.New("connection error")
 	}
-	gobot.Assert(t, a.Connect()[0], errors.New("connection error"))
+	gobottest.Assert(t, a.Connect()[0], errors.New("connection error"))
 }
 
 func TestNeuroskyAdaptorFinalize(t *testing.T) {
 	a := initTestNeuroskyAdaptor()
 	a.Connect()
-	gobot.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, len(a.Finalize()), 0)
 
 	closeError = errors.New("close error")
 	a.Connect()
-	gobot.Assert(t, a.Finalize()[0], errors.New("close error"))
+	gobottest.Assert(t, a.Finalize()[0], errors.New("close error"))
 }

--- a/platforms/neurosky/neurosky_driver_test.go
+++ b/platforms/neurosky/neurosky_driver_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func initTestNeuroskyDriver() *NeuroskyDriver {
@@ -21,18 +22,18 @@ func initTestNeuroskyDriver() *NeuroskyDriver {
 
 func TestNeuroskyDriver(t *testing.T) {
 	d := initTestNeuroskyDriver()
-	gobot.Assert(t, d.Name(), "bot")
-	gobot.Assert(t, d.Connection().Name(), "bot")
+	gobottest.Assert(t, d.Name(), "bot")
+	gobottest.Assert(t, d.Connection().Name(), "bot")
 }
 func TestNeuroskyDriverStart(t *testing.T) {
 	sem := make(chan bool, 0)
 	d := initTestNeuroskyDriver()
 	gobot.Once(d.Event("error"), func(data interface{}) {
-		gobot.Assert(t, data.(error), errors.New("read error"))
+		gobottest.Assert(t, data.(error), errors.New("read error"))
 		sem <- true
 	})
 
-	gobot.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, len(d.Start()), 0)
 
 	<-time.After(50 * time.Millisecond)
 	readError = errors.New("read error")
@@ -49,7 +50,7 @@ func TestNeuroskyDriverStart(t *testing.T) {
 
 func TestNeuroskyDriverHalt(t *testing.T) {
 	d := initTestNeuroskyDriver()
-	gobot.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, len(d.Halt()), 0)
 }
 
 func TestNeuroskyDriverParse(t *testing.T) {
@@ -79,7 +80,7 @@ func TestNeuroskyDriverParse(t *testing.T) {
 	}()
 
 	gobot.On(d.Event("signal"), func(data interface{}) {
-		gobot.Assert(t, data.(byte), byte(100))
+		gobottest.Assert(t, data.(byte), byte(100))
 		sem <- true
 	})
 
@@ -92,7 +93,7 @@ func TestNeuroskyDriverParse(t *testing.T) {
 	}()
 
 	gobot.On(d.Event("attention"), func(data interface{}) {
-		gobot.Assert(t, data.(byte), byte(40))
+		gobottest.Assert(t, data.(byte), byte(40))
 		sem <- true
 	})
 
@@ -105,7 +106,7 @@ func TestNeuroskyDriverParse(t *testing.T) {
 	}()
 
 	gobot.On(d.Event("meditation"), func(data interface{}) {
-		gobot.Assert(t, data.(byte), byte(60))
+		gobottest.Assert(t, data.(byte), byte(60))
 		sem <- true
 	})
 
@@ -118,7 +119,7 @@ func TestNeuroskyDriverParse(t *testing.T) {
 	}()
 
 	gobot.On(d.Event("blink"), func(data interface{}) {
-		gobot.Assert(t, data.(byte), byte(150))
+		gobottest.Assert(t, data.(byte), byte(150))
 		sem <- true
 	})
 
@@ -131,7 +132,7 @@ func TestNeuroskyDriverParse(t *testing.T) {
 	}()
 
 	gobot.On(d.Event("wave"), func(data interface{}) {
-		gobot.Assert(t, data.(int16), int16(16401))
+		gobottest.Assert(t, data.(int16), int16(16401))
 		sem <- true
 	})
 
@@ -146,7 +147,7 @@ func TestNeuroskyDriverParse(t *testing.T) {
 	}()
 
 	gobot.On(d.Event("eeg"), func(data interface{}) {
-		gobot.Assert(t,
+		gobottest.Assert(t,
 			data.(EEG),
 			EEG{
 				Delta:    1573241,

--- a/platforms/opencv/camera_driver_test.go
+++ b/platforms/opencv/camera_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func initTestCameraDriver() *CameraDriver {
@@ -18,13 +19,13 @@ func initTestCameraDriver() *CameraDriver {
 
 func TestCameraDriver(t *testing.T) {
 	d := initTestCameraDriver()
-	gobot.Assert(t, d.Name(), "bot")
-	gobot.Assert(t, d.Connection(), (gobot.Connection)(nil))
+	gobottest.Assert(t, d.Name(), "bot")
+	gobottest.Assert(t, d.Connection(), (gobot.Connection)(nil))
 }
 func TestCameraDriverStart(t *testing.T) {
 	sem := make(chan bool)
 	d := initTestCameraDriver()
-	gobot.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, len(d.Start()), 0)
 	gobot.On(d.Event("frame"), func(data interface{}) {
 		sem <- true
 	})
@@ -35,14 +36,14 @@ func TestCameraDriverStart(t *testing.T) {
 	}
 
 	d = NewCameraDriver("bot", "")
-	gobot.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, len(d.Start()), 0)
 
 	d = NewCameraDriver("bot", true)
-	gobot.Refute(t, len(d.Start()), 0)
+	gobottest.Refute(t, len(d.Start()), 0)
 
 }
 
 func TestCameraDriverHalt(t *testing.T) {
 	d := initTestCameraDriver()
-	gobot.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, len(d.Halt()), 0)
 }

--- a/platforms/opencv/utils_test.go
+++ b/platforms/opencv/utils_test.go
@@ -5,14 +5,14 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/hybridgroup/gobot/gobottest"
 	cv "github.com/lazywei/go-opencv/opencv"
-	"github.com/hybridgroup/gobot"
 )
 
 func TestUtils(t *testing.T) {
 	_, currentfile, _, _ := runtime.Caller(0)
 	image := cv.LoadImage(path.Join(path.Dir(currentfile), "lena-256x256.jpg"))
 	rect := DetectFaces("haarcascade_frontalface_alt.xml", image)
-	gobot.Refute(t, len(rect), 0)
-	gobot.Refute(t, DrawRectangles(image, rect, 0, 0, 0, 0), nil)
+	gobottest.Refute(t, len(rect), 0)
+	gobottest.Refute(t, DrawRectangles(image, rect, 0, 0, 0, 0), nil)
 }

--- a/platforms/opencv/window_driver_test.go
+++ b/platforms/opencv/window_driver_test.go
@@ -5,8 +5,9 @@ import (
 	"runtime"
 	"testing"
 
-	cv "github.com/lazywei/go-opencv/opencv"
 	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
+	cv "github.com/lazywei/go-opencv/opencv"
 )
 
 func initTestWindowDriver() *WindowDriver {
@@ -16,17 +17,17 @@ func initTestWindowDriver() *WindowDriver {
 
 func TestWindowDriver(t *testing.T) {
 	d := initTestWindowDriver()
-	gobot.Assert(t, d.Name(), "bot")
-	gobot.Assert(t, d.Connection(), (gobot.Connection)(nil))
+	gobottest.Assert(t, d.Name(), "bot")
+	gobottest.Assert(t, d.Connection(), (gobot.Connection)(nil))
 }
 func TestWindowDriverStart(t *testing.T) {
 	d := initTestWindowDriver()
-	gobot.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, len(d.Start()), 0)
 }
 
 func TestWindowDriverHalt(t *testing.T) {
 	d := initTestWindowDriver()
-	gobot.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, len(d.Halt()), 0)
 }
 
 func TestWindowDriverShowImage(t *testing.T) {

--- a/platforms/pebble/pebble_adaptor_test.go
+++ b/platforms/pebble/pebble_adaptor_test.go
@@ -3,7 +3,7 @@ package pebble
 import (
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func initTestPebbleAdaptor() *PebbleAdaptor {
@@ -12,14 +12,14 @@ func initTestPebbleAdaptor() *PebbleAdaptor {
 
 func TestPebbleAdaptor(t *testing.T) {
 	a := initTestPebbleAdaptor()
-	gobot.Assert(t, a.Name(), "pebble")
+	gobottest.Assert(t, a.Name(), "pebble")
 }
 func TestPebbleAdaptorConnect(t *testing.T) {
 	a := initTestPebbleAdaptor()
-	gobot.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, len(a.Connect()), 0)
 }
 
 func TestPebbleAdaptorFinalize(t *testing.T) {
 	a := initTestPebbleAdaptor()
-	gobot.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, len(a.Finalize()), 0)
 }

--- a/platforms/pebble/pebble_driver_test.go
+++ b/platforms/pebble/pebble_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func initTestPebbleDriver() *PebbleDriver {
@@ -13,28 +14,28 @@ func initTestPebbleDriver() *PebbleDriver {
 
 func TestPebbleDriverStart(t *testing.T) {
 	d := initTestPebbleDriver()
-	gobot.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, len(d.Start()), 0)
 }
 
 func TestPebbleDriverHalt(t *testing.T) {
 	d := initTestPebbleDriver()
-	gobot.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, len(d.Halt()), 0)
 }
 
 func TestPebbleDriver(t *testing.T) {
 	d := initTestPebbleDriver()
 
-	gobot.Assert(t, d.Name(), "pebble")
-	gobot.Assert(t, d.Connection().Name(), "adaptor")
+	gobottest.Assert(t, d.Name(), "pebble")
+	gobottest.Assert(t, d.Connection().Name(), "adaptor")
 
 	sem := make(chan bool)
 	d.SendNotification("Hello")
 	d.SendNotification("World")
 
-	gobot.Assert(t, d.Messages[0], "Hello")
-	gobot.Assert(t, d.PendingMessage(), "Hello")
-	gobot.Assert(t, d.PendingMessage(), "World")
-	gobot.Assert(t, d.PendingMessage(), "")
+	gobottest.Assert(t, d.Messages[0], "Hello")
+	gobottest.Assert(t, d.PendingMessage(), "Hello")
+	gobottest.Assert(t, d.PendingMessage(), "World")
+	gobottest.Assert(t, d.PendingMessage(), "")
 
 	gobot.On(d.Event("button"), func(data interface{}) {
 		sem <- true
@@ -61,9 +62,9 @@ func TestPebbleDriver(t *testing.T) {
 	}
 
 	d.Command("send_notification")(map[string]interface{}{"message": "Hey buddy!"})
-	gobot.Assert(t, d.Messages[0], "Hey buddy!")
+	gobottest.Assert(t, d.Messages[0], "Hey buddy!")
 
 	message := d.Command("pending_message")(map[string]interface{}{})
-	gobot.Assert(t, message, "Hey buddy!")
+	gobottest.Assert(t, message, "Hey buddy!")
 
 }

--- a/platforms/raspi/raspi_adaptor_test.go
+++ b/platforms/raspi/raspi_adaptor_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 	"github.com/hybridgroup/gobot/sysfs"
 )
 
@@ -56,9 +56,9 @@ Serial          : 000000003bc748ea
 `), nil
 	}
 	a := NewRaspiAdaptor("myAdaptor")
-	gobot.Assert(t, a.Name(), "myAdaptor")
-	gobot.Assert(t, a.i2cLocation, "/dev/i2c-1")
-	gobot.Assert(t, a.revision, "3")
+	gobottest.Assert(t, a.Name(), "myAdaptor")
+	gobottest.Assert(t, a.i2cLocation, "/dev/i2c-1")
+	gobottest.Assert(t, a.revision, "3")
 
 	readFile = func() ([]byte, error) {
 		return []byte(`
@@ -68,8 +68,8 @@ Serial          : 000000003bc748ea
 `), nil
 	}
 	a = NewRaspiAdaptor("myAdaptor")
-	gobot.Assert(t, a.i2cLocation, "/dev/i2c-1")
-	gobot.Assert(t, a.revision, "2")
+	gobottest.Assert(t, a.i2cLocation, "/dev/i2c-1")
+	gobottest.Assert(t, a.revision, "2")
 
 	readFile = func() ([]byte, error) {
 		return []byte(`
@@ -79,8 +79,8 @@ Serial          : 000000003bc748ea
 `), nil
 	}
 	a = NewRaspiAdaptor("myAdaptor")
-	gobot.Assert(t, a.i2cLocation, "/dev/i2c-0")
-	gobot.Assert(t, a.revision, "1")
+	gobottest.Assert(t, a.i2cLocation, "/dev/i2c-0")
+	gobottest.Assert(t, a.revision, "1")
 
 }
 func TestRaspiAdaptorFinalize(t *testing.T) {
@@ -101,26 +101,26 @@ func TestRaspiAdaptorFinalize(t *testing.T) {
 	a.PwmWrite("7", 255)
 
 	a.I2cStart(0xff)
-	gobot.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, len(a.Finalize()), 0)
 }
 
 func TestRaspiAdaptorDigitalPWM(t *testing.T) {
 	a := initTestRaspiAdaptor()
 
-	gobot.Assert(t, a.PwmWrite("7", 4), nil)
+	gobottest.Assert(t, a.PwmWrite("7", 4), nil)
 
 	fs := sysfs.NewMockFilesystem([]string{
 		"/dev/pi-blaster",
 	})
 	sysfs.SetFilesystem(fs)
 
-	gobot.Assert(t, a.PwmWrite("7", 255), nil)
+	gobottest.Assert(t, a.PwmWrite("7", 255), nil)
 
-	gobot.Assert(t, strings.Split(fs.Files["/dev/pi-blaster"].Contents, "\n")[0], "4=1")
+	gobottest.Assert(t, strings.Split(fs.Files["/dev/pi-blaster"].Contents, "\n")[0], "4=1")
 
-	gobot.Assert(t, a.ServoWrite("11", 255), nil)
+	gobottest.Assert(t, a.ServoWrite("11", 255), nil)
 
-	gobot.Assert(t, strings.Split(fs.Files["/dev/pi-blaster"].Contents, "\n")[0], "17=0.25")
+	gobottest.Assert(t, strings.Split(fs.Files["/dev/pi-blaster"].Contents, "\n")[0], "17=0.25")
 }
 
 func TestRaspiAdaptorDigitalIO(t *testing.T) {
@@ -137,11 +137,11 @@ func TestRaspiAdaptorDigitalIO(t *testing.T) {
 	sysfs.SetFilesystem(fs)
 
 	a.DigitalWrite("7", 1)
-	gobot.Assert(t, fs.Files["/sys/class/gpio/gpio4/value"].Contents, "1")
+	gobottest.Assert(t, fs.Files["/sys/class/gpio/gpio4/value"].Contents, "1")
 
 	a.DigitalWrite("13", 1)
 	i, _ := a.DigitalRead("13")
-	gobot.Assert(t, i, 1)
+	gobottest.Assert(t, i, 1)
 }
 
 func TestRaspiAdaptorI2c(t *testing.T) {
@@ -156,5 +156,5 @@ func TestRaspiAdaptorI2c(t *testing.T) {
 
 	a.I2cWrite(0xff, []byte{0x00, 0x01})
 	data, _ := a.I2cRead(0xff, 2)
-	gobot.Assert(t, data, []byte{0x00, 0x01})
+	gobottest.Assert(t, data, []byte{0x00, 0x01})
 }

--- a/platforms/spark/spark_core_adaptor_test.go
+++ b/platforms/spark/spark_core_adaptor_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/donovanhide/eventsource"
 	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 // HELPERS
@@ -74,13 +75,13 @@ func TestNewSparkCoreAdaptor(t *testing.T) {
 		t.Errorf("NewSparkCoreAdaptor() should have returned a *SparkCoreAdaptor")
 	}
 
-	gobot.Assert(t, spark.APIServer, "https://api.spark.io")
-	gobot.Assert(t, spark.Name(), "bot")
+	gobottest.Assert(t, spark.APIServer, "https://api.spark.io")
+	gobottest.Assert(t, spark.Name(), "bot")
 }
 
 func TestSparkCoreAdaptorConnect(t *testing.T) {
 	a := initTestSparkCoreAdaptor()
-	gobot.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, len(a.Connect()), 0)
 }
 
 func TestSparkCoreAdaptorFinalize(t *testing.T) {
@@ -88,7 +89,7 @@ func TestSparkCoreAdaptorFinalize(t *testing.T) {
 
 	a.Connect()
 
-	gobot.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, len(a.Finalize()), 0)
 }
 
 func TestSparkCoreAdaptorAnalogRead(t *testing.T) {
@@ -103,7 +104,7 @@ func TestSparkCoreAdaptorAnalogRead(t *testing.T) {
 	defer testServer.Close()
 
 	val, _ := a.AnalogRead("A1")
-	gobot.Assert(t, val, 5)
+	gobottest.Assert(t, val, 5)
 }
 
 func TestSparkCoreAdaptorAnalogReadError(t *testing.T) {
@@ -116,7 +117,7 @@ func TestSparkCoreAdaptorAnalogReadError(t *testing.T) {
 	a.setAPIServer(testServer.URL)
 
 	val, _ := a.AnalogRead("A1")
-	gobot.Assert(t, val, 0)
+	gobottest.Assert(t, val, 0)
 }
 
 func TestSparkCoreAdaptorPwmWrite(t *testing.T) {
@@ -176,7 +177,7 @@ func TestSparkCoreAdaptorDigitalRead(t *testing.T) {
 	a.setAPIServer(testServer.URL)
 
 	val, _ := a.DigitalRead("D7")
-	gobot.Assert(t, val, 1)
+	gobottest.Assert(t, val, 1)
 	testServer.Close()
 
 	// When LOW
@@ -188,7 +189,7 @@ func TestSparkCoreAdaptorDigitalRead(t *testing.T) {
 	defer testServer.Close()
 
 	val, _ = a.DigitalRead("D7")
-	gobot.Assert(t, val, 0)
+	gobottest.Assert(t, val, 0)
 }
 
 func TestSparkCoreAdaptorDigitalReadError(t *testing.T) {
@@ -202,7 +203,7 @@ func TestSparkCoreAdaptorDigitalReadError(t *testing.T) {
 	a.setAPIServer(testServer.URL)
 
 	val, _ := a.DigitalRead("D7")
-	gobot.Assert(t, val, -1)
+	gobottest.Assert(t, val, -1)
 }
 
 func TestSparkCoreAdaptorFunction(t *testing.T) {
@@ -214,7 +215,7 @@ func TestSparkCoreAdaptorFunction(t *testing.T) {
 	a.setAPIServer(testServer.URL)
 
 	val, _ := a.Function("hello", "100,200")
-	gobot.Assert(t, val, 1)
+	gobottest.Assert(t, val, 1)
 	testServer.Close()
 
 	// When not existent
@@ -224,7 +225,7 @@ func TestSparkCoreAdaptorFunction(t *testing.T) {
 	a.setAPIServer(testServer.URL)
 
 	_, err := a.Function("hello", "")
-	gobot.Assert(t, err.Error(), "timeout")
+	gobottest.Assert(t, err.Error(), "timeout")
 
 	testServer.Close()
 }
@@ -239,7 +240,7 @@ func TestSparkCoreAdaptorVariable(t *testing.T) {
 	a.setAPIServer(testServer.URL)
 
 	val, _ := a.Variable("variable_name")
-	gobot.Assert(t, val, "1")
+	gobottest.Assert(t, val, "1")
 	testServer.Close()
 
 	// When float
@@ -249,7 +250,7 @@ func TestSparkCoreAdaptorVariable(t *testing.T) {
 	a.setAPIServer(testServer.URL)
 
 	val, _ = a.Variable("variable_name")
-	gobot.Assert(t, val, "1.1")
+	gobottest.Assert(t, val, "1.1")
 	testServer.Close()
 
 	// When int
@@ -259,7 +260,7 @@ func TestSparkCoreAdaptorVariable(t *testing.T) {
 	a.setAPIServer(testServer.URL)
 
 	val, _ = a.Variable("variable_name")
-	gobot.Assert(t, val, "1")
+	gobottest.Assert(t, val, "1")
 	testServer.Close()
 
 	// When bool
@@ -269,7 +270,7 @@ func TestSparkCoreAdaptorVariable(t *testing.T) {
 	a.setAPIServer(testServer.URL)
 
 	val, _ = a.Variable("variable_name")
-	gobot.Assert(t, val, "true")
+	gobottest.Assert(t, val, "true")
 	testServer.Close()
 
 	// When not existent
@@ -279,7 +280,7 @@ func TestSparkCoreAdaptorVariable(t *testing.T) {
 	a.setAPIServer(testServer.URL)
 
 	_, err := a.Variable("not_existent")
-	gobot.Assert(t, err.Error(), "Variable not found")
+	gobottest.Assert(t, err.Error(), "Variable not found")
 
 	testServer.Close()
 }
@@ -287,10 +288,10 @@ func TestSparkCoreAdaptorVariable(t *testing.T) {
 func TestSparkCoreAdaptorSetAPIServer(t *testing.T) {
 	a := initTestSparkCoreAdaptor()
 	apiServer := "new_api_server"
-	gobot.Refute(t, a.APIServer, apiServer)
+	gobottest.Refute(t, a.APIServer, apiServer)
 
 	a.setAPIServer(apiServer)
-	gobot.Assert(t, a.APIServer, apiServer)
+	gobottest.Assert(t, a.APIServer, apiServer)
 }
 
 func TestSparkCoreAdaptorDeviceURL(t *testing.T) {
@@ -298,21 +299,21 @@ func TestSparkCoreAdaptorDeviceURL(t *testing.T) {
 	a := initTestSparkCoreAdaptor()
 	a.setAPIServer("http://server")
 	a.DeviceID = "devID"
-	gobot.Assert(t, a.deviceURL(), "http://server/v1/devices/devID")
+	gobottest.Assert(t, a.deviceURL(), "http://server/v1/devices/devID")
 
 	//When APIServer is not set
 	a = &SparkCoreAdaptor{name: "sparkie", DeviceID: "myDevice", AccessToken: "token"}
 
-	gobot.Assert(t, a.deviceURL(), "https://api.spark.io/v1/devices/myDevice")
+	gobottest.Assert(t, a.deviceURL(), "https://api.spark.io/v1/devices/myDevice")
 }
 
 func TestSparkCoreAdaptorPinLevel(t *testing.T) {
 
 	a := initTestSparkCoreAdaptor()
 
-	gobot.Assert(t, a.pinLevel(1), "HIGH")
-	gobot.Assert(t, a.pinLevel(0), "LOW")
-	gobot.Assert(t, a.pinLevel(5), "LOW")
+	gobottest.Assert(t, a.pinLevel(1), "HIGH")
+	gobottest.Assert(t, a.pinLevel(0), "LOW")
+	gobottest.Assert(t, a.pinLevel(5), "LOW")
 }
 
 func TestSparkCoreAdaptorPostToSpark(t *testing.T) {
@@ -360,20 +361,20 @@ func TestSparkCoreAdaptorEventStream(t *testing.T) {
 		return nil, nil, nil
 	}
 	a.EventStream("all", "ping")
-	gobot.Assert(t, url, "https://api.spark.io/v1/events/ping?access_token=token")
+	gobottest.Assert(t, url, "https://api.spark.io/v1/events/ping?access_token=token")
 	a.EventStream("devices", "ping")
-	gobot.Assert(t, url, "https://api.spark.io/v1/devices/events/ping?access_token=token")
+	gobottest.Assert(t, url, "https://api.spark.io/v1/devices/events/ping?access_token=token")
 	a.EventStream("device", "ping")
-	gobot.Assert(t, url, "https://api.spark.io/v1/devices/myDevice/events/ping?access_token=token")
+	gobottest.Assert(t, url, "https://api.spark.io/v1/devices/myDevice/events/ping?access_token=token")
 	_, err := a.EventStream("nothing", "ping")
-	gobot.Assert(t, err.Error(), "source param should be: all, devices or device")
+	gobottest.Assert(t, err.Error(), "source param should be: all, devices or device")
 
 	eventSource = func(u string) (chan eventsource.Event, chan error, error) {
 		return nil, nil, errors.New("error connecting sse")
 	}
 
 	_, err = a.EventStream("devices", "")
-	gobot.Assert(t, err.Error(), "error connecting sse")
+	gobottest.Assert(t, err.Error(), "error connecting sse")
 
 	eventChan := make(chan eventsource.Event, 0)
 	errorChan := make(chan error, 0)
@@ -384,14 +385,14 @@ func TestSparkCoreAdaptorEventStream(t *testing.T) {
 
 	sem := make(chan bool, 0)
 	stream, err := a.EventStream("devices", "")
-	gobot.Assert(t, err, nil)
+	gobottest.Assert(t, err, nil)
 
 	// stream message
 	gobot.Once(stream, func(data interface{}) {
 		e := data.(Event)
-		gobot.Assert(t, e.Name, "event")
-		gobot.Assert(t, e.Data, "sse event")
-		gobot.Assert(t, e.Error, nil)
+		gobottest.Assert(t, e.Name, "event")
+		gobottest.Assert(t, e.Data, "sse event")
+		gobottest.Assert(t, e.Error, nil)
 		sem <- true
 	})
 
@@ -406,9 +407,9 @@ func TestSparkCoreAdaptorEventStream(t *testing.T) {
 	// stream error
 	gobot.Once(stream, func(data interface{}) {
 		e := data.(Event)
-		gobot.Assert(t, e.Name, "")
-		gobot.Assert(t, e.Data, "")
-		gobot.Assert(t, e.Error.Error(), "stream error")
+		gobottest.Assert(t, e.Name, "")
+		gobottest.Assert(t, e.Data, "")
+		gobottest.Assert(t, e.Error.Error(), "stream error")
 		sem <- true
 	})
 

--- a/platforms/sphero/sphero_adaptor_test.go
+++ b/platforms/sphero/sphero_adaptor_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 type nullReadWriteCloser struct{}
@@ -44,42 +44,42 @@ func initTestSpheroAdaptor() *SpheroAdaptor {
 
 func TestSpheroAdaptor(t *testing.T) {
 	a := initTestSpheroAdaptor()
-	gobot.Assert(t, a.Name(), "bot")
-	gobot.Assert(t, a.Port(), "/dev/null")
+	gobottest.Assert(t, a.Name(), "bot")
+	gobottest.Assert(t, a.Port(), "/dev/null")
 }
 
 func TestSpheroAdaptorReconnect(t *testing.T) {
 	a := initTestSpheroAdaptor()
 	a.Connect()
-	gobot.Assert(t, a.connected, true)
+	gobottest.Assert(t, a.connected, true)
 	a.Reconnect()
-	gobot.Assert(t, a.connected, true)
+	gobottest.Assert(t, a.connected, true)
 	a.Disconnect()
-	gobot.Assert(t, a.connected, false)
+	gobottest.Assert(t, a.connected, false)
 	a.Reconnect()
-	gobot.Assert(t, a.connected, true)
+	gobottest.Assert(t, a.connected, true)
 }
 
 func TestSpheroAdaptorFinalize(t *testing.T) {
 	a := initTestSpheroAdaptor()
 	a.Connect()
-	gobot.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, len(a.Finalize()), 0)
 
 	testAdaptorClose = func() error {
 		return errors.New("close error")
 	}
 
 	a.connected = true
-	gobot.Assert(t, a.Finalize()[0], errors.New("close error"))
+	gobottest.Assert(t, a.Finalize()[0], errors.New("close error"))
 }
 
 func TestSpheroAdaptorConnect(t *testing.T) {
 	a := initTestSpheroAdaptor()
-	gobot.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, len(a.Connect()), 0)
 
 	a.connect = func(string) (io.ReadWriteCloser, error) {
 		return nil, errors.New("connect error")
 	}
 
-	gobot.Assert(t, a.Connect()[0], errors.New("connect error"))
+	gobottest.Assert(t, a.Connect()[0], errors.New("connect error"))
 }

--- a/platforms/sphero/sphero_driver_test.go
+++ b/platforms/sphero/sphero_driver_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func initTestSpheroDriver() *SpheroDriver {
@@ -21,65 +21,65 @@ func TestSpheroDriver(t *testing.T) {
 	ret = d.Command("SetRGB")(
 		map[string]interface{}{"r": 100.0, "g": 100.0, "b": 100.0},
 	)
-	gobot.Assert(t, ret, nil)
+	gobottest.Assert(t, ret, nil)
 
 	ret = d.Command("Roll")(
 		map[string]interface{}{"speed": 100.0, "heading": 100.0},
 	)
-	gobot.Assert(t, ret, nil)
+	gobottest.Assert(t, ret, nil)
 
 	ret = d.Command("SetBackLED")(
 		map[string]interface{}{"level": 100.0},
 	)
-	gobot.Assert(t, ret, nil)
+	gobottest.Assert(t, ret, nil)
 
 	ret = d.Command("ConfigureLocator")(
 		map[string]interface{}{"Flags": 1.0, "X": 100.0, "Y": 100.0, "YawTare": 100.0},
 	)
-	gobot.Assert(t, ret, nil)
+	gobottest.Assert(t, ret, nil)
 
 	ret = d.Command("SetHeading")(
 		map[string]interface{}{"heading": 100.0},
 	)
-	gobot.Assert(t, ret, nil)
+	gobottest.Assert(t, ret, nil)
 
 	ret = d.Command("SetRotationRate")(
 		map[string]interface{}{"level": 100.0},
 	)
-	gobot.Assert(t, ret, nil)
+	gobottest.Assert(t, ret, nil)
 
 	ret = d.Command("SetStabilization")(
 		map[string]interface{}{"enable": true},
 	)
-	gobot.Assert(t, ret, nil)
+	gobottest.Assert(t, ret, nil)
 
 	ret = d.Command("SetStabilization")(
 		map[string]interface{}{"enable": false},
 	)
-	gobot.Assert(t, ret, nil)
+	gobottest.Assert(t, ret, nil)
 
 	ret = d.Command("Stop")(nil)
-	gobot.Assert(t, ret, nil)
+	gobottest.Assert(t, ret, nil)
 
 	ret = d.Command("GetRGB")(nil)
-	gobot.Assert(t, ret.([]byte), []byte{})
+	gobottest.Assert(t, ret.([]byte), []byte{})
 
 	ret = d.Command("ReadLocator")(nil)
-	gobot.Assert(t, ret, []int16{})
+	gobottest.Assert(t, ret, []int16{})
 
-	gobot.Assert(t, d.Name(), "bot")
-	gobot.Assert(t, d.Connection().Name(), "bot")
+	gobottest.Assert(t, d.Name(), "bot")
+	gobottest.Assert(t, d.Connection().Name(), "bot")
 }
 
 func TestSpheroDriverStart(t *testing.T) {
 	d := initTestSpheroDriver()
-	gobot.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, len(d.Start()), 0)
 }
 
 func TestSpheroDriverHalt(t *testing.T) {
 	d := initTestSpheroDriver()
 	d.adaptor().connected = true
-	gobot.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, len(d.Halt()), 0)
 }
 
 func TestSpheroDriverSetDataStreaming(t *testing.T) {
@@ -91,7 +91,7 @@ func TestSpheroDriverSetDataStreaming(t *testing.T) {
 	buf := new(bytes.Buffer)
 	binary.Write(buf, binary.BigEndian, DefaultDataStreamingConfig())
 
-	gobot.Assert(t, data.body, buf.Bytes())
+	gobottest.Assert(t, data.body, buf.Bytes())
 
 	ret := d.Command("SetDataStreaming")(
 		map[string]interface{}{
@@ -102,14 +102,14 @@ func TestSpheroDriverSetDataStreaming(t *testing.T) {
 			"Mask2": 400.0,
 		},
 	)
-	gobot.Assert(t, ret, nil)
+	gobottest.Assert(t, ret, nil)
 	data = <-d.packetChannel
 
 	dconfig := DataStreamingConfig{N: 100, M: 200, Mask: 300, Pcnt: 255, Mask2: 400}
 	buf = new(bytes.Buffer)
 	binary.Write(buf, binary.BigEndian, dconfig)
 
-	gobot.Assert(t, data.body, buf.Bytes())
+	gobottest.Assert(t, data.body, buf.Bytes())
 }
 
 func TestConfigureLocator(t *testing.T) {
@@ -120,7 +120,7 @@ func TestConfigureLocator(t *testing.T) {
 	buf := new(bytes.Buffer)
 	binary.Write(buf, binary.BigEndian, DefaultLocatorConfig())
 
-	gobot.Assert(t, data.body, buf.Bytes())
+	gobottest.Assert(t, data.body, buf.Bytes())
 
 	ret := d.Command("ConfigureLocator")(
 		map[string]interface{}{
@@ -130,14 +130,14 @@ func TestConfigureLocator(t *testing.T) {
 			"YawTare": 0.0,
 		},
 	)
-	gobot.Assert(t, ret, nil)
+	gobottest.Assert(t, ret, nil)
 	data = <-d.packetChannel
 
 	lconfig := LocatorConfig{Flags: 1, X: 100, Y: 100, YawTare: 0}
 	buf = new(bytes.Buffer)
 	binary.Write(buf, binary.BigEndian, lconfig)
 
-	gobot.Assert(t, data.body, buf.Bytes())
+	gobottest.Assert(t, data.body, buf.Bytes())
 }
 
 func TestCalculateChecksum(t *testing.T) {

--- a/sysfs/digital_pin_test.go
+++ b/sysfs/digital_pin_test.go
@@ -6,7 +6,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func TestDigitalPin(t *testing.T) {
@@ -20,67 +20,67 @@ func TestDigitalPin(t *testing.T) {
 	SetFilesystem(fs)
 
 	pin := NewDigitalPin(10, "custom").(*digitalPin)
-	gobot.Assert(t, pin.pin, "10")
-	gobot.Assert(t, pin.label, "custom")
+	gobottest.Assert(t, pin.pin, "10")
+	gobottest.Assert(t, pin.label, "custom")
 
 	pin = NewDigitalPin(10).(*digitalPin)
-	gobot.Assert(t, pin.pin, "10")
-	gobot.Assert(t, pin.label, "gpio10")
-	gobot.Assert(t, pin.value, nil)
+	gobottest.Assert(t, pin.pin, "10")
+	gobottest.Assert(t, pin.label, "gpio10")
+	gobottest.Assert(t, pin.value, nil)
 
 	err := pin.Unexport()
-	gobot.Assert(t, err, nil)
-	gobot.Assert(t, fs.Files["/sys/class/gpio/unexport"].Contents, "10")
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, fs.Files["/sys/class/gpio/unexport"].Contents, "10")
 
 	err = pin.Export()
-	gobot.Assert(t, err, nil)
-	gobot.Assert(t, fs.Files["/sys/class/gpio/export"].Contents, "10")
-	gobot.Refute(t, pin.value, nil)
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, fs.Files["/sys/class/gpio/export"].Contents, "10")
+	gobottest.Refute(t, pin.value, nil)
 
 	err = pin.Write(1)
-	gobot.Assert(t, err, nil)
-	gobot.Assert(t, fs.Files["/sys/class/gpio/gpio10/value"].Contents, "1")
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, fs.Files["/sys/class/gpio/gpio10/value"].Contents, "1")
 
 	err = pin.Direction(IN)
-	gobot.Assert(t, err, nil)
-	gobot.Assert(t, fs.Files["/sys/class/gpio/gpio10/direction"].Contents, "in")
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, fs.Files["/sys/class/gpio/gpio10/direction"].Contents, "in")
 
 	data, _ := pin.Read()
-	gobot.Assert(t, 1, data)
+	gobottest.Assert(t, 1, data)
 
 	pin2 := NewDigitalPin(30, "custom")
 	err = pin2.Write(1)
-	gobot.Refute(t, err, nil)
+	gobottest.Refute(t, err, nil)
 
 	data, err = pin2.Read()
-	gobot.Refute(t, err, nil)
-	gobot.Assert(t, data, 0)
+	gobottest.Refute(t, err, nil)
+	gobottest.Assert(t, data, 0)
 
 	writeFile = func(File, []byte) (int, error) {
 		return 0, &os.PathError{Err: syscall.EINVAL}
 	}
 
 	err = pin.Unexport()
-	gobot.Assert(t, err, nil)
+	gobottest.Assert(t, err, nil)
 
 	writeFile = func(File, []byte) (int, error) {
 		return 0, &os.PathError{Err: errors.New("write error")}
 	}
 
 	err = pin.Unexport()
-	gobot.Assert(t, err.(*os.PathError).Err, errors.New("write error"))
+	gobottest.Assert(t, err.(*os.PathError).Err, errors.New("write error"))
 
 	writeFile = func(File, []byte) (int, error) {
 		return 0, &os.PathError{Err: syscall.EBUSY}
 	}
 
 	err = pin.Export()
-	gobot.Assert(t, err, nil)
+	gobottest.Assert(t, err, nil)
 
 	writeFile = func(File, []byte) (int, error) {
 		return 0, &os.PathError{Err: errors.New("write error")}
 	}
 
 	err = pin.Export()
-	gobot.Assert(t, err.(*os.PathError).Err, errors.New("write error"))
+	gobottest.Assert(t, err.(*os.PathError).Err, errors.New("write error"))
 }

--- a/sysfs/fs_mock_test.go
+++ b/sysfs/fs_mock_test.go
@@ -3,27 +3,27 @@ package sysfs
 import (
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func TestMockFilesystemOpen(t *testing.T) {
 	fs := NewMockFilesystem([]string{"foo"})
 	f1 := fs.Files["foo"]
 
-	gobot.Assert(t, f1.Opened, false)
+	gobottest.Assert(t, f1.Opened, false)
 	f2, err := fs.OpenFile("foo", 0, 0666)
-	gobot.Assert(t, f1, f2)
-	gobot.Assert(t, err, nil)
+	gobottest.Assert(t, f1, f2)
+	gobottest.Assert(t, err, nil)
 
 	err = f2.Sync()
-	gobot.Assert(t, err, nil)
+	gobottest.Assert(t, err, nil)
 
 	_, err = fs.OpenFile("bar", 0, 0666)
-	gobot.Refute(t, err, nil)
+	gobottest.Refute(t, err, nil)
 
 	fs.Add("bar")
 	f4, err := fs.OpenFile("bar", 0, 0666)
-	gobot.Refute(t, f4.Fd(), f1.Fd())
+	gobottest.Refute(t, f4.Fd(), f1.Fd())
 }
 
 func TestMockFilesystemWrite(t *testing.T) {
@@ -31,14 +31,14 @@ func TestMockFilesystemWrite(t *testing.T) {
 	f1 := fs.Files["bar"]
 
 	f2, err := fs.OpenFile("bar", 0, 0666)
-	gobot.Assert(t, err, nil)
+	gobottest.Assert(t, err, nil)
 	// Never been read or written.
-	gobot.Assert(t, f1.Seq <= 0, true)
+	gobottest.Assert(t, f1.Seq <= 0, true)
 
 	f2.WriteString("testing")
 	// Was written.
-	gobot.Assert(t, f1.Seq > 0, true)
-	gobot.Assert(t, f1.Contents, "testing")
+	gobottest.Assert(t, f1.Seq > 0, true)
+	gobottest.Assert(t, f1.Contents, "testing")
 }
 
 func TestMockFilesystemRead(t *testing.T) {
@@ -47,18 +47,18 @@ func TestMockFilesystemRead(t *testing.T) {
 	f1.Contents = "Yip"
 
 	f2, err := fs.OpenFile("bar", 0, 0666)
-	gobot.Assert(t, err, nil)
+	gobottest.Assert(t, err, nil)
 	// Never been read or written.
-	gobot.Assert(t, f1.Seq <= 0, true)
+	gobottest.Assert(t, f1.Seq <= 0, true)
 
 	buffer := make([]byte, 20)
 	n, err := f2.Read(buffer)
 
 	// Was read.
-	gobot.Assert(t, f1.Seq > 0, true)
-	gobot.Assert(t, n, 3)
-	gobot.Assert(t, string(buffer[:3]), "Yip")
+	gobottest.Assert(t, f1.Seq > 0, true)
+	gobottest.Assert(t, n, 3)
+	gobottest.Assert(t, string(buffer[:3]), "Yip")
 
 	n, err = f2.ReadAt(buffer, 10)
-	gobot.Assert(t, n, 3)
+	gobottest.Assert(t, n, 3)
 }

--- a/sysfs/fs_test.go
+++ b/sysfs/fs_test.go
@@ -4,12 +4,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func TestFilesystemOpen(t *testing.T) {
 	SetFilesystem(&NativeFilesystem{})
 	file, err := OpenFile(os.DevNull, os.O_RDONLY, 666)
-	gobot.Assert(t, err, nil)
+	gobottest.Assert(t, err, nil)
 	var _ File = file
 }

--- a/sysfs/i2c_device_test.go
+++ b/sysfs/i2c_device_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
 )
 
 func TestNewI2cDevice(t *testing.T) {
@@ -12,7 +12,7 @@ func TestNewI2cDevice(t *testing.T) {
 	SetFilesystem(fs)
 
 	i, err := NewI2cDevice(os.DevNull, 0xff)
-	gobot.Refute(t, err, nil)
+	gobottest.Refute(t, err, nil)
 
 	fs = NewMockFilesystem([]string{
 		"/dev/i2c-1",
@@ -21,29 +21,29 @@ func TestNewI2cDevice(t *testing.T) {
 	SetFilesystem(fs)
 
 	i, err = NewI2cDevice("/dev/i2c-1", 0xff)
-	gobot.Refute(t, err, nil)
+	gobottest.Refute(t, err, nil)
 
 	SetSyscall(&MockSyscall{})
 
 	i, err = NewI2cDevice("/dev/i2c-1", 0xff)
 	var _ I2cDevice = i
 
-	gobot.Assert(t, err, nil)
+	gobottest.Assert(t, err, nil)
 
-	gobot.Assert(t, i.SetAddress(0xff), nil)
+	gobottest.Assert(t, i.SetAddress(0xff), nil)
 
 	buf := []byte{0x01, 0x02, 0x03}
 
 	n, err := i.Write(buf)
 
-	gobot.Assert(t, n, len(buf))
-	gobot.Assert(t, err, nil)
+	gobottest.Assert(t, n, len(buf))
+	gobottest.Assert(t, err, nil)
 
 	buf = make([]byte, 4)
 
 	n, err = i.Read(buf)
 
-	gobot.Assert(t, n, 3)
-	gobot.Assert(t, err, nil)
+	gobottest.Assert(t, n, 3)
+	gobottest.Assert(t, err, nil)
 
 }

--- a/utils.go
+++ b/utils.go
@@ -3,14 +3,9 @@ package gobot
 import (
 	"crypto/rand"
 	"errors"
-	"fmt"
 	"log"
 	"math"
 	"math/big"
-	"reflect"
-	"runtime"
-	"strings"
-	"testing"
 	"time"
 )
 
@@ -26,32 +21,6 @@ var eventError = func(e *Event) (err error) {
 		return
 	}
 	return
-}
-
-var errFunc = func(t *testing.T, message string) {
-	t.Errorf(message)
-}
-
-func logFailure(t *testing.T, message string) {
-	_, file, line, _ := runtime.Caller(2)
-	s := strings.Split(file, "/")
-	errFunc(t, fmt.Sprintf("%v:%v: %v", s[len(s)-1], line, message))
-}
-
-// Assert checks if a and b are equal, emis a t.Errorf if they are not equal.
-func Assert(t *testing.T, a interface{}, b interface{}) {
-	if !reflect.DeepEqual(a, b) {
-		logFailure(t, fmt.Sprintf("%v - \"%v\", should equal,  %v - \"%v\"",
-			a, reflect.TypeOf(a), b, reflect.TypeOf(b)))
-	}
-}
-
-// Refute checks if a and b are equal, emis a t.Errorf if they are equal.
-func Refute(t *testing.T, a interface{}, b interface{}) {
-	if reflect.DeepEqual(a, b) {
-		logFailure(t, fmt.Sprintf("%v - \"%v\", should not equal,  %v - \"%v\"",
-			a, reflect.TypeOf(a), b, reflect.TypeOf(b)))
-	}
 }
 
 // Every triggers f every t time until the end of days. It does not wait for the

--- a/utils_test.go
+++ b/utils_test.go
@@ -44,6 +44,7 @@ func TestPublish(t *testing.T) {
 
 	e := &Event{Callbacks: []callback{cb}}
 	Publish(e, 1)
+	<-time.After(10 * time.Millisecond)
 	Publish(e, 2)
 	Publish(e, 3)
 	Publish(e, 4)

--- a/utils_test.go
+++ b/utils_test.go
@@ -4,41 +4,9 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/hybridgroup/gobot/gobottest"
 )
-
-func TestAssert(t *testing.T) {
-	err := ""
-	errFunc = func(t *testing.T, message string) {
-		err = message
-	}
-
-	Assert(t, 1, 1)
-	if err != "" {
-		t.Errorf("Assert failed: 1 should equal 1")
-	}
-
-	Assert(t, 1, 2)
-	if err == "" {
-		t.Errorf("Assert failed: 1 should not equal 2")
-	}
-}
-
-func TestRefute(t *testing.T) {
-	err := ""
-	errFunc = func(t *testing.T, message string) {
-		err = message
-	}
-
-	Refute(t, 1, 2)
-	if err != "" {
-		t.Errorf("Refute failed: 1 should not be 2")
-	}
-
-	Refute(t, 1, 1)
-	if err == "" {
-		t.Errorf("Refute failed: 1 should not be 1")
-	}
-}
 
 func TestEvery(t *testing.T) {
 	i := 0
@@ -62,7 +30,7 @@ func TestAfter(t *testing.T) {
 		i++
 	})
 	<-time.After(2 * time.Millisecond)
-	Assert(t, i, 1)
+	gobottest.Assert(t, i, 1)
 }
 
 func TestPublish(t *testing.T) {
@@ -80,10 +48,10 @@ func TestPublish(t *testing.T) {
 	Publish(e, 3)
 	Publish(e, 4)
 	i := <-c
-	Assert(t, i, 1)
+	gobottest.Assert(t, i, 1)
 
 	var e1 = (*Event)(nil)
-	Assert(t, Publish(e1, 4), ErrUnknownEvent)
+	gobottest.Assert(t, Publish(e1, 4), ErrUnknownEvent)
 }
 
 func TestOn(t *testing.T) {
@@ -94,13 +62,13 @@ func TestOn(t *testing.T) {
 	})
 	Publish(e, 10)
 	<-time.After(1 * time.Millisecond)
-	Assert(t, i, 10)
+	gobottest.Assert(t, i, 10)
 
 	var e1 = (*Event)(nil)
 	err := On(e1, func(data interface{}) {
 		i = data.(int)
 	})
-	Assert(t, err, ErrUnknownEvent)
+	gobottest.Assert(t, err, ErrUnknownEvent)
 }
 func TestOnce(t *testing.T) {
 	i := 0
@@ -115,23 +83,23 @@ func TestOnce(t *testing.T) {
 	<-time.After(1 * time.Millisecond)
 	Publish(e, 10)
 	<-time.After(1 * time.Millisecond)
-	Assert(t, i, 30)
+	gobottest.Assert(t, i, 30)
 
 	var e1 = (*Event)(nil)
 	err := Once(e1, func(data interface{}) {
 		i = data.(int)
 	})
-	Assert(t, err, ErrUnknownEvent)
+	gobottest.Assert(t, err, ErrUnknownEvent)
 }
 
 func TestFromScale(t *testing.T) {
-	Assert(t, FromScale(5, 0, 10), 0.5)
+	gobottest.Assert(t, FromScale(5, 0, 10), 0.5)
 }
 
 func TestToScale(t *testing.T) {
-	Assert(t, ToScale(500, 0, 10), 10.0)
-	Assert(t, ToScale(-1, 0, 10), 0.0)
-	Assert(t, ToScale(0.5, 0, 10), 5.0)
+	gobottest.Assert(t, ToScale(500, 0, 10), 10.0)
+	gobottest.Assert(t, ToScale(-1, 0, 10), 0.0)
+	gobottest.Assert(t, ToScale(0.5, 0, 10), 5.0)
 }
 
 func TestRand(t *testing.T) {


### PR DESCRIPTION
Otherwise any code importing `gobot` package will have
testing flags as well:

### Problem
Unexpected flags in my app:
```
     -test.bench string
       	regular expression to select benchmarks to run
     -test.benchmem
       	print memory allocations for benchmarks
```

### Reproduction

Here's a minimum code to reproduce the problem:

```Go
package main
// main.go

import (
	"flag"
	"github.com/hybridgroup/gobot"
)

var _ = gobot.NewJSONDevice

func main() {
	flag.Parse()
	flag.PrintDefaults()
}
```

#### Output
```console
flag_test$ go run main.go
  -test.bench string
    	regular expression to select benchmarks to run
  -test.benchmem
    	print memory allocations for benchmarks
  -test.benchtime duration
    	approximate run time for each benchmark (default 1s)

# .....
````
## Fix
Extract test helpers to `gobot/gobottest` package.