### PR TITLE
Move interface assertions to test files.

### DIFF
--- a/platforms/ardrone/ardrone_adaptor.go
+++ b/platforms/ardrone/ardrone_adaptor.go
@@ -2,10 +2,7 @@ package ardrone
 
 import (
 	client "github.com/hybridgroup/go-ardrone/client"
-	"github.com/hybridgroup/gobot"
 )
-
-var _ gobot.Adaptor = (*ArdroneAdaptor)(nil)
 
 // drone defines expected drone behaviour
 type drone interface {

--- a/platforms/ardrone/ardrone_adaptor_test.go
+++ b/platforms/ardrone/ardrone_adaptor_test.go
@@ -4,8 +4,11 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/hybridgroup/gobot"
 	"github.com/hybridgroup/gobot/gobottest"
 )
+
+var _ gobot.Adaptor = (*ArdroneAdaptor)(nil)
 
 func initTestArdroneAdaptor() *ArdroneAdaptor {
 	a := NewArdroneAdaptor("drone")

--- a/platforms/ardrone/ardrone_driver.go
+++ b/platforms/ardrone/ardrone_driver.go
@@ -4,8 +4,6 @@ import (
 	"github.com/hybridgroup/gobot"
 )
 
-var _ gobot.Driver = (*ArdroneDriver)(nil)
-
 // ArdroneDriver is gobot.Driver representation for the Ardrone
 type ArdroneDriver struct {
 	name       string

--- a/platforms/ardrone/ardrone_driver_test.go
+++ b/platforms/ardrone/ardrone_driver_test.go
@@ -3,8 +3,11 @@ package ardrone
 import (
 	"testing"
 
+	"github.com/hybridgroup/gobot"
 	"github.com/hybridgroup/gobot/gobottest"
 )
+
+var _ gobot.Driver = (*ArdroneDriver)(nil)
 
 func initTestArdroneDriver() *ArdroneDriver {
 	a := NewArdroneAdaptor("drone")

--- a/platforms/bebop/bebop_adaptor.go
+++ b/platforms/bebop/bebop_adaptor.go
@@ -1,11 +1,8 @@
 package bebop
 
 import (
-	"github.com/hybridgroup/gobot"
 	"github.com/hybridgroup/gobot/platforms/bebop/client"
 )
-
-var _ gobot.Adaptor = (*BebopAdaptor)(nil)
 
 // drone defines expected drone behaviour
 type drone interface {

--- a/platforms/bebop/bebop_adaptor_test.go
+++ b/platforms/bebop/bebop_adaptor_test.go
@@ -4,8 +4,11 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/hybridgroup/gobot"
 	"github.com/hybridgroup/gobot/gobottest"
 )
+
+var _ gobot.Adaptor = (*BebopAdaptor)(nil)
 
 func initTestBebopAdaptor() *BebopAdaptor {
 	a := NewBebopAdaptor("bot")

--- a/platforms/bebop/bebop_driver.go
+++ b/platforms/bebop/bebop_driver.go
@@ -4,8 +4,6 @@ import (
 	"github.com/hybridgroup/gobot"
 )
 
-var _ gobot.Driver = (*BebopDriver)(nil)
-
 // BebopDriver is gobot.Driver representation for the Bebop
 type BebopDriver struct {
 	name       string

--- a/platforms/bebop/bebop_driver_test.go
+++ b/platforms/bebop/bebop_driver_test.go
@@ -1,0 +1,5 @@
+package bebop
+
+import "github.com/hybridgroup/gobot"
+
+var _ gobot.Driver = (*BebopDriver)(nil)

--- a/platforms/digispark/digispark_adaptor.go
+++ b/platforms/digispark/digispark_adaptor.go
@@ -3,16 +3,7 @@ package digispark
 import (
 	"errors"
 	"strconv"
-
-	"github.com/hybridgroup/gobot"
-	"github.com/hybridgroup/gobot/platforms/gpio"
 )
-
-var _ gobot.Adaptor = (*DigisparkAdaptor)(nil)
-
-var _ gpio.DigitalWriter = (*DigisparkAdaptor)(nil)
-var _ gpio.PwmWriter = (*DigisparkAdaptor)(nil)
-var _ gpio.ServoWriter = (*DigisparkAdaptor)(nil)
 
 // ErrConnection is the error resulting of a connection error with the digispark
 var ErrConnection = errors.New("connection error")

--- a/platforms/digispark/digispark_adaptor_test.go
+++ b/platforms/digispark/digispark_adaptor_test.go
@@ -4,8 +4,16 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/hybridgroup/gobot"
 	"github.com/hybridgroup/gobot/gobottest"
+	"github.com/hybridgroup/gobot/platforms/gpio"
 )
+
+var _ gobot.Adaptor = (*DigisparkAdaptor)(nil)
+
+var _ gpio.DigitalWriter = (*DigisparkAdaptor)(nil)
+var _ gpio.PwmWriter = (*DigisparkAdaptor)(nil)
+var _ gpio.ServoWriter = (*DigisparkAdaptor)(nil)
 
 type mock struct {
 	locationA         uint8

--- a/platforms/mqtt/mqtt_adaptor.go
+++ b/platforms/mqtt/mqtt_adaptor.go
@@ -2,10 +2,7 @@ package mqtt
 
 import (
 	"git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git"
-	"github.com/hybridgroup/gobot"
 )
-
-var _ gobot.Adaptor = (*MqttAdaptor)(nil)
 
 type MqttAdaptor struct {
 	name     string

--- a/platforms/mqtt/mqtt_adaptor_test.go
+++ b/platforms/mqtt/mqtt_adaptor_test.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hybridgroup/gobot"
 	"github.com/hybridgroup/gobot/gobottest"
 )
+
+var _ gobot.Adaptor = (*MqttAdaptor)(nil)
 
 func initTestMqttAdaptor() *MqttAdaptor {
 	return NewMqttAdaptor("mqtt", "localhost:1883", "client")

--- a/platforms/pebble/pebble_adaptor.go
+++ b/platforms/pebble/pebble_adaptor.go
@@ -1,11 +1,5 @@
 package pebble
 
-import (
-	"github.com/hybridgroup/gobot"
-)
-
-var _ gobot.Adaptor = (*PebbleAdaptor)(nil)
-
 type PebbleAdaptor struct {
 	name string
 }

--- a/platforms/pebble/pebble_adaptor_test.go
+++ b/platforms/pebble/pebble_adaptor_test.go
@@ -3,8 +3,11 @@ package pebble
 import (
 	"testing"
 
+	"github.com/hybridgroup/gobot"
 	"github.com/hybridgroup/gobot/gobottest"
 )
+
+var _ gobot.Adaptor = (*PebbleAdaptor)(nil)
 
 func initTestPebbleAdaptor() *PebbleAdaptor {
 	return NewPebbleAdaptor("pebble")

--- a/platforms/pebble/pebble_driver.go
+++ b/platforms/pebble/pebble_driver.go
@@ -4,8 +4,6 @@ import (
 	"github.com/hybridgroup/gobot"
 )
 
-var _ gobot.Driver = (*PebbleDriver)(nil)
-
 type PebbleDriver struct {
 	name       string
 	connection gobot.Connection

--- a/platforms/pebble/pebble_driver_test.go
+++ b/platforms/pebble/pebble_driver_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hybridgroup/gobot/gobottest"
 )
 
+var _ gobot.Driver = (*PebbleDriver)(nil)
+
 func initTestPebbleDriver() *PebbleDriver {
 	return NewPebbleDriver(NewPebbleAdaptor("adaptor"), "pebble")
 }


### PR DESCRIPTION
In general, these shouldn't live in the package proper, since they're
actually tests.