### PR TITLE
fixed undefined method error

### DIFF
--- a/platforms/keyboard/doc.go
+++ b/platforms/keyboard/doc.go
@@ -24,7 +24,7 @@ Example:
 		keys := keyboard.NewDriver()
 
 		work := func() {
-			gobot.On(keys.Event("key"), func(data interface{}) {
+			keys.On(keys.Event("key"), func(data interface{}) {
 				key := data.(keyboard.KeyEvent)
 
 				if key.Key == keyboard.A {


### PR DESCRIPTION
Replaced gobot.On with keys.On since gobot.On returned an `undefined: gobot.On` error.