### PR TITLE
ble: populate descriptors after descovering characterisitcs

### DIFF
--- a/platforms/ble/ble_client_adaptor.go
+++ b/platforms/ble/ble_client_adaptor.go
@@ -212,7 +212,7 @@ outer:
 		}
 
 		for _, c := range cs {
-			desc, err := p.DiscoverDescriptors(nil, c)
+			_, err := p.DiscoverDescriptors(nil, c)
 			if err != nil {
 				fmt.Printf("Failed to discover descriptors: %v\n", err)
 				continue outer

--- a/platforms/ble/ble_client_adaptor.go
+++ b/platforms/ble/ble_client_adaptor.go
@@ -2,10 +2,11 @@ package ble
 
 import (
 	"fmt"
-	"github.com/currantlabs/gatt"
-	"github.com/hybridgroup/gobot"
 	"log"
 	"strings"
+
+	"github.com/currantlabs/gatt"
+	"github.com/hybridgroup/gobot"
 )
 
 var _ gobot.Adaptor = (*BLEClientAdaptor)(nil)
@@ -200,6 +201,7 @@ func (b *BLEClientAdaptor) ConnectHandler(p gatt.Peripheral, err error) {
 		return
 	}
 
+outer:
 	for _, s := range ss {
 		b.services[s.UUID().String()] = NewBLEService(s.UUID().String(), s)
 
@@ -210,6 +212,11 @@ func (b *BLEClientAdaptor) ConnectHandler(p gatt.Peripheral, err error) {
 		}
 
 		for _, c := range cs {
+			desc, err := p.DiscoverDescriptors(nil, c)
+			if err != nil {
+				fmt.Printf("Failed to discover descriptors: %v\n", err)
+				continue outer
+			}
 			b.services[s.UUID().String()].characteristics[c.UUID().String()] = c
 		}
 	}


### PR DESCRIPTION
On Linux, characteristic discovery requires setting the descriptor field
explicitly.