### PR TITLE
Adding the initial NATS platform support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
  - cd gnatsd
  - "wget https://github.com/nats-io/gnatsd/releases/download/v0.8.1/gnatsd-v0.8.1-linux-amd64.zip"
  - unzip gnatsd-v0.8.1-linux-amd64.zip
+ - ls -la
  - ./gnatsd -p 4222 &
  - ./gnatsd -p 4223 --user test --pass testwd &
  - cd $HOME/gopath/src/github.com/hybridgroup/gobot

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,13 @@ before_install:
  - sudo add-apt-repository -y ppa:zoogie/sdl2-snapshots
  - sudo apt-get update
  - sudo apt-get install --force-yes libcv-dev libcvaux-dev libhighgui-dev libopencv-dev libsdl2-dev libsdl2-image-dev libsdl2 libusb-dev xvfb libgtk2.0-0
- - go get github.com/axw/gocov/gocov
- - go get github.com/mattn/goveralls
- - go get github.com/nats-io/gnats
+ - go get github.com/nats-io/gnatsd
  - cd $HOME/gopath/src/github.com/nats-io/gnatsd
  - go build
  - ./gnatsd -p 4222 &
  - ./gnatsd -p 4223 --user test --pass testwd &
+ - go get github.com/axw/gocov/gocov
+ - go get github.com/mattn/goveralls 
  - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 install:
  - go get -d -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,16 @@ before_install:
  - sudo add-apt-repository -y ppa:kubuntu-ppa/backports
  - sudo add-apt-repository -y ppa:zoogie/sdl2-snapshots
  - sudo apt-get update
- - sudo apt-get install --force-yes libcv-dev libcvaux-dev libhighgui-dev libopencv-dev libsdl2-dev libsdl2-image-dev libsdl2 libusb-dev xvfb libgtk2.0-0
- - go get github.com/nats-io/gnatsd
- - cd $HOME/gopath/src/github.com/nats-io/gnatsd
- - go build
+ - sudo apt-get install --force-yes libcv-dev libcvaux-dev libhighgui-dev libopencv-dev libsdl2-dev libsdl2-image-dev libsdl2 libusb-dev xvfb unzip libgtk2.0-0
+ - mkdir -p gnatsd
+ - cd gnatsd
+ - "wget https://github.com/nats-io/gnatsd/releases/download/v0.8.1/gnatsd-v0.8.1-linux-amd64.zip"
+ - unzip gnatsd-v0.8.1-linux-amd64.zip
  - ./gnatsd -p 4222 &
  - ./gnatsd -p 4223 --user test --pass testwd &
+ - cd $HOME/gopath/src/github.com/hybridgroup/gobot
  - go get github.com/axw/gocov/gocov
- - go get github.com/mattn/goveralls 
+ - go get github.com/mattn/goveralls
  - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 install:
  - go get -d -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ before_install:
  - sudo apt-get install --force-yes libcv-dev libcvaux-dev libhighgui-dev libopencv-dev libsdl2-dev libsdl2-image-dev libsdl2 libusb-dev xvfb libgtk2.0-0
  - go get github.com/axw/gocov/gocov
  - go get github.com/mattn/goveralls
+ - mkdir -p gnatsd
+ - "wget https://github.com/nats-io/gnatsd/releases/download/v0.8.1/gnatsd-v0.8.1-linux-amd64.zip -qO - | tar -zxvC gnatsd/"
+ - export PATH=$PATH:$PWD/gnatsd/
+ - gnatsd -p 4222 &
+ - gnatsd -p 4223 --user test --pass testwd &
  - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 install:
  - go get -d -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,11 @@ before_install:
  - sudo apt-get install --force-yes libcv-dev libcvaux-dev libhighgui-dev libopencv-dev libsdl2-dev libsdl2-image-dev libsdl2 libusb-dev xvfb libgtk2.0-0
  - go get github.com/axw/gocov/gocov
  - go get github.com/mattn/goveralls
