### PR TITLE
Fix the ServoConfig byte order

### DIFF
--- a/platforms/firmata/client/client.go
+++ b/platforms/firmata/client/client.go
@@ -218,10 +218,10 @@ func (b *Client) ServoConfig(pin int, max int, min int) error {
 	ret := []byte{
 		ServoConfig,
 		byte(pin),
-		byte(max & 0x7F),
-		byte((max >> 7) & 0x7F),
 		byte(min & 0x7F),
 		byte((min >> 7) & 0x7F),
+		byte(max & 0x7F),
+		byte((max >> 7) & 0x7F),
 	}
 	return b.writeSysex(ret)
 }

--- a/platforms/firmata/client/client_test.go
+++ b/platforms/firmata/client/client_test.go
@@ -232,7 +232,7 @@ func TestServoConfig(t *testing.T) {
 		result      error
 	}{
 		{
-			description: "Mix values for min & max",
+			description: "Min values for min & max",
 			arguments:   [3]int{9, 0, 0},
 			expected:    []byte{0xF0, 0x70, 9, 0, 0, 0, 0, 0xF7},
 		},

--- a/platforms/firmata/firmata_adaptor.go
+++ b/platforms/firmata/firmata_adaptor.go
@@ -34,6 +34,7 @@ type firmataBoard interface {
 	I2cRead(int, int) error
 	I2cWrite(int, []byte) error
 	I2cConfig(int) error
+	ServoConfig(int, int, int) error
 	Event(string) *gobot.Event
 }
 
@@ -114,6 +115,16 @@ func (f *FirmataAdaptor) Port() string { return f.port }
 
 // Name returns the  FirmataAdaptors name
 func (f *FirmataAdaptor) Name() string { return f.name }
+
+// ServoConfig sets the PWM minimum and maximum for a pin
+func (f *FirmataAdaptor) ServoConfig(pin string, min, max int) error {
+	p, err := strconv.Atoi(pin)
+	if err != nil {
+		return err
+	}
+
+	return f.board.ServoConfig(p, max, min)
+}
 
 // ServoWrite writes the 0-180 degree angle to the specified pin.
 func (f *FirmataAdaptor) ServoWrite(pin string, angle byte) (err error) {

--- a/platforms/firmata/firmata_adaptor.go
+++ b/platforms/firmata/firmata_adaptor.go
@@ -116,7 +116,7 @@ func (f *FirmataAdaptor) Port() string { return f.port }
 // Name returns the  FirmataAdaptors name
 func (f *FirmataAdaptor) Name() string { return f.name }
 
-// ServoConfig sets the PWM minimum and maximum for a pin
+// ServoConfig sets the pulse width in microseconds for a pin attached to a servo
 func (f *FirmataAdaptor) ServoConfig(pin string, min, max int) error {
 	p, err := strconv.Atoi(pin)
 	if err != nil {

--- a/platforms/firmata/firmata_adaptor_test.go
+++ b/platforms/firmata/firmata_adaptor_test.go
@@ -1,8 +1,11 @@
 package firmata
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,10 +17,11 @@ import (
 type readWriteCloser struct{}
 
 func (readWriteCloser) Write(p []byte) (int, error) {
-	return len(p), nil
+	return testWriteData.Write(p)
 }
 
 var testReadData = []byte{}
+var testWriteData = bytes.Buffer{}
 
 func (readWriteCloser) Read(b []byte) (int, error) {
 	size := len(b)
@@ -61,14 +65,15 @@ func (m mockFirmataBoard) Disconnect() error {
 func (m mockFirmataBoard) Pins() []client.Pin {
 	return m.pins
 }
-func (mockFirmataBoard) AnalogWrite(int, int) error   { return nil }
-func (mockFirmataBoard) SetPinMode(int, int) error    { return nil }
-func (mockFirmataBoard) ReportAnalog(int, int) error  { return nil }
-func (mockFirmataBoard) ReportDigital(int, int) error { return nil }
-func (mockFirmataBoard) DigitalWrite(int, int) error  { return nil }
-func (mockFirmataBoard) I2cRead(int, int) error       { return nil }
-func (mockFirmataBoard) I2cWrite(int, []byte) error   { return nil }
-func (mockFirmataBoard) I2cConfig(int) error          { return nil }
+func (mockFirmataBoard) AnalogWrite(int, int) error      { return nil }
+func (mockFirmataBoard) SetPinMode(int, int) error       { return nil }
+func (mockFirmataBoard) ReportAnalog(int, int) error     { return nil }
+func (mockFirmataBoard) ReportDigital(int, int) error    { return nil }
+func (mockFirmataBoard) DigitalWrite(int, int) error     { return nil }
+func (mockFirmataBoard) I2cRead(int, int) error          { return nil }
+func (mockFirmataBoard) I2cWrite(int, []byte) error      { return nil }
+func (mockFirmataBoard) I2cConfig(int) error             { return nil }
+func (mockFirmataBoard) ServoConfig(int, int, int) error { return nil }
 
 func initTestFirmataAdaptor() *FirmataAdaptor {
 	a := NewFirmataAdaptor("board", "/dev/null")
@@ -165,4 +170,14 @@ func TestFirmataAdaptorI2cRead(t *testing.T) {
 func TestFirmataAdaptorI2cWrite(t *testing.T) {
 	a := initTestFirmataAdaptor()
 	a.I2cWrite(0x00, []byte{0x00, 0x01})
+}
+
+func TestServoConfig(t *testing.T) {
+	a := initTestFirmataAdaptor()
+	err := a.ServoConfig("9", 0, 0)
+	gobottest.Assert(t, err, nil)
+
+	// test atoi error
+	err = a.ServoConfig("a", 0, 0)
+	gobottest.Assert(t, true, strings.Contains(fmt.Sprintf("%v", err), "invalid syntax"))
 }


### PR DESCRIPTION
This corrects the byte order according to the [servo](https://github.com/firmata/protocol/blob/master/servos.md) protocol specification. It describes the bytes to be sent as:

```
// minPulse and maxPulse are 14-bit unsigned integers
0  START_SYSEX          (0xF0)
1  SERVO_CONFIG         (0x70)
2  pin number           (0-127)
3  minPulse LSB         (0-6)
4  minPulse MSB         (0-13)
5  maxPulse LSB         (0-6)
6  maxPulse MSB         (7-13)
7  END_SYSEX            (0xF7)
```

While this seems to fix the Firmata client, issue #172 seems to be asking for this to be exposed in the FirmataAdapter. It would be easy enough to add to the adapter, and if that's wanted I can update the PR to include that.