### PR TITLE
support gpio pin turn on and off

### DIFF
--- a/platforms/gpio/direct_pin_driver.go
+++ b/platforms/gpio/direct_pin_driver.go
@@ -72,6 +72,24 @@ func (d *DirectPinDriver) Start() (errs []error) { return }
 // Halt implements the Driver interface
 func (d *DirectPinDriver) Halt() (errs []error) { return }
 
+// Turn Off pin
+func (d *DirectPinDriver) Off() (err error) {
+	if writer, ok := d.Connection().(DigitalWriter); ok {
+		return writer.DigitalWrite(d.Pin(), byte(0))
+	}
+	err = ErrDigitalWriteUnsupported
+	return
+}
+
+// Turn On pin
+func (d *DirectPinDriver) On() (err error) {
+	if writer, ok := d.Connection().(DigitalWriter); ok {
+		return writer.DigitalWrite(d.Pin(), byte(1))
+	}
+	err = ErrDigitalWriteUnsupported
+	return
+}
+
 // DigitalRead returns the current digital state of the pin
 func (d *DirectPinDriver) DigitalRead() (val int, err error) {
 	if reader, ok := d.Connection().(DigitalReader); ok {

--- a/platforms/gpio/direct_pin_driver_test.go
+++ b/platforms/gpio/direct_pin_driver_test.go
@@ -68,6 +68,22 @@ func TestDirectPinDriverHalt(t *testing.T) {
 	gobottest.Assert(t, len(d.Halt()), 0)
 }
 
+func TestDirectPinDriverOff(t *testing.T) {
+	d := initTestDirectPinDriver(newGpioTestAdaptor("adaptor"))
+	gobot.Refute(t, d.DigitalWrite(0), nil)
+
+	d = initTestDirectPinDriver(&gpioTestBareAdaptor{})
+	gobot.Assert(t, d.DigitalWrite(0), ErrDigitalWriteUnsupported)
+}
+
+func TestDirectPinDriverOn(t *testing.T) {
+	d := initTestDirectPinDriver(newGpioTestAdaptor("adaptor"))
+	gobot.Refute(t, d.DigitalWrite(1), nil)
+
+	d = initTestDirectPinDriver(&gpioTestBareAdaptor{})
+	gobot.Assert(t, d.DigitalWrite(1), ErrDigitalWriteUnsupported)
+}
+
 func TestDirectPinDriverDigitalWrite(t *testing.T) {
 	d := initTestDirectPinDriver(newGpioTestAdaptor("adaptor"))
 	gobottest.Refute(t, d.DigitalWrite(1), nil)

--- a/platforms/gpio/direct_pin_driver_test.go
+++ b/platforms/gpio/direct_pin_driver_test.go
@@ -70,18 +70,18 @@ func TestDirectPinDriverHalt(t *testing.T) {
 
 func TestDirectPinDriverOff(t *testing.T) {
 	d := initTestDirectPinDriver(newGpioTestAdaptor("adaptor"))
-	gobot.Refute(t, d.DigitalWrite(0), nil)
+	gobottest.Refute(t, d.DigitalWrite(0), nil)
 
 	d = initTestDirectPinDriver(&gpioTestBareAdaptor{})
-	gobot.Assert(t, d.DigitalWrite(0), ErrDigitalWriteUnsupported)
+	gobottest.Assert(t, d.DigitalWrite(0), ErrDigitalWriteUnsupported)
 }
 
 func TestDirectPinDriverOn(t *testing.T) {
 	d := initTestDirectPinDriver(newGpioTestAdaptor("adaptor"))
-	gobot.Refute(t, d.DigitalWrite(1), nil)
+	gobottest.Refute(t, d.DigitalWrite(1), nil)
 
 	d = initTestDirectPinDriver(&gpioTestBareAdaptor{})
-	gobot.Assert(t, d.DigitalWrite(1), ErrDigitalWriteUnsupported)
+	gobottest.Assert(t, d.DigitalWrite(1), ErrDigitalWriteUnsupported)
 }
 
 func TestDirectPinDriverDigitalWrite(t *testing.T) {


### PR DESCRIPTION
I was doing [this tutorial](https://github.com/hybridgroup/gobot/pull/289), that uses Raspberry Pi to control a relay, but with gobot instead of python. And i felt it will be nice to have on and off for gpio pins in core gobot