- - mkdir -p gnatsd
- - "wget https://github.com/nats-io/gnatsd/releases/download/v0.8.1/gnatsd-v0.8.1-linux-amd64.zip -qO - | tar -zxvC gnatsd/"
- - export PATH=$PATH:$PWD/gnatsd/
- - gnatsd -p 4222 &
- - gnatsd -p 4223 --user test --pass testwd &
+ - go get github.com/nats-io/gnats
+ - cd $HOME/gopath/src/github.com/nats-io/gnatsd
+ - go build
+ - ./gnatsd -p 4222 &
+ - ./gnatsd -p 4223 --user test --pass testwd &
  - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 install:
  - go get -d -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,7 @@ before_install:
  - mkdir -p gnatsd
  - cd gnatsd
  - "wget https://github.com/nats-io/gnatsd/releases/download/v0.8.1/gnatsd-v0.8.1-linux-amd64.zip"
- - unzip gnatsd-v0.8.1-linux-amd64.zip
- - ls -la
+ - unzip -j gnatsd-v0.8.1-linux-amd64.zip
  - ./gnatsd -p 4222 &
  - ./gnatsd -p 4223 --user test --pass testwd &
  - cd $HOME/gopath/src/github.com/hybridgroup/gobot

--- a/examples/nats.go
+++ b/examples/nats.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/platforms/nats"
+)
+
+func main() {
+	gbot := gobot.NewGobot()
+
+	natsAdaptor := nats.NewNatsAdaptorWithAuth("nats", "localhost:4222", 1234)
+
+	work := func() {
+		natsAdaptor.On("hello", func(data []byte) {
+			fmt.Println("hello")
+		})
+		natsAdaptor.On("hola", func(data []byte) {
+			fmt.Println("hola")
+		})
+		data := []byte("o")
+		gobot.Every(1*time.Second, func() {
+			natsAdaptor.Publish("hello", data)
+		})
+		gobot.Every(5*time.Second, func() {
+			natsAdaptor.Publish("hola", data)
+		})
+	}
+
+	robot := gobot.NewRobot("natsBot",
+		[]gobot.Connection{natsAdaptor},
+		work,
+	)
+
+	gbot.AddRobot(robot)
+
+	gbot.Start()
+}

