### PR TITLE
Added return as arduinoSetup was always being called

### DIFF
--- a/platforms/intel-iot/edison/edison_adaptor.go
+++ b/platforms/intel-iot/edison/edison_adaptor.go
@@ -98,6 +98,7 @@ func (e *Adaptor) Connect() (errs []error) {
 		if err := e.miniboardSetup(); err != nil {
 			return []error{err}
 		}
+		return
 	}
 	if err := e.arduinoSetup(); err != nil {
 		return []error{err}


### PR DESCRIPTION
After making this change I managed to get the blinking LED example working on a Sparkfun Edison with GPIO block.  This helps with issue #262 