### PR TITLE
Add GoPiGo Platform

### DIFF
--- a/drivers/i2c/gopipo_driver.go
+++ b/drivers/i2c/gopipo_driver.go
@@ -1,0 +1,262 @@
+package i2c
+
+import (
+	"time"
+
+	"github.com/hybridgroup/gobot"
+)
+
+// debug=0
+//
+// us_cmd				=[117]		#Read the distance from the ultrasonic sensor
+// en_com_timeout_cmd	=[80]		#Enable communication timeout
+// dis_com_timeout_cmd	=[81]		#Disable communication timeout
+// timeout_status_cmd	=[82]		#Read the timeout status
+// enc_read_cmd		=[53]		#Read encoder values
+// trim_test_cmd		=[30]		#Test the trim values
+// trim_write_cmd		=[31]		#Write the trim values
+// trim_read_cmd		=[32]
+//
+// ir_read_cmd			=[21]
+// ir_recv_pin_cmd		=[22]
+// cpu_speed_cmd		=[25]
+
+// v16_thresh=790
+const (
+	GOPIGO_ADDRESS = 0x08 // i2c address for the GoPiGo
+
+	GOPIGO_STOP             = 0x78 // stop the gopigo
+	GOPIGO_FIRMWARE_VERSION = 0x10 // get the version of the GoPiGo
+
+	GOPIGO_MOTOR1           = 0x6F // control motor 1
+	GOPIGO_MOTOR2           = 0x70 // control motor 2
+	GOPIGO_READ_MOTOR_SPEED = 0x72 // read motor speed back
+
+	GOPIGO_SET_LEFT_SPEED  = 0x46 // set speed for the left motor
+	GOPIGO_SET_RIGHT_SPEED = 0x47 // set speed for the left motor
+	GOPIGO_INCREASE_SPEED  = 0x74 // increase the speed by 10
+	GOPIGO_DECREASE_SPEED  = 0x67 // iecrease the speed by 10
+
+	GOPIGO_FORWARD        = 0x77 // move forward with PID control
+	GOPIGO_MOTOR_FORWARD  = 0x69 // move forward without PID control
+	GOPIGO_BACKWARD       = 0x73 // move backward with PID control
+	GOPIGO_MOTOR_BACKWARD = 0x6B // move backward without PID control
+
+	GOPIGO_TURN_LEFT    = 0x73 // turn left by turning off one motor
+	GOPIGO_TURN_RIGHT   = 0x64 // turn right by turning off one motor
+	GOPIGO_ROTATE_LEFT  = 0x62 // rotate left by running both motors is opposite direction
+	GOPIGO_ROTATE_RIGHT = 0x6E // rotate Right by running both motors is opposite direction
+
+	GOPIGO_ENABLE_ENCODER  = 0x33 // enable the encoders
+	GOPIGO_DISABLE_ENCODER = 0x34 // disable the encoders
+	GOPIGO_ENCODER_TARGET  = 0x30 // set the encoder targeting
+	GOPIGO_ENCODER_STATUS  = 0x35 // read encoder status
+
+	GOPIGO_ENABLE_SERVO  = 0x3d // enable the servo's
+	GOPIGO_DISABLE_SERVO = 0x3c // disable the servo's
+	GOPIGO_SERVO         = 0x65 // rotate the servo
+)
+
+type GoPiGoDriver struct {
+	name       string
+	connection I2c
+}
+
+func NewGoPiGoDriver(a I2c) *GoPiGoDriver {
+
+	return &GoPiGoDriver{
+		name:       "GoPiGo",
+		connection: a,
+	}
+}
+
+func (g *GoPiGoDriver) SetName(name string) {
+	g.name = name
+}
+
+// Name identifies this driver objectName identifies this driver object
+func (g *GoPiGoDriver) Name() string { return g.name }
+
+func (g *GoPiGoDriver) Start() error {
+	return g.connection.I2cStart(GOPIGO_ADDRESS)
+}
+
+// Halt terminates the driver
+func (g *GoPiGoDriver) Halt() error {
+	err := g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_STOP, 0, 0, 0})
+	if err != nil {
+		return err
+	}
+	return g.connection.Finalize()
+}
+
+func (g *GoPiGoDriver) Connection() gobot.Connection {
+	return g.connection
+}
+
+func (g *GoPiGoDriver) FirmwareVersion() (int, error) {
+	err := g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_FIRMWARE_VERSION, 0, 0, 0})
+	if err != nil {
+		return 0, err
+	}
+	time.Sleep(100 * time.Millisecond)
+	d, err := g.connection.I2cRead(GOPIGO_ADDRESS, 2)
+	if err != nil {
+		return 0, err
+	}
+	return int(d[0]), nil
+}
+
+// Motor1  controls motor 1
+func (g *GoPiGoDriver) Motor1(direction byte, speed byte) error {
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_MOTOR1, direction, speed, 0})
+}
+
+// Motor2 controls motor 2
+func (g *GoPiGoDriver) Motor2(direction byte, speed byte) error {
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_MOTOR2, direction, speed, 0})
+}
+
+func (g *GoPiGoDriver) SetLeftSpeed(speed byte) error {
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_SET_LEFT_SPEED, speed, 0, 0})
+}
+
+func (g *GoPiGoDriver) SetRightSpeed(speed byte) error {
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_SET_RIGHT_SPEED, speed, 0, 0})
+}
+
+// ReadMotorSpeed returns the current speed for motor 1 and 2
+func (g *GoPiGoDriver) ReadMotorSpeed() (byte, byte, error) {
+	err := g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_READ_MOTOR_SPEED, 0, 0, 0})
+	if err != nil {
+		return 0, 0, err
+	}
+	time.Sleep(100 * time.Millisecond)
+	d, err := g.connection.I2cRead(GOPIGO_ADDRESS, 2)
+	if err != nil {
+		return 0, 0, err
+	}
+	return d[0], d[1], nil
+}
+
+func (g *GoPiGoDriver) IncreaseSpeed() error {
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_INCREASE_SPEED, 0, 0, 0})
+}
+
+func (g *GoPiGoDriver) DecraesSpeed() error {
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_DECREASE_SPEED, 0, 0, 0})
+}
+
+// Forward drives the robot forward with PID control
+func (g *GoPiGoDriver) Forward() error {
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_FORWARD, 0, 0, 0})
+}
+
+// MotorForward drives forward without PID control
+func (g *GoPiGoDriver) MotorForward() error {
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_MOTOR_FORWARD, 0, 0, 0})
+}
+
+// Backward drives the robot forward with PID control
+func (g *GoPiGoDriver) Backward() error {
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_BACKWARD, 0, 0, 0})
+}
+
+// MotorBackward moves the robot backword with out PDI control
+func (g *GoPiGoDriver) MotorBackward() error {
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_MOTOR_BACKWARD, 0, 0, 0})
+}
+
+// TurnLeft by turning off one motor
+func (g *GoPiGoDriver) TurnLeft() error {
+	// return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIPO_TURN_LEFT, 0, 0, 0})
+	return nil
+}
+
+// TurnLeft by turning off one motor
+func (g *GoPiGoDriver) TurnRight() error {
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_TURN_RIGHT, 0, 0, 0})
+}
+
+// RotateLeft by running both motors is opposite direction
+func (g *GoPiGoDriver) RotateLeft() error {
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_ROTATE_LEFT, 0, 0, 0})
+}
+
+// RotateRight by running both motors is opposite direction
+func (g *GoPiGoDriver) RotateRight() error {
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_ROTATE_RIGHT, 0, 0, 0})
+}
+
+// // EncoderTurnLeft
+// func EncoderTurnLeft(degrees int) error {
+//
+// }
+//
+// func EncoderTurnRight(degrees int) error {
+//
+// }
+//
+// func EncoderForward(distance int) error {
+//
+// }
+//
+// func EncoderBackward(distance int) error {
+//
+// }
+
+// EnableEncoder turns the encoders on
+func (g *GoPiGoDriver) EnableEncoder() error {
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_ENABLE_ENCODER, 0, 0, 0})
+}
+
+// EnableEncoder turns the encoders off
+func (g *GoPiGoDriver) DisableEncoder() error {
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_DISABLE_ENCODER, 0, 0, 0})
+}
+
+// Set encoder targeting on for motor 1 and/or motor 2 with the number of encoder pulses
+func (g *GoPiGoDriver) EncoderTarget(motor1 bool, motor2 bool, pulses int) error {
+	motorSelect := byte(0)
+	if motor1 {
+		motorSelect += 2
+	}
+	if motor2 {
+		motorSelect += 1
+	}
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_ENCODER_TARGET, motorSelect, byte(pulses / 256), byte(pulses % 256)})
+}
+
+// TODO: figure this one out
+// func (g *GoPiGoDriver) EncoderStatus()
+
+// Volt reads the voltage in V
+func (g *GoPiGoDriver) Volt() (float64, error) {
+	// err := g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_VOLT, 0, 0, 0})
+	// if err != nil {
+	// 	return err
+	// }
+	// time.Sleep(100 * time.Millisecond)
+	// d, err := g.connection.I2cRead(GOPIGO_ADDRESS, 2)
+	// if err != nil {
+	// 	return err
+	// }
+	//
+	// return (d[0]*265 + d[1]) / 1024 / 0.4
+	return 0, nil
+}
+
+// Enable turns the servo on
+func (g *GoPiGoDriver) EnableServo() error {
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_ENABLE_SERVO, 0, 0, 0})
+}
+
+// DisableServo turns the servo off
+func (g *GoPiGoDriver) DisableServo() error {
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_DISABLE_SERVO, 0, 0, 0})
+}
+
+// Servo sets the servo to angle with degrees
+func (g *GoPiGoDriver) Servo(degrees byte) error {
+	return g.connection.I2cWrite(GOPIGO_ADDRESS, []byte{GOPIGO_SERVO, degrees, 0, 0})
+}