--- a/platforms/nats/README.md
+++ b/platforms/nats/README.md
@@ -1,0 +1,82 @@
+# NATS
+
+NATS is a lightweight messaging protocol perfect for your IoT/Robotics projects. It operates over TCP, offers a great number of features but an incredibly simple Pub Sub style model of communicating broadcast messages. NATS is blazingly fast as it is written in Go. 
+
+This repository contains the Gobot adaptor/drivers to connect to NATS servers. It uses the NATS Go Client available at https://github.com/nats-io/nats. The NATS project is maintained by Nats.io and sponsored by Apcera. Find more information on setting up a NATS server and its capability at http://nats.io/.
+
+The NATS messaging protocol (http://www.nats.io/documentation/internals/nats-protocol-demo/) is really easy to work with and can be practiced by setting up a NATS server using Go or Docker. For information on setting up a server using the source code, visit https://github.com/nats-io/gnatsd. For information on the Docker image up on Docker Hub, see https://hub.docker.com/_/nats/. Getting the server set up is very easy. The server itself is Golang, can be built for different architectures and installs in a small footprint. This is an excellent way to get communications going between your IoT and Robotics projects.
+
+## How to Install
+
+Install running:
+
+```
+go get -d -u github.com/hybridgroup/gobot/... && go install github.com/hybridgroup/gobot/platforms/nats
+```
+
+## How to Use
+
+Before running the example, make sure you have an NATS server running somewhere you can connect to
+
+```go
+package main
+
+import (
+  "fmt"
+  "time"
+
+  "github.com/hybridgroup/gobot"
+  "github.com/hybridgroup/gobot/platforms/nats"
+)
+
+func main() {
+  gbot := gobot.NewGobot()
+
+  natsAdaptor := nats.NewNatsAdaptor("nats", "localhost:4222", 1234)
+
+  work := func() {
+    natsAdaptor.On("hello", func(data []byte) {
+      fmt.Println("hello")
+    })
+    natsAdaptor.On("hola", func(data []byte) {
+      fmt.Println("hola")
+    })
+    data := []byte("o")
+    gobot.Every(1*time.Second, func() {
+      natsAdaptor.Publish("hello", data)
+    })
+    gobot.Every(5*time.Second, func() {
+      natsAdaptor.Publish("hola", data)
+    })
+  }
+
+  robot := gobot.NewRobot("natsBot",
+    []gobot.Connection{natsAdaptor},
+    work,
+  )
+
+  gbot.AddRobot(robot)
+
+  gbot.Start()
+}
+```
+
+## Supported Features
+
+* Publish messages
+* Respond to incoming message events
+
+## Upcoming Features
+
+* Support for Username/password
+* Encoded messages (JSON)
+* Exposing more NATS Features (tls)
+* Simplified tests
+
+## Contributing
+
+For our contribution guidelines, please go to https://github.com/hybridgroup/gobot/blob/master/CONTRIBUTING.md
+
+## License
+
+Copyright (c) 2013-2016 The Hybrid Group. Licensed under the Apache 2.0 license.

--- a/platforms/nats/doc.go
+++ b/platforms/nats/doc.go
@@ -1,0 +1,8 @@
+/*
+Package nats provides Gobot adaptor for the nats message service.
+Installing:
+  go get github.com/hybridgroup/gobot/platforms/nats
+For further information refer to mqtt README:
+https://github.com/hybridgroup/gobot/blob/master/platforms/nats/README.md
+*/
+package nats

--- a/platforms/nats/nats_adaptor.go
+++ b/platforms/nats/nats_adaptor.go
@@ -1,0 +1,99 @@
+package nats
+
+import (
+	"github.com/nats-io/nats"
+)
+
+// NatsAdaptor is a configuration struct for interacting with a nats server.
+// Name is a logical name for the adaptor/nats server connection.
+// Host is in the form "localhost:4222" which is the hostname/ip and port of the nats server.
+// ClientID is a unique identifier integer that specifies the identity of the client.
+type NatsAdaptor struct {
+	name     string
+	Host     string
+	clientID int
+	username string
+	password string
+	client   *nats.Conn
+}
+
+// NewNatsAdaptor populates a new NatsAdaptor.
+func NewNatsAdaptor(name string, host string, clientID int) *NatsAdaptor {
+	return &NatsAdaptor{
+		name:     name,
+		Host:     host,
+		clientID: clientID,
+	}
+}
+
+// NewNatsAdaptorWithAuth populates a NatsAdaptor including username and password.
+func NewNatsAdaptorWithAuth(name string, host string, clientID int, username string, password string) *NatsAdaptor {
+	return &NatsAdaptor{
+		name:     name,
+		Host:     host,
+		clientID: clientID,
+		username: username,
+		password: password,
+	}
+}
+
+// Name returns the logical client name.
+func (a *NatsAdaptor) Name() string { return a.name }
+
+// Connect makes a connection to the Nats server.
+func (a *NatsAdaptor) Connect() (errs []error) {
+
+	auth := ""
+	if a.username != "" && a.password != "" {
+		auth = a.username + ":" + a.password + "@"
+	}
+
+	defaultURL := "nats://" + auth + a.Host
+
+	var err error
+	a.client, err = nats.Connect(defaultURL)
+	if err != nil {
+		return append(errs, err)
+	}
+	return
+}
+
+// Disconnect from the nats server. Returns an error if the client doesn't exist.
+func (a *NatsAdaptor) Disconnect() (err error) {
+	if a.client != nil {
+		a.client.Close()
+	}
+	return
+}
+
+// Finalize is simply a helper method for the disconnect.
+func (a *NatsAdaptor) Finalize() (errs []error) {
+	a.Disconnect()
+	return
+}
+
+// Publish sends a message with the particular topic to the nats server.
+func (a *NatsAdaptor) Publish(topic string, message []byte) bool {
+	if a.client == nil {
+		return false
+	}
+	a.client.Publish(topic, message)
+	return true
+}
+
+// On is an event-handler style subscriber to a particular topic (named event).
+// Supply a handler function to use the bytes returned by the server.
+func (a *NatsAdaptor) On(event string, f func(s []byte)) bool {
+	if a.client == nil {
+		return false
+	}
+	a.client.Subscribe(event, func(msg *nats.Msg) {
+		incoming := msg.Data
+		if string(incoming) == "PING" {
+			a.Publish(event, []byte("PONG"))
+		} else {
+			f(msg.Data)
+		}
+	})
+	return true
+}

--- a/platforms/nats/nats_adaptor.go
+++ b/platforms/nats/nats_adaptor.go
@@ -88,12 +88,7 @@ func (a *NatsAdaptor) On(event string, f func(s []byte)) bool {
 		return false
 	}
 	a.client.Subscribe(event, func(msg *nats.Msg) {
-		incoming := msg.Data
-		if string(incoming) == "PING" {
-			a.Publish(event, []byte("PONG"))
-		} else {
-			f(msg.Data)
-		}
+		f(msg.Data)
 	})
 	return true
 }

