### PR TITLE
Added example of how to use temp36 temperature sensor with firmata

### DIFF
--- a/examples/firmata_temp36.go
+++ b/examples/firmata_temp36.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"time"
+
+	"fmt"
+
+	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/platforms/firmata"
+)
+
+func main() {
+	gbot := gobot.NewGobot()
+
+	firmataAdaptor := firmata.NewFirmataAdaptor("firmata", "/dev/ttyACM0")
+
+	work := func() {
+		gobot.Every(1*time.Second, func() {
+			val, err := firmataAdaptor.AnalogRead("0")
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+
+			voltage := (float64(val) * 5) / 1024 // if using 3.3V replace 5 with 3.3
+			tempC := (voltage - 0.5) * 100
+			tempF := (tempC * 9 / 5) + 32
+
+			fmt.Printf("%.2f°C\n", tempC)
+			fmt.Printf("%.2f°F\n", tempF)
+		})
+	}
+
+	robot := gobot.NewRobot("sensorBot",
+		[]gobot.Connection{firmataAdaptor},
+		[]gobot.Device{},
+		work,
+	)
+
+	gbot.AddRobot(robot)
+
+	gbot.Start()
+}


### PR DESCRIPTION
Hi! I just started using Gobot (it's great!) and I wrote a program to read the temperature from a temp36 sensor with an arduino that I thought might serve as a good example. It's essentially just a translation of [this example from Adafruit](https://learn.adafruit.com/tmp36-temperature-sensor/using-a-temp-sensor) into Go using Gobot. When I was looking through the examples though, I didn't see any that used the `AnalogRead` function, so I thought it might be helpful to include one. Thanks!