### PR TITLE
Add PinMode

### DIFF
--- a/platforms/i2c/mcp23017_driver.go
+++ b/platforms/i2c/mcp23017_driver.go
@@ -155,6 +155,18 @@ func (m *MCP23017Driver) WriteGPIO(pin uint8, val uint8, portStr string) (err er
 	return nil
 }
 
+// PinMode set pin mode
+// val (0 output 1 input)
+// port (A or B).
+func (m *MCP23017Driver) PinMode(pin, val uint8, portStr string) (err error) {
+	selectedPort := m.getPort(portStr)
+	// Set IODIR register bit for given pin to an output/input.
+	if err = m.write(selectedPort.IODIR, uint8(pin), val); err != nil {
+		return
+	}
+	return
+}
+
 // ReadGPIO reads a value from a given gpio pin (0-7) and a
 // port (A or B).
 func (m *MCP23017Driver) ReadGPIO(pin uint8, portStr string) (val uint8, err error) {

--- a/platforms/i2c/mcp23017_driver_test.go
+++ b/platforms/i2c/mcp23017_driver_test.go
@@ -187,6 +187,29 @@ func TestMCP23017DriverReadGPIO(t *testing.T) {
 	gobottest.Assert(t, err, errors.New("Read came back with no data"))
 }
 
+func TestMCP23017DriverPinMode(t *testing.T) {
+        mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
+        adaptor.i2cMcpReadImpl = func(a int, b int) ([]byte, error) {
+                return make([]byte, b), nil
+        }
+        adaptor.i2cMcpWriteImpl = func() error {
+                return nil
+        }
+        err := mcp.PinMode(7, 0, "A")
+        gobottest.Assert(t, err, nil)
+
+        // write error
+        mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
+        adaptor.i2cMcpReadImpl = func(a int, b int) ([]byte, error) {
+                return make([]byte, b), nil
+        }
+        adaptor.i2cMcpWriteImpl = func() error {
+                return errors.New("write error")
+        }
+        err = mcp.PinMode(7, 0, "A")
+        gobottest.Assert(t, err, errors.New("write error"))
+}
+
 func TestMCP23017DriverSetPullUp(t *testing.T) {
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
 	adaptor.i2cMcpReadImpl = func(a int, b int) ([]byte, error) {


### PR DESCRIPTION
Add PinMode MCP23017 fix issues #310 

Usage:
mcp23017.PinMode(0,1,"A") //set port A pin 0 input
mcp23017.PinMode(0,0,"A") //set port A pin 0 output
