### PR TITLE
Adaptors/Drivers return error/multierror instead of slice of errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,4 @@ deps:
 	go get -d -v github.com/nats-io/nats
 	go get -d -v github.com/lazywei/go-opencv
 	go get -d -v github.com/donovanhide/eventsource
+	go get -d -v github.com/hashicorp/go-multierror

--- a/adaptor.go
+++ b/adaptor.go
@@ -7,9 +7,9 @@ type Adaptor interface {
 	// SetName sets the label for the Adaptor
 	SetName(n string)
 	// Connect initiates the Adaptor
-	Connect() []error
+	Connect() error
 	// Finalize terminates the Adaptor
-	Finalize() []error
+	Finalize() error
 }
 
 // Porter is the interface that describes an adaptor's port

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -28,8 +28,8 @@ type testDriver struct {
 	gobot.Eventer
 }
 
-func (t *testDriver) Start() (errs []error)        { return }
-func (t *testDriver) Halt() (errs []error)         { return }
+func (t *testDriver) Start() (err error)           { return }
+func (t *testDriver) Halt() (err error)            { return }
 func (t *testDriver) Name() string                 { return t.name }
 func (t *testDriver) SetName(n string)             { t.name = n }
 func (t *testDriver) Pin() string                  { return t.pin }
@@ -64,14 +64,14 @@ type testAdaptor struct {
 	port string
 }
 
-var testAdaptorConnect = func() (errs []error) { return }
-var testAdaptorFinalize = func() (errs []error) { return }
+var testAdaptorConnect = func() (err error) { return }
+var testAdaptorFinalize = func() (err error) { return }
 