--- a/drivers/i2c/gopipo_driver_test.go
+++ b/drivers/i2c/gopipo_driver_test.go
@@ -1,0 +1,134 @@
+package i2c
+
+import (
+	"testing"
+	"time"
+
+	"log"
+
+	"github.com/hybridgroup/gobot"
+	"github.com/hybridgroup/gobot/drivers/gpio"
+	"github.com/hybridgroup/gobot/drivers/i2c"
+	"github.com/hybridgroup/gobot/gobottest"
+	"github.com/hybridgroup/gobot/platforms/gopigo"
+)
+
+// # This is the address for the GoPiGo
+// address = 0x08
+// debug=0
+// #GoPiGo Commands
+// fwd_cmd				=[119]		#Move forward with PID
+// motor_fwd_cmd		=[105]		#Move forward without PID
+// bwd_cmd				=[115]		#Move back with PID
+// motor_bwd_cmd		=[107]		#Move back without PID
+// left_cmd			=[97]		#Turn Left by turning off one motor
+// left_rot_cmd		=[98]		#Rotate left by running both motors is opposite direction
+// right_cmd			=[100]		#Turn Right by turning off one motor
+// right_rot_cmd		=[110]		#Rotate Right by running both motors is opposite direction
+// stop_cmd			=[120]		#Stop the GoPiGo
+// ispd_cmd			=[116]		#Increase the speed by 10
+// dspd_cmd			=[103]		#Decrease the speed by 10
+// m1_cmd      		=[111]     	#Control motor1
+// m2_cmd    			=[112]     	#Control motor2
+// read_motor_speed_cmd=[114]		#Get motor speed back
+//
+// volt_cmd			=[118]		#Read the voltage of the batteries
+// us_cmd				=[117]		#Read the distance from the ultrasonic sensor
+// led_cmd				=[108]		#Turn On/Off the LED's
+// servo_cmd			=[101]		#Rotate the servo
+// enc_tgt_cmd			=[50]		#Set the encoder targeting
+// fw_ver_cmd			=[20]		#Read the firmware version
+// en_enc_cmd			=[51]		#Enable the encoders
+// dis_enc_cmd			=[52]		#Disable the encoders
+// read_enc_status_cmd	=[53]		#Read encoder status
+// en_servo_cmd		=[61]		#Enable the servo's
+// dis_servo_cmd		=[60]		#Disable the servo's
+// set_left_speed_cmd	=[70]		#Set the speed of the right motor
+// set_right_speed_cmd	=[71]		#Set the speed of the left motor
+// en_com_timeout_cmd	=[80]		#Enable communication timeout
+// dis_com_timeout_cmd	=[81]		#Disable communication timeout
+// timeout_status_cmd	=[82]		#Read the timeout status
+// enc_read_cmd		=[53]		#Read encoder values
+// trim_test_cmd		=[30]		#Test the trim values
+// trim_write_cmd		=[31]		#Write the trim values
+// trim_read_cmd		=[32]
+//
+// digital_write_cmd   =[12]      	#Digital write on a port
+// digital_read_cmd    =[13]      	#Digital read on a port
+// analog_read_cmd     =[14]      	#Analog read on a port
+// analog_write_cmd    =[15]      	#Analog read on a port
+// pin_mode_cmd        =[16]      	#Set up the pin mode on a port
+//
+// ir_read_cmd			=[21]
+// ir_recv_pin_cmd		=[22]
+// cpu_speed_cmd		=[25]
+
+type i2cGoPiGoTestAdaptor struct {
+	t       *testing.T
+	asserts []byte
+}
+
+func (g *i2cGoPiGoTestAdaptor) I2cWrite(address int, data []byte) error {
+	gobottest.Assert(g.t, 0x08, address)
+
+	for i, a := range g.asserts {
+		gobottest.Assert(g.t, data[i], a)
+	}
+
+	return nil
+}
+
+func (g *i2cGoPiGoTestAdaptor) I2cRead(address int, len int) ([]byte, error) {
+	gobottest.Assert(g.t, 0x08, address)
+	return asserts, nil
+}
+
+func initTestGoPiGo(t *testing.T, asserts []byte) *GoPiGoDriver {
+	return &i2cGoPiGoTestAdaptor{
+		t:       t,
+		asserts: asserts,
+	}
+}
+
+func TestGoPiGoMotor1(t *testing.T) {
+	asserts := []byte{byte(111), 1, 10, 0}
+	g := initTestGoPiGo(t, asserts)
+	g.Motor1(1, 10)
+}
+
+func ExampleNewGoPiGoDriver() {
+	gpg, err := gopigo.NewAdaptor()
+	if err != nil {
+		log.Fatalf("failed to crate gopigo adaptor: %s", err)
+	}
+	err = gpg.PinMode(gopigo.PIN_LED_LEFT, gopigo.PIN_MODE_OUTPUT)
+	if err != nil {
+		log.Fatalf("failed to set output mode: %s", err)
+	}
+
+	led := gpio.NewLedDriver(gpg, gopigo.PIN_LED_LEFT)
+
+	gpgDriver := i2c.NewGoPiGoDriver(gpg)
+	work := func() {
+		v, err := gpgDriver.FirmwareVersion()
+		if err != nil {
+			log.Errorf("failed to read firmware version: %s", err)
+		}
+		log.Infof("firmware version: %d", v)
+
+		gobot.Every(1*time.Second, func() {
+			err = led.Toggle()
+			if err != nil {
+				log.Error("failed to toggle led: %s", err)
+			}
+		})
+	}
+	dex := gobot.NewRobot("moe",
+		[]gobot.Connection{gpg},
+		[]gobot.Device{gpgDriver},
+		work)
+	err = dex.Start()
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/platforms/gopigo/gopipo_adaptor.go
+++ b/platforms/gopigo/gopipo_adaptor.go
@@ -1,0 +1,149 @@
+package gopigo
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/hybridgroup/gobot/platforms/raspi"
+)
+
+const (
+	ADDRESS = 0x08
+
+	DIGITAL_WRITE = 0x0C // digital write on a port
+	DIGITAL_READ  = 0x0D // digital read on a port
+	ANALOG_READ   = 0x0E // analog read on a port
+	PWM_WRITE     = 0x0F // analog read on a port
+	PIN_MODE      = 0x10 // set up the pin mode on a port TODO: function
+
+	PIN_DIGITAL   = "10"
+	PIN_ANALOG    = "15"
+	PIN_LED_LEFT  = "16"
+	PIN_LED_RIGHT = "17"
+
+	PIN_MODE_OUTPUT = 0x01
+	PIN_MODE_INPUT  = 0x00
+)
+
+var pins = map[string]byte{
+	"0":  0,
+	"1":  1,
+	"10": 10,
+	"15": 15,
+}
+
+type GoPiGoAdaptor struct {
+	name  string
+	raspi *raspi.Adaptor
+}
+
+func NewAdaptor() (*GoPiGoAdaptor, error) {
+	g := &GoPiGoAdaptor{
+		name:  "GoPiGo",
+		raspi: raspi.NewAdaptor(),
+	}
+	err := g.raspi.I2cStart(ADDRESS)
+	if err != nil {
+		return nil, err
+	}
+	return g, nil
+}
+
+func (g *GoPiGoAdaptor) Connect() error {
+	return g.raspi.Connect()
+}
+
+func (g *GoPiGoAdaptor) Finalize() error {
+	return g.raspi.Finalize()
+}
+
+func (g *GoPiGoAdaptor) I2cStart(address int) error {
+	return g.raspi.I2cStart(address)
+}
+
+func (g *GoPiGoAdaptor) Name() string {
+	return g.name
+}
+
+func (g *GoPiGoAdaptor) SetName(name string) {
+	g.name = name
+}
+
+// DigitalRead reads the from pin
+func (g *GoPiGoAdaptor) DigitalRead(pin string) (int, error) {
+	p, err := strconv.Atoi(pin)
+	if err != nil {
+		return 0, err
+	}
+	err = g.I2cWrite(ADDRESS, []byte{DIGITAL_READ, byte(p), 0, 0})
+	if err != nil {
+		return 0, err
+	}
+	time.Sleep(100 * time.Millisecond)
+	d, err := g.I2cRead(ADDRESS, 2)
+	return int(d[0]), err
+}
+
+func (g *GoPiGoAdaptor) DigitalWrite(pin string, val byte) error {
+	p, err := strconv.Atoi(pin)
+	if err != nil {
+		return err
+	}
+	err = g.I2cWrite(ADDRESS, []byte{DIGITAL_WRITE, byte(p), val, 0})
+	return err
+}
+
+func (g *GoPiGoAdaptor) AnalogRead(pin string) (int, error) {
+	p, err := strconv.Atoi(pin)
+	if err != nil {
+		return 0, err
+	}
+	err = g.I2cWrite(ADDRESS, []byte{ANALOG_READ, byte(p), 0, 0})
+	if err != nil {
+		return 0, err
+	}
+	time.Sleep(100 * time.Millisecond)
+	d, err := g.I2cRead(ADDRESS, 2)
+	if err != nil {
+		return 0, err
+	}
+	return int(d[0])*256 + int(d[1]), nil
+}
+
+func (g *GoPiGoAdaptor) PwmWrite(pin string, val byte) error {
+	p, err := strconv.Atoi(pin)
+	if err != nil {
+		return err
+	}
+	err = g.I2cWrite(ADDRESS, []byte{PWM_WRITE, byte(p), val, 0})
+	return err
+}
+
+func (g *GoPiGoAdaptor) I2cWrite(address int, data []byte) error {
+	err := g.raspi.I2cWrite(address, data)
+	time.Sleep(5 * time.Millisecond)
+	return err
+}
+
+func (g *GoPiGoAdaptor) I2cRead(address int, size int) ([]byte, error) {
+	buf := make([]byte, size)
+	for i := 0; i < size; i++ {
+		d, err := g.raspi.I2cRead(address, size)
+		buf[i] = d[0]
+		if err != nil {
+			return nil, err
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return buf, nil
+}
+
+func (g *GoPiGoAdaptor) PinMode(pin string, mode byte) error {
+	p, err := strconv.Atoi(pin)
+	if err != nil {
+		return err
+	}
+	err = g.raspi.I2cWrite(ADDRESS, []byte{PIN_MODE, byte(p), mode, 0})
+	time.Sleep(5 * time.Millisecond)
+	return err
+}


### PR DESCRIPTION
This is a WIP pull request to get feedback and help on the design. 
Furthermore this is the first time I'm working with Gobot and the GoPiGo platform, so if some of the decisions I make seem totally bonkers feel free to correct me.  

The implementation is based of the Python and C implementation from [Dexter Industries](https://github.com/DexterInd/GoPiGo/tree/master/Software).

Some questions regarding the design:

The `NewGoPiPoAdaptor` returns an error because it starts the I2C communication between the Rasberry Pi and the GoPiGo board. Can it stay this way or should the start call to I2C be moved into its own method?  

At the moment the commands to control the robot are tied to the platform. Should this be moved 
into one or multiple drivers?

I implemented the `DigitalRead` Method as an example for the Gobot interface. The pin gets translated with the help of the `pins` map. The pin numbers are limited because of the way its done in the [Python implementation](https://github.com/DexterInd/GoPiGo/blob/master/Software/Python/gopigo.py#L298).
And returns `erros.New("no such pin")` if a wrong pin number is provided.
@DexterInd can you tell me why it's limited this way in the read methods but in the wirte methods its commented out?  

The I2C communication uses it's own buffer for every call. I could use one global buffer to reduce 
the GC noise but then I would need to take care of concurrent API calls? 

The next question is about how much work should be offloaded into the Adaptor.
One example: 
To turn the robot 90° left it's necessary to do the Encoder calculations for movement manually:
```go
gopigo.EncoderTarget(false, true, 90/360.0/64)
gopigo.TurnLeft()
```
I cloud change the movement methods to:
```go
// 0 disables the encoder
func (g *GoPiGoAdaptor) TurnLeft(degrees int) 
```
Or:
```
// passing no value disables the encoder
func (g *GoPiGoAdaptor) TurnLeft(degrees ...int)
```
This would affect methods like `Forward` where it would be possible specify a distance in cm. 