--- a/platforms/nats/nats_adaptor_test.go
+++ b/platforms/nats/nats_adaptor_test.go
@@ -1,0 +1,55 @@
+package nats
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/gobottest"
+)
+
+var _ gobot.Adaptor = (*NatsAdaptor)(nil)
+
+func initTestNatsAdaptor() *NatsAdaptor {
+	return NewNatsAdaptor("Nats", "localhost:4222", 9999)
+}
+
+// These tests only succeed when there is a nats server available
+func TestNatsAdaptorPublishWhenConnected(t *testing.T) {
+	a := initTestNatsAdaptor()
+	a.Connect()
+	data := []byte("o")
+	gobottest.Assert(t, a.Publish("test", data), true)
+}
+
+func TestNatsAdaptorOnWhenConnected(t *testing.T) {
+	a := initTestNatsAdaptor()
+	a.Connect()
+	gobottest.Assert(t, a.On("hola", func(data []byte) {
+		fmt.Println("hola")
+	}), true)
+}
+
+// These tests only succeed when there is no nats server available
+func TestNatsAdaptorConnect(t *testing.T) {
+	a := initTestNatsAdaptor()
+	gobottest.Assert(t, a.Connect()[0].Error(), "nats: no servers available for connection")
+}
+
+func TestNatsAdaptorFinalize(t *testing.T) {
+	a := initTestNatsAdaptor()
+	gobottest.Assert(t, len(a.Finalize()), 0)
+}
+
+func TestNatsAdaptorCannotPublishUnlessConnected(t *testing.T) {
+	a := initTestNatsAdaptor()
+	data := []byte("o")
+	gobottest.Assert(t, a.Publish("test", data), false)
+}
+
+func TestNatsAdaptorCannotOnUnlessConnected(t *testing.T) {
+	a := initTestNatsAdaptor()
+	gobottest.Assert(t, a.On("hola", func(data []byte) {
+		fmt.Println("hola")
+	}), false)
+}