-func (t *testAdaptor) Finalize() (errs []error) { return testAdaptorFinalize() }
-func (t *testAdaptor) Connect() (errs []error)  { return testAdaptorConnect() }
-func (t *testAdaptor) Name() string             { return t.name }
-func (t *testAdaptor) SetName(n string)         { t.name = n }
-func (t *testAdaptor) Port() string             { return t.port }
+func (t *testAdaptor) Finalize() (err error) { return testAdaptorFinalize() }
+func (t *testAdaptor) Connect() (err error)  { return testAdaptorConnect() }
+func (t *testAdaptor) Name() string          { return t.name }
+func (t *testAdaptor) SetName(n string)      { t.name = n }
+func (t *testAdaptor) Port() string          { return t.port }
 
 func newTestAdaptor(name string, port string) *testAdaptor {
 	return &testAdaptor{

--- a/cli/generate.go
+++ b/cli/generate.go
@@ -175,9 +175,9 @@ func ({{.FirstLetter}} *{{.UpperName}}Adaptor) Name() string { return {{.FirstLe
 
 func ({{.FirstLetter}} *{{.UpperName}}Adaptor) SetName(name string) { {{.FirstLetter}}.name = name }
 
-func ({{.FirstLetter}} *{{.UpperName}}Adaptor) Connect() []error { return nil }
+func ({{.FirstLetter}} *{{.UpperName}}Adaptor) Connect() error { return nil }
 
-func ({{.FirstLetter}} *{{.UpperName}}Adaptor) Finalize() []error { return nil }
+func ({{.FirstLetter}} *{{.UpperName}}Adaptor) Finalize() error { return nil }
 
 func ({{.FirstLetter}} *{{.UpperName}}Adaptor) Ping() string { return "pong" }
 `
@@ -242,7 +242,7 @@ func ({{.FirstLetter}} *{{.UpperName}}Driver) Ping() string {
 	return {{.FirstLetter}}.adaptor().Ping()
 }
 
-func ({{.FirstLetter}} *{{.UpperName}}Driver) Start() []error {
+func ({{.FirstLetter}} *{{.UpperName}}Driver) Start() error {
 	go func() {
 		for {
 			{{.FirstLetter}}.Publish({{.FirstLetter}}.Event(Hello), {{.FirstLetter}}.Hello())
@@ -257,7 +257,7 @@ func ({{.FirstLetter}} *{{.UpperName}}Driver) Start() []error {
 	return nil
 }
 
-func ({{.FirstLetter}} *{{.UpperName}}Driver) Halt() []error {
+func ({{.FirstLetter}} *{{.UpperName}}Driver) Halt() error {
 	{{.FirstLetter}}.halt <- true
 	return nil
 }

--- a/device.go
+++ b/device.go
@@ -1,9 +1,10 @@
 package gobot
 
 import (
-	"fmt"
 	"log"
 	"reflect"
+
+	multierror "github.com/hashicorp/go-multierror"
 )
 
 // JSONDevice is a JSON representation of a Device.
@@ -52,7 +53,7 @@ func (d *Devices) Each(f func(Device)) {
 }
 
 // Start calls Start on each Device in d
-func (d *Devices) Start() (errs []error) {
+func (d *Devices) Start() (err error) {
 	log.Println("Starting devices...")
 	for _, device := range *d {
 		info := "Starting device " + device.Name()
@@ -62,25 +63,19 @@ func (d *Devices) Start() (errs []error) {
 		}
 
 		log.Println(info + "...")
-		if errs = device.Start(); len(errs) > 0 {
-			for i, err := range errs {
-				errs[i] = fmt.Errorf("Device %q: %v", device.Name(), err)
-			}
-			return
+		if derr := device.Start(); derr != nil {
+			err = multierror.Append(err, derr)
 		}
 	}
-	return
+	return err
 }
 
 // Halt calls Halt on each Device in d
-func (d *Devices) Halt() (errs []error) {
+func (d *Devices) Halt() (err error) {
 	for _, device := range *d {
-		if derrs := device.Halt(); len(derrs) > 0 {
-			for i, err := range derrs {
-				derrs[i] = fmt.Errorf("Device %q: %v", device.Name(), err)
-			}
-			errs = append(errs, derrs...)
+		if derr := device.Halt(); derr != nil {
+			err = multierror.Append(err, derr)
 		}
 	}
-	return
+	return err
 }

--- a/driver.go
+++ b/driver.go
@@ -7,9 +7,9 @@ type Driver interface {
 	// SetName sets the label for the Driver
 	SetName(s string)
 	// Start initiates the Driver
-	Start() []error
+	Start() error
 	// Halt terminates the Driver
-	Halt() []error
+	Halt() error
 	// Connection returns the Connection assiciated with the Driver
 	Connection() Connection
 }

--- a/drivers/gpio/analog_sensor_driver.go
+++ b/drivers/gpio/analog_sensor_driver.go
@@ -55,7 +55,7 @@ func NewAnalogSensorDriver(a AnalogReader, pin string, v ...time.Duration) *Anal
 // Emits the Events:
 //	Data int - Event is emitted on change and represents the current reading from the sensor.
 //	Error error - Event is emitted on error reading from the sensor.
-func (a *AnalogSensorDriver) Start() (errs []error) {
+func (a *AnalogSensorDriver) Start() (err error) {
 	value := 0
 	go func() {
 		timer := time.NewTimer(a.interval)
@@ -82,7 +82,7 @@ func (a *AnalogSensorDriver) Start() (errs []error) {
 }
 
 // Halt stops polling the analog sensor for new information
-func (a *AnalogSensorDriver) Halt() (errs []error) {
+func (a *AnalogSensorDriver) Halt() (err error) {
 	a.halt <- true
 	return
 }

--- a/drivers/gpio/analog_sensor_driver_test.go
+++ b/drivers/gpio/analog_sensor_driver_test.go
@@ -36,7 +36,7 @@ func TestAnalogSensorDriverStart(t *testing.T) {
 
 	d := NewAnalogSensorDriver(newGpioTestAdaptor(), "1")
 
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 
 	// expect data to be received
 	d.Once(d.Event(Data), func(data interface{}) {
@@ -100,7 +100,7 @@ func TestAnalogSensorDriverHalt(t *testing.T) {
 		<-d.halt
 		close(done)
 	}()
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 	select {
 	case <-done:
 	case <-time.After(time.Millisecond):

--- a/drivers/gpio/button_driver.go
+++ b/drivers/gpio/button_driver.go
@@ -50,7 +50,7 @@ func NewButtonDriver(a DigitalReader, pin string, v ...time.Duration) *ButtonDri
 // 	Push int - On button push
 //	Release int - On button release
 //	Error error - On button error
-func (b *ButtonDriver) Start() (errs []error) {
+func (b *ButtonDriver) Start() (err error) {
 	state := 0
 	go func() {
 		for {
@@ -72,7 +72,7 @@ func (b *ButtonDriver) Start() (errs []error) {
 }
 
 // Halt stops polling the button for new information
-func (b *ButtonDriver) Halt() (errs []error) {
+func (b *ButtonDriver) Halt() (err error) {
 	b.halt <- true
 	return
 }

--- a/drivers/gpio/button_driver_test.go
+++ b/drivers/gpio/button_driver_test.go
@@ -22,7 +22,7 @@ func TestButtonDriverHalt(t *testing.T) {
 	go func() {
 		<-d.halt
 	}()
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 }
 
 func TestButtonDriver(t *testing.T) {
@@ -36,7 +36,7 @@ func TestButtonDriver(t *testing.T) {
 func TestButtonDriverStart(t *testing.T) {
 	sem := make(chan bool, 0)
 	d := initTestButtonDriver()
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 
 	d.Once(ButtonPush, func(data interface{}) {
 		gobottest.Assert(t, d.Active, true)

--- a/drivers/gpio/buzzer_driver.go
+++ b/drivers/gpio/buzzer_driver.go
@@ -150,10 +150,10 @@ func NewBuzzerDriver(a DigitalWriter, pin string) *BuzzerDriver {
 }
 
 // Start implements the Driver interface
-func (l *BuzzerDriver) Start() (errs []error) { return }
+func (l *BuzzerDriver) Start() (err error) { return }
 
 // Halt implements the Driver interface
-func (l *BuzzerDriver) Halt() (errs []error) { return }
+func (l *BuzzerDriver) Halt() (err error) { return }
 
 // Name returns the BuzzerDrivers name
 func (l *BuzzerDriver) Name() string { return l.name }

--- a/drivers/gpio/direct_pin_driver.go
+++ b/drivers/gpio/direct_pin_driver.go
@@ -68,10 +68,10 @@ func (d *DirectPinDriver) Pin() string { return d.pin }
 func (d *DirectPinDriver) Connection() gobot.Connection { return d.connection }
 
 // Start implements the Driver interface
-func (d *DirectPinDriver) Start() (errs []error) { return }
+func (d *DirectPinDriver) Start() (err error) { return }
 
 // Halt implements the Driver interface
-func (d *DirectPinDriver) Halt() (errs []error) { return }
+func (d *DirectPinDriver) Halt() (err error) { return }
 
 // Turn Off pin
 func (d *DirectPinDriver) Off() (err error) {

--- a/drivers/gpio/direct_pin_driver_test.go
+++ b/drivers/gpio/direct_pin_driver_test.go
@@ -61,12 +61,12 @@ func TestDirectPinDriver(t *testing.T) {
 
 func TestDirectPinDriverStart(t *testing.T) {
 	d := initTestDirectPinDriver(newGpioTestAdaptor())
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 }
 
 func TestDirectPinDriverHalt(t *testing.T) {
 	d := initTestDirectPinDriver(newGpioTestAdaptor())
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 }
 
 func TestDirectPinDriverOff(t *testing.T) {

--- a/drivers/gpio/grove_drivers_test.go
+++ b/drivers/gpio/grove_drivers_test.go
@@ -131,7 +131,7 @@ func TestDriverPublishesError(t *testing.T) {
 		testAdaptorAnalogRead = returnErr
 		testAdaptorDigitalRead = returnErr
 
-		gobottest.Assert(t, len(driver.Start()), 0)
+		gobottest.Assert(t, driver.Start(), nil)
 
 		// expect error
 		driver.Once(driver.Event(Error), func(data interface{}) {

--- a/drivers/gpio/grove_temperature_sensor_driver.go
+++ b/drivers/gpio/grove_temperature_sensor_driver.go
@@ -52,7 +52,7 @@ func NewGroveTemperatureSensorDriver(a AnalogReader, pin string, v ...time.Durat
 // Emits the Events:
 //	Data int - Event is emitted on change and represents the current temperature in celsius from the sensor.
 //	Error error - Event is emitted on error reading from the sensor.
-func (a *GroveTemperatureSensorDriver) Start() (errs []error) {
+func (a *GroveTemperatureSensorDriver) Start() (err error) {
 	thermistor := 3975.0
 	a.temperature = 0
 
@@ -80,7 +80,7 @@ func (a *GroveTemperatureSensorDriver) Start() (errs []error) {
 }
 
 // Halt stops polling the analog sensor for new information
-func (a *GroveTemperatureSensorDriver) Halt() (errs []error) {
+func (a *GroveTemperatureSensorDriver) Halt() (err error) {
 	a.halt <- true
 	return
 }

--- a/drivers/gpio/grove_temperature_sensor_driver_test.go
+++ b/drivers/gpio/grove_temperature_sensor_driver_test.go
@@ -28,7 +28,7 @@ func TestGroveTempSensorPublishesTemperatureInCelsius(t *testing.T) {
 		val = 585
 		return
 	}
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 
 	d.Once(d.Event(Data), func(data interface{}) {
 		gobottest.Assert(t, fmt.Sprintf("%.2f", data.(float64)), "31.62")
@@ -46,7 +46,7 @@ func TestGroveTempSensorPublishesError(t *testing.T) {
 		return
 	}
 
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 
 	// expect error
 	d.Once(d.Event(Error), func(data interface{}) {
@@ -68,7 +68,7 @@ func TestGroveTempSensorHalt(t *testing.T) {
 		<-d.halt
 		close(done)
 	}()
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 	select {
 	case <-done:
 	case <-time.After(time.Millisecond):

--- a/drivers/gpio/helpers_test.go
+++ b/drivers/gpio/helpers_test.go
@@ -2,10 +2,10 @@ package gpio
 
 type gpioTestBareAdaptor struct{}
 
-func (t *gpioTestBareAdaptor) Connect() (errs []error)  { return }
-func (t *gpioTestBareAdaptor) Finalize() (errs []error) { return }
-func (t *gpioTestBareAdaptor) Name() string             { return "" }
-func (t *gpioTestBareAdaptor) SetName(n string)         {}
+func (t *gpioTestBareAdaptor) Connect() (err error)  { return }
+func (t *gpioTestBareAdaptor) Finalize() (err error) { return }
+func (t *gpioTestBareAdaptor) Name() string          { return "" }
+func (t *gpioTestBareAdaptor) SetName(n string)      {}
 
 type gpioTestDigitalWriter struct {
 	gpioTestBareAdaptor
@@ -49,11 +49,11 @@ func (t *gpioTestAdaptor) AnalogRead(string) (val int, err error) {
 func (t *gpioTestAdaptor) DigitalRead(string) (val int, err error) {
 	return testAdaptorDigitalRead()
 }
-func (t *gpioTestAdaptor) Connect() (errs []error)  { return }
-func (t *gpioTestAdaptor) Finalize() (errs []error) { return }
-func (t *gpioTestAdaptor) Name() string             { return t.name }
-func (t *gpioTestAdaptor) SetName(n string)         { t.name = n }
-func (t *gpioTestAdaptor) Port() string             { return t.port }
+func (t *gpioTestAdaptor) Connect() (err error)  { return }
+func (t *gpioTestAdaptor) Finalize() (err error) { return }
+func (t *gpioTestAdaptor) Name() string          { return t.name }
+func (t *gpioTestAdaptor) SetName(n string)      { t.name = n }
+func (t *gpioTestAdaptor) Port() string          { return t.port }
 
 func newGpioTestAdaptor() *gpioTestAdaptor {
 	return &gpioTestAdaptor{

--- a/drivers/gpio/led_driver.go
+++ b/drivers/gpio/led_driver.go
@@ -50,10 +50,10 @@ func NewLedDriver(a DigitalWriter, pin string) *LedDriver {
 }
 
 // Start implements the Driver interface
-func (l *LedDriver) Start() (errs []error) { return }
+func (l *LedDriver) Start() (err error) { return }
 
 // Halt implements the Driver interface
-func (l *LedDriver) Halt() (errs []error) { return }
+func (l *LedDriver) Halt() (err error) { return }
 
 // Name returns the LedDrivers name
 func (l *LedDriver) Name() string { return l.name }

--- a/drivers/gpio/led_driver_test.go
+++ b/drivers/gpio/led_driver_test.go
@@ -48,12 +48,12 @@ func TestLedDriver(t *testing.T) {
 
 func TestLedDriverStart(t *testing.T) {
 	d := initTestLedDriver(newGpioTestAdaptor())
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 }
 
 func TestLedDriverHalt(t *testing.T) {
 	d := initTestLedDriver(newGpioTestAdaptor())
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 }
 
 func TestLedDriverToggle(t *testing.T) {

--- a/drivers/gpio/makey_button_driver.go
+++ b/drivers/gpio/makey_button_driver.go
@@ -62,7 +62,7 @@ func (b *MakeyButtonDriver) Connection() gobot.Connection { return b.connection.
 // 	Push int - On button push
 //	Release int - On button release
 //	Error error - On button error
-func (b *MakeyButtonDriver) Start() (errs []error) {
+func (b *MakeyButtonDriver) Start() (err error) {
 	state := 1
 	go func() {
 		timer := time.NewTimer(b.interval)
@@ -93,7 +93,7 @@ func (b *MakeyButtonDriver) Start() (errs []error) {
 }
 
 // Halt stops polling the makey button for new information
-func (b *MakeyButtonDriver) Halt() (errs []error) {
+func (b *MakeyButtonDriver) Halt() (err error) {
 	b.halt <- true
 	return
 }

--- a/drivers/gpio/makey_button_driver_test.go
+++ b/drivers/gpio/makey_button_driver_test.go
@@ -24,7 +24,7 @@ func TestMakeyButtonDriverHalt(t *testing.T) {
 		<-d.halt
 		close(done)
 	}()
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 	select {
 	case <-done:
 	case <-time.After(time.Millisecond):
@@ -45,7 +45,7 @@ func TestMakeyButtonDriver(t *testing.T) {
 func TestMakeyButtonDriverStart(t *testing.T) {
 	sem := make(chan bool)
 	d := initTestMakeyButtonDriver()
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 
 	testAdaptorDigitalRead = func() (val int, err error) {
 		val = 0

--- a/drivers/gpio/motor_driver.go
+++ b/drivers/gpio/motor_driver.go
@@ -42,10 +42,10 @@ func (m *MotorDriver) SetName(n string) { m.name = n }
 func (m *MotorDriver) Connection() gobot.Connection { return m.connection.(gobot.Connection) }
 
 // Start implements the Driver interface
-func (m *MotorDriver) Start() (errs []error) { return }
+func (m *MotorDriver) Start() (err error) { return }
 
 // Halt implements the Driver interface
-func (m *MotorDriver) Halt() (errs []error) { return }
+func (m *MotorDriver) Halt() (err error) { return }
 
 // Off turns the motor off or sets the motor to a 0 speed
 func (m *MotorDriver) Off() (err error) {

--- a/drivers/gpio/motor_driver_test.go
+++ b/drivers/gpio/motor_driver_test.go
@@ -20,12 +20,12 @@ func TestMotorDriver(t *testing.T) {
 }
 func TestMotorDriverStart(t *testing.T) {
 	d := initTestMotorDriver()
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 }
 
 func TestMotorDriverHalt(t *testing.T) {
 	d := initTestMotorDriver()
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 }
 
 func TestMotorDriverIsOn(t *testing.T) {

--- a/drivers/gpio/pir_motion_driver.go
+++ b/drivers/gpio/pir_motion_driver.go
@@ -55,7 +55,7 @@ func NewPIRMotionDriver(a DigitalReader, pin string, v ...time.Duration) *PIRMot
 // just as long as motion is still being detected.
 // It will only send the MotionStopped event once, however, until
 // motion starts being detected again
-func (p *PIRMotionDriver) Start() (errs []error) {
+func (p *PIRMotionDriver) Start() (err error) {
 	go func() {
 		for {
 			newValue, err := p.connection.DigitalRead(p.Pin())
@@ -86,7 +86,7 @@ func (p *PIRMotionDriver) Start() (errs []error) {
 }
 
 // Halt stops polling the button for new information
-func (p *PIRMotionDriver) Halt() (errs []error) {
+func (p *PIRMotionDriver) Halt() (err error) {
 	p.halt <- true
 	return
 }

--- a/drivers/gpio/pir_motion_driver_test.go
+++ b/drivers/gpio/pir_motion_driver_test.go
@@ -22,7 +22,7 @@ func TestPIRMotionDriverHalt(t *testing.T) {
 	go func() {
 		<-d.halt
 	}()
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 }
 
 func TestPIRMotionDriver(t *testing.T) {
@@ -36,7 +36,7 @@ func TestPIRMotionDriver(t *testing.T) {
 func TestPIRMotionDriverStart(t *testing.T) {
 	sem := make(chan bool, 0)
 	d := initTestPIRMotionDriver()
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 
 	d.Once(MotionDetected, func(data interface{}) {
 		gobottest.Assert(t, d.Active, true)

--- a/drivers/gpio/relay_driver.go
+++ b/drivers/gpio/relay_driver.go
@@ -42,10 +42,10 @@ func NewRelayDriver(a DigitalWriter, pin string) *RelayDriver {
 }
 
 // Start implements the Driver interface
-func (l *RelayDriver) Start() (errs []error) { return }
+func (l *RelayDriver) Start() (err error) { return }
 
 // Halt implements the Driver interface
-func (l *RelayDriver) Halt() (errs []error) { return }
+func (l *RelayDriver) Halt() (err error) { return }
 
 // Name returns the RelayDrivers name
 func (l *RelayDriver) Name() string { return l.name }

--- a/drivers/gpio/rgb_led_driver.go
+++ b/drivers/gpio/rgb_led_driver.go
@@ -58,10 +58,10 @@ func NewRgbLedDriver(a DigitalWriter, redPin string, greenPin string, bluePin st
 }
 
 // Start implements the Driver interface
-func (l *RgbLedDriver) Start() (errs []error) { return }
+func (l *RgbLedDriver) Start() (err error) { return }
 
 // Halt implements the Driver interface
-func (l *RgbLedDriver) Halt() (errs []error) { return }
+func (l *RgbLedDriver) Halt() (err error) { return }
 
 // Name returns the RGBLEDDrivers name
 func (l *RgbLedDriver) Name() string { return l.name }

--- a/drivers/gpio/rgb_led_driver_test.go
+++ b/drivers/gpio/rgb_led_driver_test.go
@@ -54,12 +54,12 @@ func TestRgbLedDriver(t *testing.T) {
 
 func TestRgbLedDriverStart(t *testing.T) {
 	d := initTestRgbLedDriver(newGpioTestAdaptor())
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 }
 
 func TestRgbLedDriverHalt(t *testing.T) {
 	d := initTestRgbLedDriver(newGpioTestAdaptor())
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 }
 
 func TestRgbLedDriverToggle(t *testing.T) {

--- a/drivers/gpio/servo_driver.go
+++ b/drivers/gpio/servo_driver.go
@@ -58,10 +58,10 @@ func (s *ServoDriver) Pin() string { return s.pin }
 func (s *ServoDriver) Connection() gobot.Connection { return s.connection.(gobot.Connection) }
 
 // Start implements the Driver interface
-func (s *ServoDriver) Start() (errs []error) { return }
+func (s *ServoDriver) Start() (err error) { return }
 
 // Halt implements the Driver interface
-func (s *ServoDriver) Halt() (errs []error) { return }
+func (s *ServoDriver) Halt() (err error) { return }
 
 // Move sets the servo to the specified angle. Acceptable angles are 0-180
 func (s *ServoDriver) Move(angle uint8) (err error) {

--- a/drivers/gpio/servo_driver_test.go
+++ b/drivers/gpio/servo_driver_test.go
@@ -42,12 +42,12 @@ func TestServoDriver(t *testing.T) {
 
 func TestServoDriverStart(t *testing.T) {
 	d := initTestServoDriver()
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 }
 
 func TestServoDriverHalt(t *testing.T) {
 	d := initTestServoDriver()
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 }
 
 func TestServoDriverMove(t *testing.T) {

--- a/drivers/i2c/adafruit_driver.go
+++ b/drivers/i2c/adafruit_driver.go
@@ -103,14 +103,14 @@ type AdafruitMotorHatDriver struct {
 
 // SetMotorHatAddress sets the I2C address for the DC and Stepper Motor HAT.
 // This addressing flexibility empowers "stacking" the HATs.
-func (a *AdafruitMotorHatDriver) SetMotorHatAddress(addr int) (errs []error) {
+func (a *AdafruitMotorHatDriver) SetMotorHatAddress(addr int) (err error) {
 	motorHatAddress = addr
 	return
 }
 
 // SetServoHatAddress sets the I2C address for the PWM-Servo Motor HAT.
 // This addressing flexibility empowers "stacking" the HATs.
-func (a *AdafruitMotorHatDriver) SetServoHatAddress(addr int) (errs []error) {
+func (a *AdafruitMotorHatDriver) SetServoHatAddress(addr int) (err error) {
 	servoHatAddress = addr
 	return
 }
@@ -157,12 +157,12 @@ func NewAdafruitMotorHatDriver(a I2c) *AdafruitMotorHatDriver {
 }
 
 // Start initializes both I2C-addressable Adafruit Motor HAT drivers
-func (a *AdafruitMotorHatDriver) Start() (errs []error) {
+func (a *AdafruitMotorHatDriver) Start() (err error) {
 	addrs := []int{motorHatAddress, servoHatAddress}
 	for i := range addrs {
 
 		if err := a.connection.I2cStart(addrs[i]); err != nil {
-			return []error{err}
+			return err
 		}
 		if err := a.setAllPWM(addrs[i], 0, 0); err != nil {
 			return
@@ -197,7 +197,7 @@ func (a *AdafruitMotorHatDriver) Start() (errs []error) {
 }
 
 // Halt returns true if devices is halted successfully
-func (a *AdafruitMotorHatDriver) Halt() (errs []error) { return }
+func (a *AdafruitMotorHatDriver) Halt() (err error) { return }
 
 // setPWM sets the start (on) and end (off) of the high-segment of the PWM pulse
 // on the specific channel (pin).
@@ -463,7 +463,7 @@ func (a *AdafruitMotorHatDriver) oneStep(motor int, dir AdafruitDirection, style
 }
 
 // SetStepperMotorSpeed sets the seconds-per-step for the given Stepper Motor.
-func (a *AdafruitMotorHatDriver) SetStepperMotorSpeed(stepperMotor int, rpm int) (errs []error) {
+func (a *AdafruitMotorHatDriver) SetStepperMotorSpeed(stepperMotor int, rpm int) (err error) {
 	revSteps := a.stepperMotors[stepperMotor].revSteps
 	a.stepperMotors[stepperMotor].secPerStep = 60.0 / float64(revSteps*rpm)
 	a.stepperMotors[stepperMotor].stepCounter = 0

--- a/drivers/i2c/adafruit_driver.go
+++ b/drivers/i2c/adafruit_driver.go
@@ -161,33 +161,33 @@ func (a *AdafruitMotorHatDriver) Start() (err error) {
 	addrs := []int{motorHatAddress, servoHatAddress}
 	for i := range addrs {
 
-		if err := a.connection.I2cStart(addrs[i]); err != nil {
-			return err
+		if err = a.connection.I2cStart(addrs[i]); err != nil {
+			return
 		}
-		if err := a.setAllPWM(addrs[i], 0, 0); err != nil {
+		if err = a.setAllPWM(addrs[i], 0, 0); err != nil {
 			return
 		}
 		reg := byte(_Mode2)
 		val := byte(_Outdrv)
-		if err := a.connection.I2cWrite(addrs[i], []byte{reg, val}); err != nil {
+		if err = a.connection.I2cWrite(addrs[i], []byte{reg, val}); err != nil {
 			return
 		}
 		reg = byte(_Mode1)
 		val = byte(_AllCall)
-		if err := a.connection.I2cWrite(addrs[i], []byte{reg, val}); err != nil {
+		if err = a.connection.I2cWrite(addrs[i], []byte{reg, val}); err != nil {
 			return
 		}
 		time.Sleep(5 * time.Millisecond)
 
 		// Read a byte from the I2C device.  Note: no ability to read from a specified reg?
-		mode1, err := a.connection.I2cRead(addrs[i], 1)
-		if err != nil {
-			return
+		mode1, rerr := a.connection.I2cRead(addrs[i], 1)
+		if rerr != nil {
+			return rerr
 		}
 		if len(mode1) > 0 {
 			reg = byte(_Mode1)
 			val = mode1[0] & _Sleep
-			if err := a.connection.I2cWrite(addrs[i], []byte{reg, val}); err != nil {
+			if err = a.connection.I2cWrite(addrs[i], []byte{reg, val}); err != nil {
 				return
 			}
 			time.Sleep(5 * time.Millisecond)

--- a/drivers/i2c/adafruit_driver_test.go
+++ b/drivers/i2c/adafruit_driver_test.go
@@ -37,28 +37,28 @@ func TestNewAdafruitMotorHatDriver(t *testing.T) {
 func TestAdafruitMotorHatDriverStart(t *testing.T) {
 	ada, adaptor := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
 
-	gobottest.Assert(t, len(ada.Start()), 0)
+	gobottest.Assert(t, ada.Start(), nil)
 
 	adaptor.i2cStartImpl = func() error {
 		return errors.New("start error")
 	}
 	err := ada.Start()
-	gobottest.Assert(t, err[0], errors.New("start error"))
+	gobottest.Assert(t, err, errors.New("start error"))
 
 }
 
 func TestAdafruitMotorHatDriverHalt(t *testing.T) {
 	ada, _ := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
 
-	gobottest.Assert(t, len(ada.Halt()), 0)
+	gobottest.Assert(t, ada.Halt(), nil)
 }
 func TestSetHatAddresses(t *testing.T) {
 	ada, _ := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
 
 	motorHatAddr := 0x61
 	servoHatAddr := 0x41
-	gobottest.Assert(t, len(ada.SetMotorHatAddress(motorHatAddr)), 0)
-	gobottest.Assert(t, len(ada.SetServoHatAddress(servoHatAddr)), 0)
+	gobottest.Assert(t, ada.SetMotorHatAddress(motorHatAddr), nil)
+	gobottest.Assert(t, ada.SetServoHatAddress(servoHatAddr), nil)
 }
 
 func TestAdafruitMotorHatDriverSetServoMotorFreq(t *testing.T) {
@@ -103,7 +103,7 @@ func TestAdafruitMotorHatDriverSetStepperMotorSpeed(t *testing.T) {
 
 	stepperMotor := 1
 	rpm := 30
-	gobottest.Assert(t, len(ada.SetStepperMotorSpeed(stepperMotor, rpm)), 0)
+	gobottest.Assert(t, ada.SetStepperMotorSpeed(stepperMotor, rpm), nil)
 }
 
 func TestAdafruitMotorHatDriverStepperStep(t *testing.T) {

--- a/drivers/i2c/blinkm_driver.go
+++ b/drivers/i2c/blinkm_driver.go
@@ -60,18 +60,18 @@ func (b *BlinkMDriver) Connection() gobot.Connection { return b.connection.(gobo
 // adaptor returns I2C adaptor
 
 // Start writes start bytes
-func (b *BlinkMDriver) Start() (errs []error) {
+func (b *BlinkMDriver) Start() (err error) {
 	if err := b.connection.I2cStart(blinkmAddress); err != nil {
-		return []error{err}
+		return err
 	}
 	if err := b.connection.I2cWrite(blinkmAddress, []byte("o")); err != nil {
-		return []error{err}
+		return err
 	}
 	return
 }
 
 // Halt returns true if device is halted successfully
-func (b *BlinkMDriver) Halt() (errs []error) { return }
+func (b *BlinkMDriver) Halt() (err error) { return }
 
 // Rgb sets color using r,g,b params
 func (b *BlinkMDriver) Rgb(red byte, green byte, blue byte) (err error) {

--- a/drivers/i2c/blinkm_driver_test.go
+++ b/drivers/i2c/blinkm_driver_test.go
@@ -90,25 +90,25 @@ func TestBlinkMDriver(t *testing.T) {
 func TestBlinkMDriverStart(t *testing.T) {
 	blinkM, adaptor := initTestBlinkDriverWithStubbedAdaptor()
 
-	gobottest.Assert(t, len(blinkM.Start()), 0)
+	gobottest.Assert(t, blinkM.Start(), nil)
 
 	adaptor.i2cStartImpl = func() error {
 		return errors.New("start error")
 	}
 
-	gobottest.Assert(t, blinkM.Start()[0], errors.New("start error"))
+	gobottest.Assert(t, blinkM.Start(), errors.New("start error"))
 	adaptor.i2cStartImpl = func() error {
 		return nil
 	}
 	adaptor.i2cWriteImpl = func() error {
 		return errors.New("write error")
 	}
-	gobottest.Assert(t, blinkM.Start()[0], errors.New("write error"))
+	gobottest.Assert(t, blinkM.Start(), errors.New("write error"))
 }
 
 func TestBlinkMDriverHalt(t *testing.T) {
 	blinkM := initTestBlinkMDriver()
-	gobottest.Assert(t, len(blinkM.Halt()), 0)
+	gobottest.Assert(t, blinkM.Halt(), nil)
 }
 
 func TestBlinkMDriverFirmwareVersion(t *testing.T) {

--- a/drivers/i2c/helpers_test.go
+++ b/drivers/i2c/helpers_test.go
@@ -30,10 +30,10 @@ func (t *i2cTestAdaptor) I2cRead(int, int) (data []byte, err error) {
 func (t *i2cTestAdaptor) I2cWrite(int, []byte) (err error) {
 	return t.i2cWriteImpl()
 }
-func (t *i2cTestAdaptor) Name() string             { return t.name }
-func (t *i2cTestAdaptor) SetName(n string)         { t.name = n }
-func (t *i2cTestAdaptor) Connect() (errs []error)  { return }
-func (t *i2cTestAdaptor) Finalize() (errs []error) { return }
+func (t *i2cTestAdaptor) Name() string          { return t.name }
+func (t *i2cTestAdaptor) SetName(n string)      { t.name = n }
+func (t *i2cTestAdaptor) Connect() (err error)  { return }
+func (t *i2cTestAdaptor) Finalize() (err error) { return }
 
 func newI2cTestAdaptor() *i2cTestAdaptor {
 	return &i2cTestAdaptor{

--- a/drivers/i2c/hmc6352_driver.go
+++ b/drivers/i2c/hmc6352_driver.go
@@ -24,18 +24,18 @@ func (h *HMC6352Driver) SetName(n string)             { h.name = n }
 func (h *HMC6352Driver) Connection() gobot.Connection { return h.connection.(gobot.Connection) }
 
 // Start initialized the hmc6352
-func (h *HMC6352Driver) Start() (errs []error) {
+func (h *HMC6352Driver) Start() (err error) {
 	if err := h.connection.I2cStart(hmc6352Address); err != nil {
-		return []error{err}
+		return err
 	}
 	if err := h.connection.I2cWrite(hmc6352Address, []byte("A")); err != nil {
-		return []error{err}
+		return err
 	}
 	return
 }
 
 // Halt returns true if devices is halted successfully
-func (h *HMC6352Driver) Halt() (errs []error) { return }
+func (h *HMC6352Driver) Halt() (err error) { return }
 
 // Heading returns the current heading
 func (h *HMC6352Driver) Heading() (heading uint16, err error) {

--- a/drivers/i2c/hmc6352_driver_test.go
+++ b/drivers/i2c/hmc6352_driver_test.go
@@ -36,26 +36,26 @@ func TestNewHMC6352Driver(t *testing.T) {
 func TestHMC6352DriverStart(t *testing.T) {
 	hmc, adaptor := initTestHMC6352DriverWithStubbedAdaptor()
 
-	gobottest.Assert(t, len(hmc.Start()), 0)
+	gobottest.Assert(t, hmc.Start(), nil)
 
 	adaptor.i2cWriteImpl = func() error {
 		return errors.New("write error")
 	}
 	err := hmc.Start()
-	gobottest.Assert(t, err[0], errors.New("write error"))
+	gobottest.Assert(t, err, errors.New("write error"))
 
 	adaptor.i2cStartImpl = func() error {
 		return errors.New("start error")
 	}
 	err = hmc.Start()
-	gobottest.Assert(t, err[0], errors.New("start error"))
+	gobottest.Assert(t, err, errors.New("start error"))
 
 }
 
 func TestHMC6352DriverHalt(t *testing.T) {
 	hmc := initTestHMC6352Driver()
 
-	gobottest.Assert(t, len(hmc.Halt()), 0)
+	gobottest.Assert(t, hmc.Halt(), nil)
 }
 
 func TestHMC6352DriverHeading(t *testing.T) {

--- a/drivers/i2c/jhd1313m1_driver.go
+++ b/drivers/i2c/jhd1313m1_driver.go
@@ -101,49 +101,49 @@ func (h *JHD1313M1Driver) Connection() gobot.Connection {
 }
 
 // Start starts the backlit and the screen and initializes the states.
-func (h *JHD1313M1Driver) Start() []error {
+func (h *JHD1313M1Driver) Start() error {
 	if err := h.connection.I2cStart(h.lcdAddress); err != nil {
-		return []error{err}
+		return err
 	}
 
 	if err := h.connection.I2cStart(h.rgbAddress); err != nil {
-		return []error{err}
+		return err
 	}
 
 	time.Sleep(50000 * time.Microsecond)
 	payload := []byte{LCD_CMD, LCD_FUNCTIONSET | LCD_2LINE}
 	if err := h.connection.I2cWrite(h.lcdAddress, payload); err != nil {
 		if err := h.connection.I2cWrite(h.lcdAddress, payload); err != nil {
-			return []error{err}
+			return err
 		}
 	}
 
 	time.Sleep(100 * time.Microsecond)
 	if err := h.connection.I2cWrite(h.lcdAddress, []byte{LCD_CMD, LCD_DISPLAYCONTROL | LCD_DISPLAYON}); err != nil {
-		return []error{err}
+		return err
 	}
 
 	time.Sleep(100 * time.Microsecond)
 	if err := h.Clear(); err != nil {
-		return []error{err}
+		return err
 	}
 
 	if err := h.connection.I2cWrite(h.lcdAddress, []byte{LCD_CMD, LCD_ENTRYMODESET | LCD_ENTRYLEFT | LCD_ENTRYSHIFTDECREMENT}); err != nil {
-		return []error{err}
+		return err
 	}
 
 	if err := h.setReg(0, 0); err != nil {
-		return []error{err}
+		return err
 	}
 	if err := h.setReg(1, 0); err != nil {
-		return []error{err}
+		return err
 	}
 	if err := h.setReg(0x08, 0xAA); err != nil {
-		return []error{err}
+		return err
 	}
 
 	if err := h.SetRGB(255, 255, 255); err != nil {
-		return []error{err}
+		return err
 	}
 
 	return nil
@@ -218,7 +218,7 @@ func (h *JHD1313M1Driver) Scroll(leftToRight bool) error {
 }
 
 // Halt is a noop function.
-func (h *JHD1313M1Driver) Halt() []error { return nil }
+func (h *JHD1313M1Driver) Halt() error { return nil }
 
 func (h *JHD1313M1Driver) setReg(command int, data int) error {
 	return h.connection.I2cWrite(h.rgbAddress, []byte{byte(command), byte(data)})

--- a/drivers/i2c/lidarlite_driver.go
+++ b/drivers/i2c/lidarlite_driver.go
@@ -28,15 +28,15 @@ func (h *LIDARLiteDriver) SetName(n string)             { h.name = n }
 func (h *LIDARLiteDriver) Connection() gobot.Connection { return h.connection.(gobot.Connection) }
 
 // Start initialized the LIDAR
-func (h *LIDARLiteDriver) Start() (errs []error) {
+func (h *LIDARLiteDriver) Start() (err error) {
 	if err := h.connection.I2cStart(lidarliteAddress); err != nil {
-		return []error{err}
+		return err
 	}
 	return
 }
 
 // Halt returns true if devices is halted successfully
-func (h *LIDARLiteDriver) Halt() (errs []error) { return }
+func (h *LIDARLiteDriver) Halt() (err error) { return }
 
 // Distance returns the current distance in cm
 func (h *LIDARLiteDriver) Distance() (distance int, err error) {

--- a/drivers/i2c/lidarlite_driver_test.go
+++ b/drivers/i2c/lidarlite_driver_test.go
@@ -36,20 +36,20 @@ func TestNewLIDARLiteDriver(t *testing.T) {
 func TestLIDARLiteDriverStart(t *testing.T) {
 	hmc, adaptor := initTestLIDARLiteDriverWithStubbedAdaptor()
 
-	gobottest.Assert(t, len(hmc.Start()), 0)
+	gobottest.Assert(t, hmc.Start(), nil)
 
 	adaptor.i2cStartImpl = func() error {
 		return errors.New("start error")
 	}
 	err := hmc.Start()
-	gobottest.Assert(t, err[0], errors.New("start error"))
+	gobottest.Assert(t, err, errors.New("start error"))
 
 }
 
 func TestLIDARLiteDriverHalt(t *testing.T) {
 	hmc := initTestLIDARLiteDriver()
 
-	gobottest.Assert(t, len(hmc.Halt()), 0)
+	gobottest.Assert(t, hmc.Halt(), nil)
 }
 
 func TestLIDARLiteDriverDistance(t *testing.T) {

--- a/drivers/i2c/mcp23017_driver.go
+++ b/drivers/i2c/mcp23017_driver.go
@@ -128,18 +128,18 @@ func (m *MCP23017Driver) SetName(n string) { m.name = n }
 func (m *MCP23017Driver) Connection() gobot.Connection { return m.connection.(gobot.Connection) }
 
 // Halt stops the driver.
-func (m *MCP23017Driver) Halt() (err []error) { return }
+func (m *MCP23017Driver) Halt() (err error) { return }
 
 // Start writes the device configuration.
-func (m *MCP23017Driver) Start() (errs []error) {
+func (m *MCP23017Driver) Start() (errs error) {
 	if err := m.connection.I2cStart(m.mcp23017Address); err != nil {
-		return []error{err}
+		return err
 	}
 	// Set IOCON register with MCP23017 configuration.
 	ioconReg := m.getPort("A").IOCON // IOCON address is the same for Port A or B.
 	ioconVal := m.conf.GetUint8Value()
 	if err := m.connection.I2cWrite(m.mcp23017Address, []uint8{ioconReg, ioconVal}); err != nil {
-		return []error{err}
+		return err
 	}
 	return
 }

--- a/drivers/i2c/mcp23017_driver_test.go
+++ b/drivers/i2c/mcp23017_driver_test.go
@@ -26,10 +26,10 @@ func (t *i2cMcpTestAdaptor) I2cRead(address int, numBytes int) (data []byte, err
 func (t *i2cMcpTestAdaptor) I2cWrite(int, []byte) (err error) {
 	return t.i2cMcpWriteImpl()
 }
-func (t *i2cMcpTestAdaptor) Name() string             { return t.name }
-func (t *i2cMcpTestAdaptor) SetName(n string)         { t.name = n }
-func (t *i2cMcpTestAdaptor) Connect() (errs []error)  { return }
-func (t *i2cMcpTestAdaptor) Finalize() (errs []error) { return }
+func (t *i2cMcpTestAdaptor) Name() string          { return t.name }
+func (t *i2cMcpTestAdaptor) SetName(n string)      { t.name = n }
+func (t *i2cMcpTestAdaptor) Connect() (err error)  { return }
+func (t *i2cMcpTestAdaptor) Finalize() (err error) { return }
 
 func newMcpI2cTestAdaptor() *i2cMcpTestAdaptor {
 	return &i2cMcpTestAdaptor{

--- a/drivers/i2c/mcp23017_driver_test.go
+++ b/drivers/i2c/mcp23017_driver_test.go
@@ -80,24 +80,24 @@ func TestNewMCP23017Driver(t *testing.T) {
 func TestMCP23017DriverStart(t *testing.T) {
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
 
-	gobottest.Assert(t, len(mcp.Start()), 0)
+	gobottest.Assert(t, mcp.Start(), nil)
 
 	adaptor.i2cMcpWriteImpl = func() error {
 		return errors.New("write error")
 	}
 	err := mcp.Start()
-	gobottest.Assert(t, err[0], errors.New("write error"))
+	gobottest.Assert(t, err, errors.New("write error"))
 
 	adaptor.i2cMcpStartImpl = func() error {
 		return errors.New("start error")
 	}
 	err = mcp.Start()
-	gobottest.Assert(t, err[0], errors.New("start error"))
+	gobottest.Assert(t, err, errors.New("start error"))
 }
 
 func TestMCP23017DriverHalt(t *testing.T) {
 	mcp := initTestMCP23017Driver(0)
-	gobottest.Assert(t, len(mcp.Halt()), 0)
+	gobottest.Assert(t, mcp.Halt(), nil)
 }
 
 func TestMCP23017DriverCommandsWriteGPIO(t *testing.T) {

--- a/drivers/i2c/mma7660_driver.go
+++ b/drivers/i2c/mma7660_driver.go
@@ -47,28 +47,28 @@ func (h *MMA7660Driver) SetName(n string)             { h.name = n }
 func (h *MMA7660Driver) Connection() gobot.Connection { return h.connection.(gobot.Connection) }
 
 // Start initialized the mma7660
-func (h *MMA7660Driver) Start() (errs []error) {
+func (h *MMA7660Driver) Start() (err error) {
 	if err := h.connection.I2cStart(mma7660Address); err != nil {
-		return []error{err}
+		return err
 	}
 
 	if err := h.connection.I2cWrite(mma7660Address, []byte{MMA7660_MODE, MMA7660_STAND_BY}); err != nil {
-		return []error{err}
+		return err
 	}
 
 	if err := h.connection.I2cWrite(mma7660Address, []byte{MMA7660_SR, MMA7660_AUTO_SLEEP_32}); err != nil {
-		return []error{err}
+		return err
 	}
 
 	if err := h.connection.I2cWrite(mma7660Address, []byte{MMA7660_MODE, MMA7660_ACTIVE}); err != nil {
-		return []error{err}
+		return err
 	}
 
 	return
 }
 
 // Halt returns true if devices is halted successfully
-func (h *MMA7660Driver) Halt() (errs []error) { return }
+func (h *MMA7660Driver) Halt() (err error) { return }
 
 // Acceleration returns the acceleration  of the provided x, y, z
 func (h *MMA7660Driver) Acceleration(x, y, z float64) (ax, ay, az float64) {

--- a/drivers/i2c/mpl115a2_driver.go
+++ b/drivers/i2c/mpl115a2_driver.go
@@ -61,13 +61,13 @@ func (h *MPL115A2Driver) Connection() gobot.Connection { return h.connection.(go
 
 // Start writes initialization bytes and reads from adaptor
 // using specified interval to accelerometer andtemperature data
-func (h *MPL115A2Driver) Start() (errs []error) {
+func (h *MPL115A2Driver) Start() (err error) {
 	var temperature uint16
 	var pressure uint16
 	var pressureComp float32
 
 	if err := h.initialization(); err != nil {
-		return []error{err}
+		return err
 	}
 
 	go func() {
@@ -108,7 +108,7 @@ func (h *MPL115A2Driver) Start() (errs []error) {
 }
 
 // Halt returns true if devices is halted successfully
-func (h *MPL115A2Driver) Halt() (err []error) { return }
+func (h *MPL115A2Driver) Halt() (err error) { return }
 
 func (h *MPL115A2Driver) initialization() (err error) {
 	var coA0 int16

--- a/drivers/i2c/mpl115a2_driver_test.go
+++ b/drivers/i2c/mpl115a2_driver_test.go
@@ -46,7 +46,7 @@ func TestMPL115A2DriverStart(t *testing.T) {
 	adaptor.i2cReadImpl = func() ([]byte, error) {
 		return []byte{0x00, 0x01, 0x02, 0x04}, nil
 	}
-	gobottest.Assert(t, len(mpl.Start()), 0)
+	gobottest.Assert(t, mpl.Start(), nil)
 	time.Sleep(100 * time.Millisecond)
 	gobottest.Assert(t, mpl.Pressure, float32(50.007942))
 	gobottest.Assert(t, mpl.Temperature, float32(116.58878))
@@ -55,5 +55,5 @@ func TestMPL115A2DriverStart(t *testing.T) {
 func TestMPL115A2DriverHalt(t *testing.T) {
 	mpl := initTestMPL115A2Driver()
 
-	gobottest.Assert(t, len(mpl.Halt()), 0)
+	gobottest.Assert(t, mpl.Halt(), nil)
 }

--- a/drivers/i2c/mpu6050_driver.go
+++ b/drivers/i2c/mpu6050_driver.go
@@ -67,9 +67,9 @@ func (h *MPU6050Driver) Connection() gobot.Connection { return h.connection.(gob
 
 // Start writes initialization bytes and reads from adaptor
 // using specified interval to accelerometer andtemperature data
-func (h *MPU6050Driver) Start() (errs []error) {
+func (h *MPU6050Driver) Start() (err error) {
 	if err := h.initialize(); err != nil {
-		return []error{err}
+		return err
 	}
 
 	go func() {
@@ -96,7 +96,7 @@ func (h *MPU6050Driver) Start() (errs []error) {
 }
 
 // Halt returns true if devices is halted successfully
-func (h *MPU6050Driver) Halt() (errs []error) { return }
+func (h *MPU6050Driver) Halt() (err error) { return }
 
 func (h *MPU6050Driver) initialize() (err error) {
 	if err = h.connection.I2cStart(mpu6050Address); err != nil {

--- a/drivers/i2c/mpu6050_driver_test.go
+++ b/drivers/i2c/mpu6050_driver_test.go
@@ -42,11 +42,11 @@ func TestMPU6050Driver(t *testing.T) {
 func TestMPU6050DriverStart(t *testing.T) {
 	mpu := initTestMPU6050Driver()
 
-	gobottest.Assert(t, len(mpu.Start()), 0)
+	gobottest.Assert(t, mpu.Start(), nil)
 }
 
 func TestMPU6050DriverHalt(t *testing.T) {
 	mpu := initTestMPU6050Driver()
 
-	gobottest.Assert(t, len(mpu.Halt()), 0)
+	gobottest.Assert(t, mpu.Halt(), nil)
 }

--- a/drivers/i2c/wiichuck_driver.go
+++ b/drivers/i2c/wiichuck_driver.go
@@ -62,9 +62,9 @@ func (w *WiichuckDriver) Connection() gobot.Connection { return w.connection.(go
 
 // Start initilizes i2c and reads from adaptor
 // using specified interval to update with new value
-func (w *WiichuckDriver) Start() (errs []error) {
+func (w *WiichuckDriver) Start() (errs error) {
 	if err := w.connection.I2cStart(wiichuckAddress); err != nil {
-		return []error{err}
+		return err
 	}
 
 	go func() {
@@ -97,7 +97,7 @@ func (w *WiichuckDriver) Start() (errs []error) {
 }
 
 // Halt returns true if driver is halted successfully
-func (w *WiichuckDriver) Halt() (errs []error) { return }
+func (w *WiichuckDriver) Halt() (err error) { return }
 
 // update parses value to update buttons and joystick.
 // If value is encrypted, warning message is printed

--- a/drivers/i2c/wiichuck_driver_test.go
+++ b/drivers/i2c/wiichuck_driver_test.go
@@ -49,7 +49,7 @@ func TestWiichuckDriverStart(t *testing.T) {
 	numberOfCyclesForEvery := 3
 
 	wii.interval = 1 * time.Millisecond
-	gobottest.Assert(t, len(wii.Start()), 0)
+	gobottest.Assert(t, wii.Start(), nil)
 
 	go func() {
 		for {
@@ -72,7 +72,7 @@ func TestWiichuckDriverStart(t *testing.T) {
 func TestWiichuckDriverHalt(t *testing.T) {
 	wii := initTestWiichuckDriver()
 
-	gobottest.Assert(t, len(wii.Halt()), 0)
+	gobottest.Assert(t, wii.Halt(), nil)
 }
 
 func TestWiichuckDriverCanParse(t *testing.T) {

--- a/examples/batty.go
+++ b/examples/batty.go
@@ -46,11 +46,11 @@ type loopbackAdaptor struct {
 	port string
 }
 
-func (t *loopbackAdaptor) Finalize() (errs []error) { return }
-func (t *loopbackAdaptor) Connect() (errs []error)  { return }
-func (t *loopbackAdaptor) Name() string             { return t.name }
-func (t *loopbackAdaptor) SetName(n string)         { t.name = n }
-func (t *loopbackAdaptor) Port() string             { return t.port }
+func (t *loopbackAdaptor) Finalize() (err error) { return }
+func (t *loopbackAdaptor) Connect() (err error)  { return }
+func (t *loopbackAdaptor) Name() string          { return t.name }
+func (t *loopbackAdaptor) SetName(n string)      { t.name = n }
+func (t *loopbackAdaptor) Port() string          { return t.port }
 
 func NewLoopbackAdaptor(port string) *loopbackAdaptor {
 	return &loopbackAdaptor{
@@ -69,8 +69,8 @@ type pingDriver struct {
 	gobot.Commander
 }
 
-func (t *pingDriver) Start() (errs []error)        { return }
-func (t *pingDriver) Halt() (errs []error)         { return }
+func (t *pingDriver) Start() (err error)           { return }
+func (t *pingDriver) Halt() (err error)            { return }
 func (t *pingDriver) Name() string                 { return t.name }
 func (t *pingDriver) SetName(n string)             { t.name = n }
 func (t *pingDriver) Pin() string                  { return t.pin }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -23,11 +23,11 @@ type testDriver struct {
 	Commander
 }
 
-var testDriverStart = func() (errs []error) { return }
-var testDriverHalt = func() (errs []error) { return }
+var testDriverStart = func() (err error) { return }
+var testDriverHalt = func() (err error) { return }
 
-func (t *testDriver) Start() (errs []error)  { return testDriverStart() }
-func (t *testDriver) Halt() (errs []error)   { return testDriverHalt() }
+func (t *testDriver) Start() (err error)     { return testDriverStart() }
+func (t *testDriver) Halt() (err error)      { return testDriverHalt() }
 func (t *testDriver) Name() string           { return t.name }
 func (t *testDriver) SetName(n string)       { t.name = n }
 func (t *testDriver) Pin() string            { return t.pin }
@@ -51,14 +51,14 @@ type testAdaptor struct {
 	port string
 }
 
-var testAdaptorConnect = func() (errs []error) { return }
-var testAdaptorFinalize = func() (errs []error) { return }
+var testAdaptorConnect = func() (err error) { return }
+var testAdaptorFinalize = func() (err error) { return }
 
-func (t *testAdaptor) Finalize() (errs []error) { return testAdaptorFinalize() }
-func (t *testAdaptor) Connect() (errs []error)  { return testAdaptorConnect() }
-func (t *testAdaptor) Name() string             { return t.name }
-func (t *testAdaptor) SetName(n string)         { t.name = n }
-func (t *testAdaptor) Port() string             { return t.port }
+func (t *testAdaptor) Finalize() (err error) { return testAdaptorFinalize() }
+func (t *testAdaptor) Connect() (err error)  { return testAdaptorConnect() }
+func (t *testAdaptor) Name() string          { return t.name }
+func (t *testAdaptor) SetName(n string)      { t.name = n }
+func (t *testAdaptor) Port() string          { return t.port }
 
 func newTestAdaptor(name string, port string) *testAdaptor {
 	return &testAdaptor{

--- a/master_test.go
+++ b/master_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hybridgroup/gobot/gobottest"
 )
 
@@ -86,12 +87,17 @@ func TestMasterStart(t *testing.T) {
 
 func TestMasterStartDriverErrors(t *testing.T) {
 	g := initTestMaster1Robot()
-
+	e := errors.New("driver start error 1")
 	testDriverStart = func() (err error) {
-		return errors.New("driver start error 1")
+		return e
 	}
 
-	gobottest.Assert(t, g.Start().Error(), "3 error(s) occurred:\n\n* driver start error 1\n* driver start error 1\n* driver start error 1")
+	var expected error
+	expected = multierror.Append(expected, e)
+	expected = multierror.Append(expected, e)
+	expected = multierror.Append(expected, e)
+
+	gobottest.Assert(t, g.Start(), expected)
 	gobottest.Assert(t, g.Stop(), nil)
 
 	testDriverStart = func() (err error) { return }
@@ -99,28 +105,36 @@ func TestMasterStartDriverErrors(t *testing.T) {
 
 func TestMasterStartAdaptorErrors(t *testing.T) {
 	g := initTestMaster1Robot()
+	e := errors.New("adaptor start error 1")
 
 	testAdaptorConnect = func() (err error) {
-		return errors.New("adaptor start error 1")
+		return e
 	}
 
-	gobottest.Assert(t, g.Start().Error(), "3 error(s) occurred:\n\n* adaptor start error 1\n* adaptor start error 1\n* adaptor start error 1")
+	var expected error
+	expected = multierror.Append(expected, e)
+	expected = multierror.Append(expected, e)
+	expected = multierror.Append(expected, e)
+
+	gobottest.Assert(t, g.Start(), expected)
 	gobottest.Assert(t, g.Stop(), nil)
 
 	testAdaptorConnect = func() (err error) { return }
 }
 
-func TestMasterHaltErrors(t *testing.T) {
+func TestMasterFinalizeErrors(t *testing.T) {
 	g := initTestMaster1Robot()
-
-	testDriverHalt = func() (err error) {
-		return errors.New("driver halt error 2")
-	}
+	e := errors.New("adaptor finalize error 2")
 
 	testAdaptorFinalize = func() (err error) {
-		return errors.New("adaptor finalize error 2")
+		return e
 	}
 
+	var expected error
+	expected = multierror.Append(expected, e)
+	expected = multierror.Append(expected, e)
+	expected = multierror.Append(expected, e)
+
 	gobottest.Assert(t, g.Start(), nil)
-	gobottest.Assert(t, g.Stop().Error(), "3 error(s) occurred:\n\n* adaptor finalize error 2\n* adaptor finalize error 2\n* adaptor finalize error 2")
+	gobottest.Assert(t, g.Stop(), expected)
 }

--- a/master_test.go
+++ b/master_test.go
@@ -80,55 +80,47 @@ func TestGobotToJSON(t *testing.T) {
 
 func TestMasterStart(t *testing.T) {
 	g := initTestMaster()
-	gobottest.Assert(t, len(g.Start()), 0)
-	gobottest.Assert(t, len(g.Stop()), 0)
+	gobottest.Assert(t, g.Start(), nil)
+	gobottest.Assert(t, g.Stop(), nil)
 }
 
 func TestMasterStartDriverErrors(t *testing.T) {
 	g := initTestMaster1Robot()
 
-	testDriverStart = func() (errs []error) {
-		return []error{
-			errors.New("driver start error 1"),
-		}
+	testDriverStart = func() (err error) {
+		return errors.New("driver start error 1")
 	}
 
-	gobottest.Assert(t, len(g.Start()), 1)
-	gobottest.Assert(t, len(g.Stop()), 0)
+	gobottest.Assert(t, g.Start().Error(), "3 error(s) occurred:\n\n* driver start error 1\n* driver start error 1\n* driver start error 1")
+	gobottest.Assert(t, g.Stop(), nil)
 
-	testDriverStart = func() (errs []error) { return }
+	testDriverStart = func() (err error) { return }
 }
 
 func TestMasterStartAdaptorErrors(t *testing.T) {
 	g := initTestMaster1Robot()
 
-	testAdaptorConnect = func() (errs []error) {
-		return []error{
-			errors.New("adaptor start error 1"),
-		}
+	testAdaptorConnect = func() (err error) {
+		return errors.New("adaptor start error 1")
 	}
 
-	gobottest.Assert(t, len(g.Start()), 1)
-	gobottest.Assert(t, len(g.Stop()), 0)
+	gobottest.Assert(t, g.Start().Error(), "3 error(s) occurred:\n\n* adaptor start error 1\n* adaptor start error 1\n* adaptor start error 1")
+	gobottest.Assert(t, g.Stop(), nil)
 
-	testAdaptorConnect = func() (errs []error) { return }
+	testAdaptorConnect = func() (err error) { return }
 }
 
 func TestMasterHaltErrors(t *testing.T) {
 	g := initTestMaster1Robot()
 
-	testDriverHalt = func() (errs []error) {
-		return []error{
-			errors.New("driver halt error 1"),
-		}
+	testDriverHalt = func() (err error) {
+		return errors.New("driver halt error 2")
 	}
 
-	testAdaptorFinalize = func() (errs []error) {
-		return []error{
-			errors.New("adaptor finalize error 1"),
-		}
+	testAdaptorFinalize = func() (err error) {
+		return errors.New("adaptor finalize error 2")
 	}
 
-	gobottest.Assert(t, len(g.Start()), 0)
-	gobottest.Assert(t, len(g.Stop()), 6)
+	gobottest.Assert(t, g.Start(), nil)
+	gobottest.Assert(t, g.Stop().Error(), "3 error(s) occurred:\n\n* adaptor finalize error 2\n* adaptor finalize error 2\n* adaptor finalize error 2")
 }

--- a/platforms/ardrone/ardrone_adaptor.go
+++ b/platforms/ardrone/ardrone_adaptor.go
@@ -54,14 +54,14 @@ func (a *Adaptor) Name() string { return a.name }
 func (a *Adaptor) SetName(n string) { a.name = n }
 
 // Connect establishes a connection to the ardrone
-func (a *Adaptor) Connect() (errs []error) {
+func (a *Adaptor) Connect() (err error) {
 	d, err := a.connect(a)
 	if err != nil {
-		return []error{err}
+		return err
 	}
 	a.drone = d
 	return
 }
 
 // Finalize terminates the connection to the ardrone
-func (a *Adaptor) Finalize() (errs []error) { return }
+func (a *Adaptor) Finalize() (err error) { return }

--- a/platforms/ardrone/ardrone_adaptor_test.go
+++ b/platforms/ardrone/ardrone_adaptor_test.go
@@ -28,15 +28,15 @@ func TestArdroneAdaptor(t *testing.T) {
 
 func TestArdroneAdaptorConnect(t *testing.T) {
 	a := initTestArdroneAdaptor()
-	gobottest.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, a.Connect(), nil)
 
 	a.connect = func(a *Adaptor) (drone, error) {
 		return nil, errors.New("connection error")
 	}
-	gobottest.Assert(t, a.Connect()[0], errors.New("connection error"))
+	gobottest.Assert(t, a.Connect(), errors.New("connection error"))
 }
 
 func TestArdroneAdaptorFinalize(t *testing.T) {
 	a := initTestArdroneAdaptor()
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Finalize(), nil)
 }

--- a/platforms/ardrone/ardrone_driver.go
+++ b/platforms/ardrone/ardrone_driver.go
@@ -45,12 +45,12 @@ func (a *Driver) adaptor() *Adaptor {
 }
 
 // Start starts the Driver
-func (a *Driver) Start() (errs []error) {
+func (a *Driver) Start() (err error) {
 	return
 }
 
 // Halt halts the Driver
-func (a *Driver) Halt() (errs []error) {
+func (a *Driver) Halt() (err error) {
 	return
 }
 

--- a/platforms/ardrone/ardrone_driver_test.go
+++ b/platforms/ardrone/ardrone_driver_test.go
@@ -27,12 +27,12 @@ func TestArdroneDriver(t *testing.T) {
 
 func TestArdroneDriverStart(t *testing.T) {
 	d := initTestArdroneDriver()
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 }
 
 func TestArdroneDriverHalt(t *testing.T) {
 	d := initTestArdroneDriver()
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 }
 func TestArdroneDriverTakeOff(t *testing.T) {
 	d := initTestArdroneDriver()

--- a/platforms/audio/audio_adaptor.go
+++ b/platforms/audio/audio_adaptor.go
@@ -21,9 +21,9 @@ func (a *Adaptor) Name() string { return a.name }
 
 func (a *Adaptor) SetName(n string) { a.name = n }
 
-func (a *Adaptor) Connect() []error { return nil }
+func (a *Adaptor) Connect() error { return nil }
 
-func (a *Adaptor) Finalize() []error { return nil }
+func (a *Adaptor) Finalize() error { return nil }
 
 func (a *Adaptor) Sound(fileName string) []error {
 	var errorsList []error

--- a/platforms/audio/audio_adaptor_test.go
+++ b/platforms/audio/audio_adaptor_test.go
@@ -14,8 +14,8 @@ var _ gobot.Adaptor = (*Adaptor)(nil)
 func TestAudioAdaptor(t *testing.T) {
 	a := NewAdaptor()
 
-	gobottest.Assert(t, len(a.Connect()), 0)
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Connect(), nil)
+	gobottest.Assert(t, a.Finalize(), nil)
 }
 
 func TestAudioAdaptorCommandsWav(t *testing.T) {

--- a/platforms/audio/audio_driver.go
+++ b/platforms/audio/audio_driver.go
@@ -53,10 +53,10 @@ func (d *Driver) adaptor() *Adaptor {
 	return d.Connection().(*Adaptor)
 }
 
-func (d *Driver) Start() (err []error) {
+func (d *Driver) Start() (err error) {
 	return
 }
 
-func (d *Driver) Halt() (err []error) {
+func (d *Driver) Halt() (err error) {
 	return
 }

--- a/platforms/audio/audio_driver_test.go
+++ b/platforms/audio/audio_driver_test.go
@@ -19,9 +19,9 @@ func TestAudioDriver(t *testing.T) {
 
 	gobottest.Refute(t, d.Connection(), nil)
 
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 }
 
 func TestAudioDriverSoundWithNoFilename(t *testing.T) {

--- a/platforms/beaglebone/beaglebone_adaptor_test.go
+++ b/platforms/beaglebone/beaglebone_adaptor_test.go
@@ -146,5 +146,5 @@ func TestBeagleboneAdaptor(t *testing.T) {
 	data, _ := a.I2cRead(0xff, 2)
 	gobottest.Assert(t, data, []byte{0x00, 0x01})
 
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Finalize(), nil)
 }

--- a/platforms/bebop/bebop_adaptor.go
+++ b/platforms/bebop/bebop_adaptor.go
@@ -50,13 +50,10 @@ func (a *Adaptor) Name() string { return a.name }
 func (a *Adaptor) SetName(n string) { a.name = n }
 
 // Connect establishes a connection to the ardrone
-func (a *Adaptor) Connect() (errs []error) {
-	err := a.connect(a)
-	if err != nil {
-		return []error{err}
-	}
+func (a *Adaptor) Connect() (err error) {
+	err = a.connect(a)
 	return
 }
 
 // Finalize terminates the connection to the ardrone
-func (a *Adaptor) Finalize() (errs []error) { return }
+func (a *Adaptor) Finalize() (err error) { return }

--- a/platforms/bebop/bebop_adaptor_test.go
+++ b/platforms/bebop/bebop_adaptor_test.go
@@ -21,16 +21,16 @@ func initTestBebopAdaptor() *Adaptor {
 
 func TestBebopAdaptorConnect(t *testing.T) {
 	a := initTestBebopAdaptor()
-	gobottest.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, a.Connect(), nil)
 
 	a.connect = func(a *Adaptor) error {
 		return errors.New("connection error")
 	}
-	gobottest.Assert(t, a.Connect()[0], errors.New("connection error"))
+	gobottest.Assert(t, a.Connect(), errors.New("connection error"))
 }
 
 func TestBebopAdaptorFinalize(t *testing.T) {
 	a := initTestBebopAdaptor()
 	a.Connect()
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Finalize(), nil)
 }

--- a/platforms/bebop/bebop_driver.go
+++ b/platforms/bebop/bebop_driver.go
@@ -42,12 +42,12 @@ func (a *Driver) adaptor() *Adaptor {
 }
 
 // Start starts the Bebop Driver
-func (a *Driver) Start() (errs []error) {
+func (a *Driver) Start() (err error) {
 	return
 }
 
 // Halt halts the Bebop Driver
-func (a *Driver) Halt() (errs []error) {
+func (a *Driver) Halt() (err error) {
 	return
 }
 

--- a/platforms/ble/battery.go
+++ b/platforms/ble/battery.go
@@ -34,12 +34,12 @@ func (b *BatteryDriver) adaptor() *ClientAdaptor {
 }
 
 // Start tells driver to get ready to do work
-func (b *BatteryDriver) Start() (errs []error) {
+func (b *BatteryDriver) Start() (err error) {
 	return
 }
 
 // Halt stops battery driver (void)
-func (b *BatteryDriver) Halt() (errs []error) { return }
+func (b *BatteryDriver) Halt() (err error) { return }
 
 func (b *BatteryDriver) GetBatteryLevel() (level uint8) {
 	var l uint8

--- a/platforms/ble/ble_client_adaptor.go
+++ b/platforms/ble/ble_client_adaptor.go
@@ -39,11 +39,11 @@ func (b *ClientAdaptor) UUID() string                { return b.uuid }
 func (b *ClientAdaptor) Peripheral() gatt.Peripheral { return b.peripheral }
 
 // Connect initiates a connection to the BLE peripheral. Returns true on successful connection.
-func (b *ClientAdaptor) Connect() (errs []error) {
-	device, err := gatt.NewDevice(DefaultClientOptions...)
-	if err != nil {
+func (b *ClientAdaptor) Connect() (err error) {
+	device, e := gatt.NewDevice(DefaultClientOptions...)
+	if e != nil {
 		log.Fatalf("Failed to open BLE device, err: %s\n", err)
-		return
+		return e
 	}
 
 	b.device = device
@@ -64,7 +64,7 @@ func (b *ClientAdaptor) Connect() (errs []error) {
 // Reconnect attempts to reconnect to the BLE peripheral. If it has an active connection
 // it will first close that connection and then establish a new connection.
 // Returns true on Successful reconnection
-func (b *ClientAdaptor) Reconnect() (errs []error) {
+func (b *ClientAdaptor) Reconnect() (err error) {
 	if b.connected {
 		b.Disconnect()
 	}
@@ -72,14 +72,14 @@ func (b *ClientAdaptor) Reconnect() (errs []error) {
 }
 
 // Disconnect terminates the connection to the BLE peripheral. Returns true on successful disconnect.
-func (b *ClientAdaptor) Disconnect() (errs []error) {
+func (b *ClientAdaptor) Disconnect() (err error) {
 	b.peripheral.Device().CancelConnection(b.peripheral)
 
 	return
 }
 
 // Finalize finalizes the BLEAdaptor
-func (b *ClientAdaptor) Finalize() (errs []error) {
+func (b *ClientAdaptor) Finalize() (err error) {
 	return b.Disconnect()
 }
 

--- a/platforms/ble/ble_minidrone.go
+++ b/platforms/ble/ble_minidrone.go
@@ -97,7 +97,7 @@ func (b *MinidroneDriver) adaptor() *ClientAdaptor {
 }
 
 // Start tells driver to get ready to do work
-func (b *MinidroneDriver) Start() (errs []error) {
+func (b *MinidroneDriver) Start() (err error) {
 	b.Init()
 	b.FlatTrim()
 	b.StartPcmd()
@@ -107,7 +107,7 @@ func (b *MinidroneDriver) Start() (errs []error) {
 }
 
 // Halt stops minidrone driver (void)
-func (b *MinidroneDriver) Halt() (errs []error) {
+func (b *MinidroneDriver) Halt() (err error) {
 	b.Land()
 
 	time.Sleep(500 * time.Millisecond)

--- a/platforms/ble/device_information.go
+++ b/platforms/ble/device_information.go
@@ -34,12 +34,12 @@ func (b *DeviceInformationDriver) adaptor() *ClientAdaptor {
 }
 
 // Start tells driver to get ready to do work
-func (b *DeviceInformationDriver) Start() (errs []error) {
+func (b *DeviceInformationDriver) Start() (err error) {
 	return
 }
 
 // Halt stops driver (void)
-func (b *DeviceInformationDriver) Halt() (errs []error) { return }
+func (b *DeviceInformationDriver) Halt() (err error) { return }
 
 func (b *DeviceInformationDriver) GetModelNumber() (model string) {
 	c, _ := b.adaptor().ReadCharacteristic("180a", "2a24")

--- a/platforms/ble/ollie.go
+++ b/platforms/ble/ollie.go
@@ -64,7 +64,7 @@ func (b *SpheroOllieDriver) adaptor() *ClientAdaptor {
 }
 
 // Start tells driver to get ready to do work
-func (s *SpheroOllieDriver) Start() (errs []error) {
+func (s *SpheroOllieDriver) Start() (err error) {
 	s.Init()
 
 	// send commands
@@ -82,7 +82,7 @@ func (s *SpheroOllieDriver) Start() (errs []error) {
 }
 
 // Halt stops Ollie driver (void)
-func (b *SpheroOllieDriver) Halt() (errs []error) {
+func (b *SpheroOllieDriver) Halt() (err error) {
 	b.Sleep()
 	time.Sleep(750 * time.Microsecond)
 	return

--- a/platforms/chip/chip_adaptor.go
+++ b/platforms/chip/chip_adaptor.go
@@ -3,6 +3,7 @@ package chip
 import (
 	"errors"
 
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hybridgroup/gobot/sysfs"
 )
 
@@ -39,25 +40,25 @@ func (c *Adaptor) Name() string { return c.name }
 func (c *Adaptor) SetName(n string) { c.name = n }
 
 // Connect initializes the board
-func (c *Adaptor) Connect() (errs []error) {
+func (c *Adaptor) Connect() (err error) {
 	return
 }
 
 // Finalize closes connection to board and pins
-func (c *Adaptor) Finalize() (errs []error) {
+func (c *Adaptor) Finalize() (err error) {
 	for _, pin := range c.digitalPins {
 		if pin != nil {
-			if err := pin.Unexport(); err != nil {
-				errs = append(errs, err)
+			if e := pin.Unexport(); e != nil {
+				err = multierror.Append(err, e)
 			}
 		}
 	}
 	if c.i2cDevice != nil {
-		if err := c.i2cDevice.Close(); err != nil {
-			errs = append(errs, err)
+		if e := c.i2cDevice.Close(); e != nil {
+			err = multierror.Append(err, e)
 		}
 	}
-	return errs
+	return
 }
 
 func (c *Adaptor) translatePin(pin string) (i int, err error) {

--- a/platforms/chip/chip_adaptor_test.go
+++ b/platforms/chip/chip_adaptor_test.go
@@ -87,5 +87,5 @@ func TestChipAdaptorI2c(t *testing.T) {
 	data, _ := a.I2cRead(0xff, 2)
 	gobottest.Assert(t, data, []byte{0x00, 0x01})
 
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Finalize(), nil)
 }

--- a/platforms/digispark/digispark_adaptor.go
+++ b/platforms/digispark/digispark_adaptor.go
@@ -38,15 +38,13 @@ func (d *Adaptor) Name() string { return d.name }
 func (d *Adaptor) SetName(n string) { d.name = n }
 
 // Connect starts a connection to the digispark
-func (d *Adaptor) Connect() (errs []error) {
-	if err := d.connect(d); err != nil {
-		return []error{err}
-	}
+func (d *Adaptor) Connect() (err error) {
+	err = d.connect(d)
 	return
 }
 
 // Finalize implements the Adaptor interface
-func (d *Adaptor) Finalize() (errs []error) { return }
+func (d *Adaptor) Finalize() (err error) { return }
 
 // DigitalWrite writes a value to the pin. Acceptable values are 1 or 0.
 func (d *Adaptor) DigitalWrite(pin string, level byte) (err error) {

--- a/platforms/digispark/digispark_adaptor_test.go
+++ b/platforms/digispark/digispark_adaptor_test.go
@@ -72,15 +72,15 @@ func initTestAdaptor() *Adaptor {
 
 func TestAdaptorConnect(t *testing.T) {
 	a := NewAdaptor()
-	gobottest.Assert(t, a.Connect()[0], ErrConnection)
+	gobottest.Assert(t, a.Connect(), ErrConnection)
 
 	a = initTestAdaptor()
-	gobottest.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, a.Connect(), nil)
 }
 
 func TestAdaptorFinalize(t *testing.T) {
 	a := initTestAdaptor()
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Finalize(), nil)
 }
 
 func TestAdaptorDigitalWrite(t *testing.T) {

--- a/platforms/firmata/firmata_adaptor.go
+++ b/platforms/firmata/firmata_adaptor.go
@@ -70,16 +70,16 @@ func NewAdaptor(args ...interface{}) *Adaptor {
 }
 
 // Connect starts a connection to the board.
-func (f *Adaptor) Connect() (errs []error) {
+func (f *Adaptor) Connect() (err error) {
 	if f.conn == nil {
-		sp, err := f.openSP(f.Port())
-		if err != nil {
-			return []error{err}
+		sp, e := f.openSP(f.Port())
+		if e != nil {
+			return e
 		}
 		f.conn = sp
 	}
-	if err := f.board.Connect(f.conn); err != nil {
-		return []error{err}
+	if err = f.board.Connect(f.conn); err != nil {
+		return err
 	}
 	return
 }
@@ -93,11 +93,9 @@ func (f *Adaptor) Disconnect() (err error) {
 }
 
 // Finalize terminates the firmata connection
-func (f *Adaptor) Finalize() (errs []error) {
-	if err := f.Disconnect(); err != nil {
-		return []error{err}
-	}
-	return
+func (f *Adaptor) Finalize() (err error) {
+	err = f.Disconnect()
+	return err
 }
 
 // Port returns the Firmata Adaptors port

--- a/platforms/firmata/firmata_adaptor_test.go
+++ b/platforms/firmata/firmata_adaptor_test.go
@@ -104,11 +104,11 @@ func TestAdaptor(t *testing.T) {
 
 func TestAdaptorFinalize(t *testing.T) {
 	a := initTestAdaptor()
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Finalize(), nil)
 
 	a = initTestAdaptor()
 	a.board.(*mockFirmataBoard).disconnectError = errors.New("close error")
-	gobottest.Assert(t, a.Finalize()[0], errors.New("close error"))
+	gobottest.Assert(t, a.Finalize(), errors.New("close error"))
 }
 
 func TestAdaptorConnect(t *testing.T) {
@@ -118,18 +118,18 @@ func TestAdaptorConnect(t *testing.T) {
 	a := NewAdaptor("/dev/null")
 	a.openSP = openSP
 	a.board = newMockFirmataBoard()
-	gobottest.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, a.Connect(), nil)
 
 	a = NewAdaptor("/dev/null")
 	a.board = newMockFirmataBoard()
 	a.openSP = func(port string) (io.ReadWriteCloser, error) {
 		return nil, errors.New("connect error")
 	}
-	gobottest.Assert(t, a.Connect()[0], errors.New("connect error"))
+	gobottest.Assert(t, a.Connect(), errors.New("connect error"))
 
 	a = NewAdaptor(&readWriteCloser{})
 	a.board = newMockFirmataBoard()
-	gobottest.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, a.Connect(), nil)
 
 }
 

--- a/platforms/intel-iot/edison/edison_adaptor_test.go
+++ b/platforms/intel-iot/edison/edison_adaptor_test.go
@@ -40,7 +40,7 @@ func (n *NullReadWriteCloser) Read(b []byte) (int, error) {
 	return len(b), nil
 }
 
-var closeErr error = nil
+var closeErr error
 
 func (n *NullReadWriteCloser) Close() error {
 	return closeErr
@@ -125,11 +125,11 @@ func initTestAdaptor() (*Adaptor, *sysfs.MockFilesystem) {
 
 func TestAdaptorConnect(t *testing.T) {
 	a, _ := initTestAdaptor()
-	gobottest.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, a.Connect(), nil)
 
 	a = NewAdaptor()
 	sysfs.SetFilesystem(sysfs.NewMockFilesystem([]string{}))
-	gobottest.Refute(t, len(a.Connect()), 0)
+	gobottest.Refute(t, a.Connect(), nil)
 }
 
 func TestAdaptorFinalize(t *testing.T) {
@@ -140,11 +140,11 @@ func TestAdaptorFinalize(t *testing.T) {
 	sysfs.SetSyscall(&sysfs.MockSyscall{})
 	a.I2cStart(0xff)
 
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Finalize(), nil)
 
 	closeErr = errors.New("close error")
 	sysfs.SetFilesystem(sysfs.NewMockFilesystem([]string{}))
-	gobottest.Refute(t, len(a.Finalize()), 0)
+	gobottest.Refute(t, a.Finalize(), nil)
 }
 
 func TestAdaptorDigitalIO(t *testing.T) {

--- a/platforms/intel-iot/joule/joule_adaptor_test.go
+++ b/platforms/intel-iot/joule/joule_adaptor_test.go
@@ -39,7 +39,7 @@ func (n *NullReadWriteCloser) Read(b []byte) (int, error) {
 	return len(b), nil
 }
 
-var closeErr error = nil
+var closeErr error
 
 func (n *NullReadWriteCloser) Close() error {
 	return closeErr
@@ -128,7 +128,7 @@ func initTestAdaptor() (*Adaptor, *sysfs.MockFilesystem) {
 
 func TestAdaptorConnect(t *testing.T) {
 	a, _ := initTestAdaptor()
-	gobottest.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, a.Connect(), nil)
 }
 
 func TestAdaptorFinalize(t *testing.T) {
@@ -139,11 +139,11 @@ func TestAdaptorFinalize(t *testing.T) {
 	sysfs.SetSyscall(&sysfs.MockSyscall{})
 	a.I2cStart(0xff)
 
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Finalize(), nil)
 
 	closeErr = errors.New("close error")
 	sysfs.SetFilesystem(sysfs.NewMockFilesystem([]string{}))
-	gobottest.Refute(t, len(a.Finalize()), 0)
+	gobottest.Refute(t, a.Finalize(), nil)
 }
 
 func TestAdaptorDigitalIO(t *testing.T) {

--- a/platforms/intel-iot/joule/pwm_pin.go
+++ b/platforms/intel-iot/joule/pwm_pin.go
@@ -1,4 +1,5 @@
-// TODO: move this into shared PWM package
+// package joule pwm implementation
+// TODO: move this into shared Intel package
 package joule
 
 import "strconv"

--- a/platforms/joystick/joystick_adaptor.go
+++ b/platforms/joystick/joystick_adaptor.go
@@ -40,15 +40,13 @@ func (j *Adaptor) Name() string { return j.name }
 func (j *Adaptor) SetName(n string) { j.name = n }
 
 // Connect connects to the joystick
-func (j *Adaptor) Connect() (errs []error) {
-	if err := j.connect(j); err != nil {
-		return []error{err}
-	}
+func (j *Adaptor) Connect() (err error) {
+	err = j.connect(j)
 	return
 }
 
 // Finalize closes connection to joystick
-func (j *Adaptor) Finalize() (errs []error) {
+func (j *Adaptor) Finalize() (err error) {
 	j.joystick.Close()
 	return
 }

--- a/platforms/joystick/joystick_adaptor_test.go
+++ b/platforms/joystick/joystick_adaptor_test.go
@@ -21,14 +21,14 @@ func initTestAdaptor() *Adaptor {
 
 func TestAdaptorConnect(t *testing.T) {
 	a := initTestAdaptor()
-	gobottest.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, a.Connect(), nil)
 
 	a = NewAdaptor()
-	gobottest.Assert(t, a.Connect()[0], errors.New("No joystick available"))
+	gobottest.Assert(t, a.Connect(), errors.New("No joystick available"))
 }
 
 func TestAdaptorFinalize(t *testing.T) {
 	a := initTestAdaptor()
 	a.Connect()
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Finalize(), nil)
 }

--- a/platforms/joystick/joystick_driver.go
+++ b/platforms/joystick/joystick_driver.go
@@ -94,10 +94,10 @@ func (j *Driver) adaptor() *Adaptor {
 //		[button]_press
 //		[button]_release
 //		[axis]
-func (j *Driver) Start() (errs []error) {
-	file, err := ioutil.ReadFile(j.configPath)
-	if err != nil {
-		return []error{err}
+func (j *Driver) Start() (err error) {
+	file, e := ioutil.ReadFile(j.configPath)
+	if e != nil {
+		return e
 	}
 
 	var jsontype joystickConfig
@@ -118,8 +118,8 @@ func (j *Driver) Start() (errs []error) {
 	go func() {
 		for {
 			for event := j.poll(); event != nil; event = j.poll() {
-				if err = j.handleEvent(event); err != nil {
-					j.Publish(j.Event("error"), err)
+				if errs := j.handleEvent(event); errs != nil {
+					j.Publish(j.Event("error"), errs)
 				}
 			}
 			select {
@@ -133,7 +133,7 @@ func (j *Driver) Start() (errs []error) {
 }
 
 // Halt stops joystick driver
-func (j *Driver) Halt() (errs []error) {
+func (j *Driver) Halt() (err error) {
 	j.halt <- true
 	return
 }

--- a/platforms/joystick/joystick_driver_test.go
+++ b/platforms/joystick/joystick_driver_test.go
@@ -28,8 +28,8 @@ func initTestDriver() *Driver {
 func TestDriverStart(t *testing.T) {
 	d := initTestDriver()
 	d.interval = 1 * time.Millisecond
-	gobottest.Assert(t, len(d.Start()), 0)
-	<-time.After(2 * time.Millisecond)
+	gobottest.Assert(t, d.Start(), nil)
+	time.Sleep(2 * time.Millisecond)
 }
 
 func TestDriverHalt(t *testing.T) {
@@ -37,7 +37,7 @@ func TestDriverHalt(t *testing.T) {
 	go func() {
 		<-d.halt
 	}()
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 }
 
 func TestDriverHandleEvent(t *testing.T) {

--- a/platforms/keyboard/keyboard.go
+++ b/platforms/keyboard/keyboard.go
@@ -135,13 +135,13 @@ func configure() (err error) {
 }
 
 // restores the TTY to the original state
-func restore() (errs []error) {
-	if _, err := stty("echo"); err != nil {
-		return []error{err}
+func restore() (err error) {
+	if _, err = stty("echo"); err != nil {
+		return
 	}
 
-	if _, err := stty(originalState); err != nil {
-		return []error{err}
+	if _, err = stty(originalState); err != nil {
+		return
 	}
 
 	return

--- a/platforms/keyboard/keyboard_driver.go
+++ b/platforms/keyboard/keyboard_driver.go
@@ -66,9 +66,9 @@ func (k *Driver) Connection() gobot.Connection { return nil }
 
 // Start initializes keyboard by grabbing key events as they come in and
 // publishing a key event
-func (k *Driver) Start() (errs []error) {
-	if err := k.connect(k); err != nil {
-		return []error{err}
+func (k *Driver) Start() (err error) {
+	if err = k.connect(k); err != nil {
+		return err
 	}
 
 	go k.listen(k)
@@ -77,7 +77,7 @@ func (k *Driver) Start() (errs []error) {
 }
 
 // Halt stops camera driver
-func (k *Driver) Halt() (errs []error) {
+func (k *Driver) Halt() (err error) {
 	if originalState != "" {
 		return restore()
 	}

--- a/platforms/keyboard/keyboard_driver_test.go
+++ b/platforms/keyboard/keyboard_driver_test.go
@@ -27,10 +27,10 @@ func TestKeyboardDriver(t *testing.T) {
 
 func TestKeyboardDriverStart(t *testing.T) {
 	d := initTestKeyboardDriver()
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 }
 
 func TestKeyboardDriverHalt(t *testing.T) {
 	d := initTestKeyboardDriver()
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 }

--- a/platforms/leap/leap_motion_adaptor.go
+++ b/platforms/leap/leap_motion_adaptor.go
@@ -28,9 +28,9 @@ func (l *Adaptor) SetName(n string) { l.name = n }
 func (l *Adaptor) Port() string     { return l.port }
 
 // Connect returns true if connection to leap motion is established successfully
-func (l *Adaptor) Connect() (errs []error) {
-	if ws, err := l.connect(l.Port()); err != nil {
-		return []error{err}
+func (l *Adaptor) Connect() (err error) {
+	if ws, e := l.connect(l.Port()); e != nil {
+		return e
 	} else {
 		l.ws = ws
 	}
@@ -38,4 +38,4 @@ func (l *Adaptor) Connect() (errs []error) {
 }
 
 // Finalize ends connection to leap motion
-func (l *Adaptor) Finalize() (errs []error) { return }
+func (l *Adaptor) Finalize() (err error) { return }

--- a/platforms/leap/leap_motion_adaptor_test.go
+++ b/platforms/leap/leap_motion_adaptor_test.go
@@ -23,15 +23,15 @@ func TestLeapMotionAdaptor(t *testing.T) {
 }
 func TestLeapMotionAdaptorConnect(t *testing.T) {
 	a := initTestLeapMotionAdaptor()
-	gobottest.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, a.Connect(), nil)
 
 	a.connect = func(port string) (io.ReadWriteCloser, error) {
 		return nil, errors.New("connection error")
 	}
-	gobottest.Assert(t, a.Connect()[0], errors.New("connection error"))
+	gobottest.Assert(t, a.Connect(), errors.New("connection error"))
 }
 
 func TestLeapMotionAdaptorFinalize(t *testing.T) {
 	a := initTestLeapMotionAdaptor()
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Finalize(), nil)
 }

--- a/platforms/leap/leap_motion_driver.go
+++ b/platforms/leap/leap_motion_driver.go
@@ -9,11 +9,11 @@ import (
 )
 
 const (
-	// Message event
+	// MessageEvent event
 	MessageEvent = "message"
-	// Hand event
+	// HandEvent event
 	HandEvent = "hand"
-	// Gesture event
+	// GestureEvent event
 	GestureEvent = "gesture"
 )
 
@@ -61,15 +61,15 @@ func (l *Driver) adaptor() *Adaptor {
 //		"message" - Emits Frame on new message received from Leap.
 //		"hand" - Emits Hand when detected in message from Leap.
 //		"gesture" - Emits Gesture when detected in message from Leap.
-func (l *Driver) Start() (errs []error) {
+func (l *Driver) Start() (err error) {
 	enableGestures := map[string]bool{"enableGestures": true}
-	b, err := json.Marshal(enableGestures)
-	if err != nil {
-		return []error{err}
+	b, e := json.Marshal(enableGestures)
+	if e != nil {
+		return e
 	}
-	_, err = l.adaptor().ws.Write(b)
-	if err != nil {
-		return []error{err}
+	_, e = l.adaptor().ws.Write(b)
+	if e != nil {
+		return e
 	}
 
 	go func() {
@@ -93,5 +93,5 @@ func (l *Driver) Start() (errs []error) {
 	return
 }
 
-// Halt returns true if driver is halted successfully
-func (l *Driver) Halt() (errs []error) { return }
+// Halt returns nil if driver is halted successfully
+func (l *Driver) Halt() (errs error) { return }

--- a/platforms/leap/leap_motion_driver_test.go
+++ b/platforms/leap/leap_motion_driver_test.go
@@ -14,7 +14,7 @@ var _ gobot.Driver = (*Driver)(nil)
 
 type NullReadWriteCloser struct{}
 
-var writeError error = nil
+var writeError error
 
 func (NullReadWriteCloser) Write(p []byte) (int, error) {
 	return len(p), writeError
@@ -46,16 +46,16 @@ func TestLeapMotionDriver(t *testing.T) {
 
 func TestLeapMotionDriverStart(t *testing.T) {
 	d := initTestLeapMotionDriver()
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 
 	d = initTestLeapMotionDriver()
 	writeError = errors.New("write error")
-	gobottest.Assert(t, d.Start()[0], errors.New("write error"))
+	gobottest.Assert(t, d.Start(), errors.New("write error"))
 }
 
 func TestLeapMotionDriverHalt(t *testing.T) {
 	d := initTestLeapMotionDriver()
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 }
 
 func TestLeapMotionDriverParser(t *testing.T) {

--- a/platforms/mavlink/mavlink_adaptor.go
+++ b/platforms/mavlink/mavlink_adaptor.go
@@ -29,9 +29,9 @@ func (m *Adaptor) SetName(n string) { m.name = n }
 func (m *Adaptor) Port() string     { return m.port }
 
 // Connect returns true if connection to device is successful
-func (m *Adaptor) Connect() (errs []error) {
-	if sp, err := m.connect(m.Port()); err != nil {
-		return []error{err}
+func (m *Adaptor) Connect() (err error) {
+	if sp, e := m.connect(m.Port()); e != nil {
+		return e
 	} else {
 		m.sp = sp
 	}
@@ -39,9 +39,7 @@ func (m *Adaptor) Connect() (errs []error) {
 }
 
 // Finalize returns true if connection to devices is closed successfully
-func (m *Adaptor) Finalize() (errs []error) {
-	if err := m.sp.Close(); err != nil {
-		return []error{err}
-	}
+func (m *Adaptor) Finalize() (err error) {
+	err = m.sp.Close()
 	return
 }

--- a/platforms/mavlink/mavlink_adaptor_test.go
+++ b/platforms/mavlink/mavlink_adaptor_test.go
@@ -57,18 +57,18 @@ func TestMavlinkAdaptor(t *testing.T) {
 }
 func TestMavlinkAdaptorConnect(t *testing.T) {
 	a := initTestMavlinkAdaptor()
-	gobottest.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, a.Connect(), nil)
 
 	a.connect = func(port string) (io.ReadWriteCloser, error) { return nil, errors.New("connect error") }
-	gobottest.Assert(t, a.Connect()[0], errors.New("connect error"))
+	gobottest.Assert(t, a.Connect(), errors.New("connect error"))
 }
 
 func TestMavlinkAdaptorFinalize(t *testing.T) {
 	a := initTestMavlinkAdaptor()
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Finalize(), nil)
 
 	testAdaptorClose = func() error {
 		return errors.New("close error")
 	}
-	gobottest.Assert(t, a.Finalize()[0], errors.New("close error"))
+	gobottest.Assert(t, a.Finalize(), errors.New("close error"))
 }

--- a/platforms/mavlink/mavlink_driver.go
+++ b/platforms/mavlink/mavlink_driver.go
@@ -12,7 +12,7 @@ const (
 	PacketEvent = "packet"
 	// MessageEvent event
 	MessageEvent = "message"
-	// ErrorIOE event
+	// ErrorIOEEvent event
 	ErrorIOEvent = "errorIO"
 	// ErrorMAVLinkEvent event
 	ErrorMAVLinkEvent = "errorMAVLink"
@@ -64,7 +64,7 @@ func (m *Driver) adaptor() *Adaptor {
 
 // Start begins process to read mavlink packets every m.Interval
 // and process them
-func (m *Driver) Start() (errs []error) {
+func (m *Driver) Start() error {
 	go func() {
 		for {
 			packet, err := common.ReadMAVLinkPacket(m.adaptor().sp)
@@ -82,11 +82,11 @@ func (m *Driver) Start() (errs []error) {
 			time.Sleep(m.interval)
 		}
 	}()
-	return
+	return nil
 }
 
 // Halt returns true if device is halted successfully
-func (m *Driver) Halt() (errs []error) { return }
+func (m *Driver) Halt() (err error) { return }
 
 // SendPacket sends a packet to mavlink device
 func (m *Driver) SendPacket(packet *common.MAVLinkPacket) (err error) {

--- a/platforms/mavlink/mavlink_driver_test.go
+++ b/platforms/mavlink/mavlink_driver_test.go
@@ -51,7 +51,7 @@ func TestMavlinkDriverStart(t *testing.T) {
 		err <- data.(error)
 	})
 
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 
 	select {
 	case p := <-packet:
@@ -74,5 +74,5 @@ func TestMavlinkDriverStart(t *testing.T) {
 
 func TestMavlinkDriverHalt(t *testing.T) {
 	d := initTestMavlinkDriver()
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 }

--- a/platforms/megapi/megapi_adaptor.go
+++ b/platforms/megapi/megapi_adaptor.go
@@ -42,11 +42,11 @@ func (megaPi *Adaptor) SetName(n string) {
 }
 
 // Connect starts a connection to the board
-func (megaPi *Adaptor) Connect() (errs []error) {
+func (megaPi *Adaptor) Connect() error {
 	if megaPi.connection == nil {
 		sp, err := serial.OpenPort(megaPi.serialConfig)
 		if err != nil {
-			return []error{err}
+			return err
 		}
 
 		// sleeping is required to give the board a chance to reset
@@ -69,15 +69,15 @@ func (megaPi *Adaptor) Connect() (errs []error) {
 			}
 		}
 	}()
-	return
+	return nil
 }
 
 // Finalize terminates the connection to the board
-func (megaPi *Adaptor) Finalize() (errs []error) {
+func (megaPi *Adaptor) Finalize() error {
 	megaPi.finalizeChannel <- struct{}{}
 	<-megaPi.finalizeChannel
 	if err := megaPi.connection.Close(); err != nil {
-		return []error{err}
+		return err
 	}
-	return
+	return nil
 }

--- a/platforms/megapi/motor_driver.go
+++ b/platforms/megapi/motor_driver.go
@@ -41,21 +41,21 @@ func (m *MotorDriver) SetName(n string) {
 }
 
 // Start implements the Driver interface
-func (m *MotorDriver) Start() []error {
+func (m *MotorDriver) Start() error {
 	m.syncRoot.Lock()
 	defer m.syncRoot.Unlock()
 	m.halted = false
 	m.speedHelper(0)
-	return []error{}
+	return nil
 }
 
 // Halt terminates the Driver interface
-func (m *MotorDriver) Halt() []error {
+func (m *MotorDriver) Halt() error {
 	m.syncRoot.Lock()
 	defer m.syncRoot.Unlock()
 	m.halted = true
 	m.speedHelper(0)
-	return []error{}
+	return nil
 }
 
 // Connection returns the Connection associated with the Driver

--- a/platforms/mqtt/mqtt_adaptor.go
+++ b/platforms/mqtt/mqtt_adaptor.go
@@ -1,6 +1,9 @@
 package mqtt
 
-import paho "github.com/eclipse/paho.mqtt.golang"
+import (
+	paho "github.com/eclipse/paho.mqtt.golang"
+	multierror "github.com/hashicorp/go-multierror"
+)
 
 type Adaptor struct {
 	name     string
@@ -34,10 +37,10 @@ func (a *Adaptor) Name() string     { return a.name }
 func (a *Adaptor) SetName(n string) { a.name = n }
 
 // Connect returns true if connection to mqtt is established
-func (a *Adaptor) Connect() (errs []error) {
+func (a *Adaptor) Connect() (err error) {
 	a.client = paho.NewClient(createClientOptions(a.clientID, a.Host, a.username, a.password))
 	if token := a.client.Connect(); token.Wait() && token.Error() != nil {
-		errs = append(errs, token.Error())
+		err = multierror.Append(err, token.Error())
 	}
 
 	return
@@ -52,7 +55,7 @@ func (a *Adaptor) Disconnect() (err error) {
 }
 
 // Finalize returns true if connection to mqtt is finalized successfully
-func (a *Adaptor) Finalize() (errs []error) {
+func (a *Adaptor) Finalize() (err error) {
 	a.Disconnect()
 	return
 }

--- a/platforms/mqtt/mqtt_adaptor_test.go
+++ b/platforms/mqtt/mqtt_adaptor_test.go
@@ -16,12 +16,12 @@ func initTestMqttAdaptor() *Adaptor {
 
 func TestMqttAdaptorConnect(t *testing.T) {
 	a := initTestMqttAdaptor()
-	gobottest.Assert(t, a.Connect()[0].Error(), "Network Error : Unknown protocol")
+	gobottest.Assert(t, a.Connect().Error(), "1 error(s) occurred:\n\n* Network Error : Unknown protocol")
 }
 
 func TestMqttAdaptorFinalize(t *testing.T) {
 	a := initTestMqttAdaptor()
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Finalize(), nil)
 }
 
 func TestMqttAdaptorCannotPublishUnlessConnected(t *testing.T) {

--- a/platforms/mqtt/mqtt_adaptor_test.go
+++ b/platforms/mqtt/mqtt_adaptor_test.go
@@ -1,9 +1,11 @@
 package mqtt
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hybridgroup/gobot"
 	"github.com/hybridgroup/gobot/gobottest"
 )
@@ -16,7 +18,10 @@ func initTestMqttAdaptor() *Adaptor {
 
 func TestMqttAdaptorConnect(t *testing.T) {
 	a := initTestMqttAdaptor()
-	gobottest.Assert(t, a.Connect().Error(), "1 error(s) occurred:\n\n* Network Error : Unknown protocol")
+	var expected error
+	expected = multierror.Append(expected, errors.New("Network Error : Unknown protocol"))
+
+	gobottest.Assert(t, a.Connect(), expected)
 }
 
 func TestMqttAdaptorFinalize(t *testing.T) {

--- a/platforms/nats/nats_adaptor.go
+++ b/platforms/nats/nats_adaptor.go
@@ -54,7 +54,7 @@ func (a *Adaptor) Connect() (err error) {
 
 	var e error
 	a.client, e = nats.Connect(defaultURL)
-	if err != nil {
+	if e != nil {
 		err = multierror.Append(err, e)
 	}
 	return

--- a/platforms/nats/nats_adaptor.go
+++ b/platforms/nats/nats_adaptor.go
@@ -1,6 +1,7 @@
 package nats
 
 import (
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/nats-io/nats"
 )
 
@@ -43,8 +44,7 @@ func (a *Adaptor) Name() string { return a.name }
 func (a *Adaptor) SetName(n string) { a.name = n }
 
 // Connect makes a connection to the Nats server.
-func (a *Adaptor) Connect() (errs []error) {
-
+func (a *Adaptor) Connect() (err error) {
 	auth := ""
 	if a.username != "" && a.password != "" {
 		auth = a.username + ":" + a.password + "@"
@@ -52,10 +52,10 @@ func (a *Adaptor) Connect() (errs []error) {
 
 	defaultURL := "nats://" + auth + a.Host
 
-	var err error
-	a.client, err = nats.Connect(defaultURL)
+	var e error
+	a.client, e = nats.Connect(defaultURL)
 	if err != nil {
-		return append(errs, err)
+		err = multierror.Append(err, e)
 	}
 	return
 }
@@ -69,7 +69,7 @@ func (a *Adaptor) Disconnect() (err error) {
 }
 
 // Finalize is simply a helper method for the disconnect.
-func (a *Adaptor) Finalize() (errs []error) {
+func (a *Adaptor) Finalize() (err error) {
 	a.Disconnect()
 	return
 }

--- a/platforms/nats/nats_adaptor_test.go
+++ b/platforms/nats/nats_adaptor_test.go
@@ -1,6 +1,7 @@
 package nats
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -47,12 +48,12 @@ func TestNatsAdaptorOnWhenConnectedWithAuth(t *testing.T) {
 
 func TestNatsAdaptorConnect(t *testing.T) {
 	a := NewAdaptor("localhost:9999", 9999)
-	gobottest.Assert(t, a.Connect()[0].Error(), "nats: no servers available for connection")
+	gobottest.Assert(t, a.Connect(), errors.New("nats: no servers available for connection"))
 }
 
 func TestNatsAdaptorFinalize(t *testing.T) {
 	a := NewAdaptor("localhost:9999", 9999)
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Finalize(), nil)
 }
 
 func TestNatsAdaptorCannotPublishUnlessConnected(t *testing.T) {

--- a/platforms/nats/nats_adaptor_test.go
+++ b/platforms/nats/nats_adaptor_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hybridgroup/gobot"
 	"github.com/hybridgroup/gobot/gobottest"
 )
@@ -48,7 +49,9 @@ func TestNatsAdaptorOnWhenConnectedWithAuth(t *testing.T) {
 
 func TestNatsAdaptorConnect(t *testing.T) {
 	a := NewAdaptor("localhost:9999", 9999)
-	gobottest.Assert(t, a.Connect(), errors.New("nats: no servers available for connection"))
+	var expected error
+	expected = multierror.Append(expected, errors.New("nats: no servers available for connection"))
+	gobottest.Assert(t, a.Connect(), expected)
 }
 
 func TestNatsAdaptorFinalize(t *testing.T) {

--- a/platforms/neurosky/neurosky_adaptor.go
+++ b/platforms/neurosky/neurosky_adaptor.go
@@ -29,19 +29,17 @@ func (n *Adaptor) SetName(name string) { n.name = name }
 func (n *Adaptor) Port() string        { return n.port }
 
 // Connect returns true if connection to device is successful
-func (n *Adaptor) Connect() (errs []error) {
+func (n *Adaptor) Connect() error {
 	if sp, err := n.connect(n); err != nil {
-		return []error{err}
+		return err
 	} else {
 		n.sp = sp
 	}
-	return
+	return nil
 }
 
 // Finalize returns true if device finalization is successful
-func (n *Adaptor) Finalize() (errs []error) {
-	if err := n.sp.Close(); err != nil {
-		return []error{err}
-	}
+func (n *Adaptor) Finalize() (err error) {
+	err = n.sp.Close()
 	return
 }

--- a/platforms/neurosky/neurosky_adaptor_test.go
+++ b/platforms/neurosky/neurosky_adaptor_test.go
@@ -23,7 +23,7 @@ func (NullReadWriteCloser) Read(b []byte) (int, error) {
 	return len(b), readError
 }
 
-var closeError error = nil
+var closeError error
 
 func (NullReadWriteCloser) Close() error {
 	return closeError
@@ -44,20 +44,20 @@ func TestNeuroskyAdaptor(t *testing.T) {
 
 func TestNeuroskyAdaptorConnect(t *testing.T) {
 	a := initTestNeuroskyAdaptor()
-	gobottest.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, a.Connect(), nil)
 
 	a.connect = func(n *Adaptor) (io.ReadWriteCloser, error) {
 		return nil, errors.New("connection error")
 	}
-	gobottest.Assert(t, a.Connect()[0], errors.New("connection error"))
+	gobottest.Assert(t, a.Connect(), errors.New("connection error"))
 }
 
 func TestNeuroskyAdaptorFinalize(t *testing.T) {
 	a := initTestNeuroskyAdaptor()
 	a.Connect()
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Finalize(), nil)
 
 	closeError = errors.New("close error")
 	a.Connect()
-	gobottest.Assert(t, a.Finalize()[0], errors.New("close error"))
+	gobottest.Assert(t, a.Finalize(), errors.New("close error"))
 }

--- a/platforms/neurosky/neurosky_driver.go
+++ b/platforms/neurosky/neurosky_driver.go
@@ -85,7 +85,7 @@ func (n *Driver) adaptor() *Adaptor {
 
 // Start creates a go routine to listen from serial port
 // and parse buffer readings
-func (n *Driver) Start() (errs []error) {
+func (n *Driver) Start() (err error) {
 	go func() {
 		for {
 			buff := make([]byte, 1024)
@@ -101,7 +101,7 @@ func (n *Driver) Start() (errs []error) {
 }
 
 // Halt stops neurosky driver (void)
-func (n *Driver) Halt() (errs []error) { return }
+func (n *Driver) Halt() (err error) { return }
 
 // parse converts bytes buffer into packets until no more data is present
 func (n *Driver) parse(buf *bytes.Buffer) {

--- a/platforms/neurosky/neurosky_driver.go
+++ b/platforms/neurosky/neurosky_driver.go
@@ -8,25 +8,25 @@ import (
 
 const BTSync byte = 0xAA
 
-// Extended code
+// CodeEx Extended code
 const CodeEx byte = 0x55
 
-// POOR_SIGNAL quality 0-255
+// CodeSignalQuality POOR_SIGNAL quality 0-255
 const CodeSignalQuality byte = 0x02
 
-// ATTENTION eSense 0-100
+// CodeAttention ATTENTION eSense 0-100
 const CodeAttention byte = 0x04
 
-// MEDITATION eSense 0-100
+// CodeMeditation MEDITATION eSense 0-100
 const CodeMeditation byte = 0x05
 
-// BLINK strength 0-255
+// CodeBlink BLINK strength 0-255
 const CodeBlink byte = 0x16
 
-// RAW wave value: 2-byte big-endian 2s-complement
+// CodeWave RAW wave value: 2-byte big-endian 2s-complement
 const CodeWave byte = 0x80
 
-// ASIC EEG POWER 8 3-byte big-endian integers
+// CodeAsicEEG ASIC EEG POWER 8 3-byte big-endian integers
 const CodeAsicEEG byte = 0x83
 
 type Driver struct {

--- a/platforms/neurosky/neurosky_driver_test.go
+++ b/platforms/neurosky/neurosky_driver_test.go
@@ -34,7 +34,7 @@ func TestNeuroskyDriverStart(t *testing.T) {
 		sem <- true
 	})
 
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 
 	time.Sleep(50 * time.Millisecond)
 	readError = errors.New("read error")
@@ -51,7 +51,7 @@ func TestNeuroskyDriverStart(t *testing.T) {
 
 func TestNeuroskyDriverHalt(t *testing.T) {
 	d := initTestNeuroskyDriver()
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 }
 
 func TestNeuroskyDriverParse(t *testing.T) {

--- a/platforms/opencv/camera_driver.go
+++ b/platforms/opencv/camera_driver.go
@@ -64,9 +64,9 @@ func (c *CameraDriver) Connection() gobot.Connection { return nil }
 
 // Start initializes camera by grabbing a frame
 // every `interval` and publishing an frame event
-func (c *CameraDriver) Start() (errs []error) {
+func (c *CameraDriver) Start() (err error) {
 	if err := c.start(c); err != nil {
-		return []error{err}
+		return err
 	}
 	go func() {
 		for {
@@ -76,11 +76,11 @@ func (c *CameraDriver) Start() (errs []error) {
 					c.Publish(Frame, image)
 				}
 			}
-			<-time.After(c.interval)
+			time.Sleep(c.interval)
 		}
 	}()
 	return
 }
 
 // Halt stops camera driver
-func (c *CameraDriver) Halt() (errs []error) { return }
+func (c *CameraDriver) Halt() (err error) { return }

--- a/platforms/opencv/camera_driver_test.go
+++ b/platforms/opencv/camera_driver_test.go
@@ -28,7 +28,7 @@ func TestCameraDriver(t *testing.T) {
 func TestCameraDriverStart(t *testing.T) {
 	sem := make(chan bool)
 	d := initTestCameraDriver()
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 	d.On(d.Event("frame"), func(data interface{}) {
 		sem <- true
 	})
@@ -39,13 +39,13 @@ func TestCameraDriverStart(t *testing.T) {
 	}
 
 	d = NewCameraDriver("")
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 
 	d = NewCameraDriver(true)
-	gobottest.Refute(t, len(d.Start()), 0)
+	gobottest.Refute(t, d.Start(), nil)
 }
 
 func TestCameraDriverHalt(t *testing.T) {
 	d := initTestCameraDriver()
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 }

--- a/platforms/opencv/window_driver.go
+++ b/platforms/opencv/window_driver.go
@@ -31,14 +31,14 @@ func (w *WindowDriver) SetName(n string)             { w.name = n }
 func (w *WindowDriver) Connection() gobot.Connection { return nil }
 
 // Start starts window thread and driver
-func (w *WindowDriver) Start() (errs []error) {
+func (w *WindowDriver) Start() (err error) {
 	cv.StartWindowThread()
 	w.start(w)
 	return
 }
 
 // Halt returns true if camera is halted successfully
-func (w *WindowDriver) Halt() (errs []error) { return }
+func (w *WindowDriver) Halt() (err error) { return }
 
 // ShowImage displays image in window
 func (w *WindowDriver) ShowImage(image *cv.IplImage) {

--- a/platforms/opencv/window_driver_test.go
+++ b/platforms/opencv/window_driver_test.go
@@ -25,12 +25,12 @@ func TestWindowDriver(t *testing.T) {
 
 func TestWindowDriverStart(t *testing.T) {
 	d := initTestWindowDriver()
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 }
 
 func TestWindowDriverHalt(t *testing.T) {
 	d := initTestWindowDriver()
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 }
 
 func TestWindowDriverShowImage(t *testing.T) {

--- a/platforms/particle/adaptor.go
+++ b/platforms/particle/adaptor.go
@@ -51,12 +51,12 @@ func (s *Adaptor) Name() string     { return s.name }
 func (s *Adaptor) SetName(n string) { s.name = n }
 
 // Connect returns true if connection to Particle Photon or Electron is successful
-func (s *Adaptor) Connect() (errs []error) {
+func (s *Adaptor) Connect() (err error) {
 	return
 }
 
 // Finalize returns true if connection to Particle Photon or Electron is finalized successfully
-func (s *Adaptor) Finalize() (errs []error) {
+func (s *Adaptor) Finalize() (err error) {
 	return
 }
 

--- a/platforms/particle/adaptor_test.go
+++ b/platforms/particle/adaptor_test.go
@@ -88,13 +88,13 @@ func TestNewAdaptor(t *testing.T) {
 
 func TestAdaptorConnect(t *testing.T) {
 	a := initTestAdaptor()
-	gobottest.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, a.Connect(), nil)
 }
 
 func TestAdaptorFinalize(t *testing.T) {
 	a := initTestAdaptor()
 	a.Connect()
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Finalize(), nil)
 }
 
 func TestAdaptorAnalogRead(t *testing.T) {

--- a/platforms/pebble/pebble_adaptor.go
+++ b/platforms/pebble/pebble_adaptor.go
@@ -15,11 +15,11 @@ func (a *Adaptor) Name() string     { return a.name }
 func (a *Adaptor) SetName(n string) { a.name = n }
 
 // Connect returns true if connection to pebble is established successfully
-func (a *Adaptor) Connect() (errs []error) {
+func (a *Adaptor) Connect() (err error) {
 	return
 }
 
 // Finalize returns true if connection to pebble is finalized successfully
-func (a *Adaptor) Finalize() (errs []error) {
+func (a *Adaptor) Finalize() (err error) {
 	return
 }

--- a/platforms/pebble/pebble_adaptor_test.go
+++ b/platforms/pebble/pebble_adaptor_test.go
@@ -19,10 +19,10 @@ func TestAdaptor(t *testing.T) {
 }
 func TestAdaptorConnect(t *testing.T) {
 	a := initTestAdaptor()
-	gobottest.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, a.Connect(), nil)
 }
 
 func TestAdaptorFinalize(t *testing.T) {
 	a := initTestAdaptor()
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Finalize(), nil)
 }

--- a/platforms/pebble/pebble_driver.go
+++ b/platforms/pebble/pebble_driver.go
@@ -55,10 +55,10 @@ func (d *Driver) SetName(n string)             { d.name = n }
 func (d *Driver) Connection() gobot.Connection { return d.connection }
 
 // Start returns true if driver is initialized correctly
-func (d *Driver) Start() (errs []error) { return }
+func (d *Driver) Start() (err error) { return }
 
 // Halt returns true if driver is halted successfully
-func (d *Driver) Halt() (errs []error) { return }
+func (d *Driver) Halt() (err error) { return }
 
 // PublishEvent publishes event with specified name and data in gobot
 func (d *Driver) PublishEvent(name string, data string) {

--- a/platforms/pebble/pebble_driver_test.go
+++ b/platforms/pebble/pebble_driver_test.go
@@ -16,12 +16,12 @@ func initTestDriver() *Driver {
 
 func TestDriverStart(t *testing.T) {
 	d := initTestDriver()
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 }
 
 func TestDriverHalt(t *testing.T) {
 	d := initTestDriver()
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 }
 
 func TestDriver(t *testing.T) {

--- a/platforms/raspi/raspi_adaptor.go
+++ b/platforms/raspi/raspi_adaptor.go
@@ -168,7 +168,7 @@ func (r *Adaptor) Finalize() (err error) {
 			err = multierror.Append(err, perr)
 		}
 	}
-	return err
+	return
 }
 
 func (r *Adaptor) translatePin(pin string) (i int, err error) {

--- a/platforms/raspi/raspi_adaptor_test.go
+++ b/platforms/raspi/raspi_adaptor_test.go
@@ -111,7 +111,7 @@ func TestAdaptorFinalize(t *testing.T) {
 	a.PwmWrite("7", 255)
 
 	a.I2cStart(0xff)
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Finalize(), nil)
 }
 
 func TestAdaptorDigitalPWM(t *testing.T) {

--- a/platforms/sphero/sphero_adaptor.go
+++ b/platforms/sphero/sphero_adaptor.go
@@ -32,9 +32,9 @@ func (a *Adaptor) Port() string     { return a.port }
 func (a *Adaptor) SetPort(p string) { a.port = p }
 
 // Connect initiates a connection to the Sphero. Returns true on successful connection.
-func (a *Adaptor) Connect() (errs []error) {
-	if sp, err := a.connect(a.Port()); err != nil {
-		return []error{err}
+func (a *Adaptor) Connect() (err error) {
+	if sp, e := a.connect(a.Port()); e != nil {
+		return e
 	} else {
 		a.sp = sp
 		a.connected = true
@@ -45,7 +45,7 @@ func (a *Adaptor) Connect() (errs []error) {
 // Reconnect attempts to reconnect to the Sphero. If the Sphero has an active connection
 // it will first close that connection and then establish a new connection.
 // Returns true on Successful reconnection
-func (a *Adaptor) Reconnect() (errs []error) {
+func (a *Adaptor) Reconnect() (err error) {
 	if a.connected {
 		a.Disconnect()
 	}
@@ -53,17 +53,17 @@ func (a *Adaptor) Reconnect() (errs []error) {
 }
 
 // Disconnect terminates the connection to the Sphero. Returns true on successful disconnect.
-func (a *Adaptor) Disconnect() (errs []error) {
+func (a *Adaptor) Disconnect() error {
 	if a.connected {
-		if err := a.sp.Close(); err != nil {
-			return []error{err}
+		if e := a.sp.Close(); e != nil {
+			return e
 		}
 		a.connected = false
 	}
-	return
+	return nil
 }
 
 // Finalize finalizes the Sphero Adaptor
-func (a *Adaptor) Finalize() (errs []error) {
+func (a *Adaptor) Finalize() error {
 	return a.Disconnect()
 }

--- a/platforms/sphero/sphero_adaptor_test.go
+++ b/platforms/sphero/sphero_adaptor_test.go
@@ -66,23 +66,23 @@ func TestSpheroAdaptorReconnect(t *testing.T) {
 func TestSpheroAdaptorFinalize(t *testing.T) {
 	a := initTestSpheroAdaptor()
 	a.Connect()
-	gobottest.Assert(t, len(a.Finalize()), 0)
+	gobottest.Assert(t, a.Finalize(), nil)
 
 	testAdaptorClose = func() error {
 		return errors.New("close error")
 	}
 
 	a.connected = true
-	gobottest.Assert(t, a.Finalize()[0], errors.New("close error"))
+	gobottest.Assert(t, a.Finalize(), errors.New("close error"))
 }
 
 func TestSpheroAdaptorConnect(t *testing.T) {
 	a := initTestSpheroAdaptor()
-	gobottest.Assert(t, len(a.Connect()), 0)
+	gobottest.Assert(t, a.Connect(), nil)
 
 	a.connect = func(string) (io.ReadWriteCloser, error) {
 		return nil, errors.New("connect error")
 	}
 
-	gobottest.Assert(t, a.Connect()[0], errors.New("connect error"))
+	gobottest.Assert(t, a.Connect(), errors.New("connect error"))
 }

--- a/platforms/sphero/sphero_driver.go
+++ b/platforms/sphero/sphero_driver.go
@@ -157,7 +157,7 @@ func (s *SpheroDriver) adaptor() *Adaptor {
 // 	Collision  sphero.CollisionPacket - On Collision Detected
 // 	SensorData sphero.DataStreamingPacket - On Data Streaming event
 // 	Error      error- On error while processing asynchronous response
-func (s *SpheroDriver) Start() (errs []error) {
+func (s *SpheroDriver) Start() (err error) {
 	go func() {
 		for {
 			packet := <-s.packetChannel
@@ -218,7 +218,7 @@ func (s *SpheroDriver) Start() (errs []error) {
 
 // Halt halts the SpheroDriver and sends a SpheroDriver.Stop command to the Sphero.
 // Returns true on successful halt.
-func (s *SpheroDriver) Halt() (errs []error) {
+func (s *SpheroDriver) Halt() (err error) {
 	if s.adaptor().connected {
 		gobot.Every(10*time.Millisecond, func() {
 			s.Stop()

--- a/platforms/sphero/sphero_driver_test.go
+++ b/platforms/sphero/sphero_driver_test.go
@@ -76,13 +76,13 @@ func TestSpheroDriver(t *testing.T) {
 
 func TestSpheroDriverStart(t *testing.T) {
 	d := initTestSpheroDriver()
-	gobottest.Assert(t, len(d.Start()), 0)
+	gobottest.Assert(t, d.Start(), nil)
 }
 
 func TestSpheroDriverHalt(t *testing.T) {
 	d := initTestSpheroDriver()
 	d.adaptor().connected = true
-	gobottest.Assert(t, len(d.Halt()), 0)
+	gobottest.Assert(t, d.Halt(), nil)
 }
 
 func TestSpheroDriverSetDataStreaming(t *testing.T) {


### PR DESCRIPTION
All Gobot Adaptors and Drivers now return an error instead of an slice of errors. In the case where an Adaptor or Driver needs or wants to return a list of errors, it uses https://github.com/hashicorp/go-multierror to still support the normal `error` interface.

This addresses the issues raised in https://github.com/hybridgroup/gobot/issues/200 thanks everyone who contributed to the conversation.