### PR TITLE
Adds note about the kernel version for CHIP

### DIFF
--- a/platforms/chip/README.md
+++ b/platforms/chip/README.md
@@ -2,6 +2,10 @@
 
 The [CHIP](http://www.getchip.com/) is a small, inexpensive ARM based single board computer, with many different IO interfaces available on the [pin headers](http://docs.getchip.com/#pin-headers).
 
+The current ChipAdaptor will only work with CHIP devices running OS 4.3.
+This is because of the change in the GPIO expander pins between kernel
+versions OS 4.3 vs. OS 4.4. See [here](http://docs.getchip.com/chip.html#gpio) for more details.
+
 For documentation about the CHIP platform click [here](http://docs.getchip.com/).
 
 ## How to Install


### PR DESCRIPTION
- The current ChipAdaptor will only support OS 4.3 because of the
GPIO pin mapping.

See http://docs.getchip.com/chip.html#gpio for more details.

Signed-off-by: Warren Fernandes <warren.f.fernandes@gmail.com>