--- a/platforms/nats/nats_adaptor_test.go
+++ b/platforms/nats/nats_adaptor_test.go
@@ -10,45 +10,54 @@ import (
 
 var _ gobot.Adaptor = (*NatsAdaptor)(nil)
 
-func initTestNatsAdaptor() *NatsAdaptor {
-	return NewNatsAdaptor("Nats", "localhost:4222", 9999)
-}
-
-// These tests only succeed when there is a nats server available
 func TestNatsAdaptorPublishWhenConnected(t *testing.T) {
-	a := initTestNatsAdaptor()
+	a := NewNatsAdaptor("Nats", "localhost:4222", 9999)
 	a.Connect()
 	data := []byte("o")
 	gobottest.Assert(t, a.Publish("test", data), true)
 }
 
 func TestNatsAdaptorOnWhenConnected(t *testing.T) {
-	a := initTestNatsAdaptor()
+	a := NewNatsAdaptor("Nats", "localhost:4222", 9999)
 	a.Connect()
 	gobottest.Assert(t, a.On("hola", func(data []byte) {
 		fmt.Println("hola")
 	}), true)
 }
 
-// These tests only succeed when there is no nats server available
+func TestNatsAdaptorPublishWhenConnectedWithAuth(t *testing.T) {
+	a := NewNatsAdaptorWithAuth("Nats", "localhost:4222", 9999, "test", "testwd")
+	a.Connect()
+	data := []byte("o")
+	gobottest.Assert(t, a.Publish("test", data), true)
+}
+
+func TestNatsAdaptorOnWhenConnectedWithAuth(t *testing.T) {
+	a := NewNatsAdaptorWithAuth("Nats", "localhost:4222", 9999, "test", "testwd")
+	a.Connect()
+	gobottest.Assert(t, a.On("hola", func(data []byte) {
+		fmt.Println("hola")
+	}), true)
+}
+
 func TestNatsAdaptorConnect(t *testing.T) {
-	a := initTestNatsAdaptor()
+	a := NewNatsAdaptor("Nats", "localhost:9999", 9999)
 	gobottest.Assert(t, a.Connect()[0].Error(), "nats: no servers available for connection")
 }
 
 func TestNatsAdaptorFinalize(t *testing.T) {
-	a := initTestNatsAdaptor()
+	a := NewNatsAdaptor("Nats", "localhost:9999", 9999)
 	gobottest.Assert(t, len(a.Finalize()), 0)
 }
 
 func TestNatsAdaptorCannotPublishUnlessConnected(t *testing.T) {
-	a := initTestNatsAdaptor()
+	a := NewNatsAdaptor("Nats", "localhost:9999", 9999)
 	data := []byte("o")
 	gobottest.Assert(t, a.Publish("test", data), false)
 }
 
 func TestNatsAdaptorCannotOnUnlessConnected(t *testing.T) {
-	a := initTestNatsAdaptor()
+	a := NewNatsAdaptor("Nats", "localhost:9999", 9999)
 	gobottest.Assert(t, a.On("hola", func(data []byte) {
 		fmt.Println("hola")
 	}), false)

--- a/platforms/nats/nats_adaptor_test.go
+++ b/platforms/nats/nats_adaptor_test.go
@@ -10,6 +10,11 @@ import (
 
 var _ gobot.Adaptor = (*NatsAdaptor)(nil)
 
+func TestNatsAdaptorReturnsName(t *testing.T) {
+	a := NewNatsAdaptor("Nats", "localhost:4222", 9999)
+	gobottest.Assert(t, a.Name(), "Nats")
+}
+
 func TestNatsAdaptorPublishWhenConnected(t *testing.T) {
 	a := NewNatsAdaptor("Nats", "localhost:4222", 9999)
 	a.Connect()


### PR DESCRIPTION
This commit is to support NATS.io messaging protocol. This basic implementation supports the simplest use cases and follows directly the same implementation as the MQTT protocol. Parity is brought to bear between the two protocols. You can almost use them interchangeably except that the CLIENTID on the MQTT platform for GoBot uses a `string` while NATS uses an `int` for unique client. 

I intend to extend this code to add many more features from NATS. However, I wanted to at least get the platform docs, examples and happy-path use case implemented so that GoBotters (is that a thing?!?) could jump on using the NATS protocol for their projects. 

Finally, while I added some tests, once again I tried to meet the same type/number of tests that the MQTT platform added. This is weird to me because they added some tests which succeed only when the server is running and some that only succeed when the server is NOT running. I did meet both of these but don't really like this because there is no way to run the whole suite to success. I could fix this through mocking but with such little amount of code, I didn't want to expand the platform just for dependency injection and mocking - NOR did I want to add support for a mocking library and complicate the deployment process. I'm open to comments on this - I can work harder on the tests if needed. 

Thanks for consideration! (P.S. It was great meeting you @deadprogram at GopherCon. What a fantastic Hack Day! Best Ever! GO GOBOT!)