### PR TITLE
platforms/firmata/client: use io.ReadFull

### DIFF
--- a/platforms/firmata/client/client.go
+++ b/platforms/firmata/client/client.go
@@ -315,21 +315,9 @@ func (b *Client) write(data []byte) (err error) {
 	return
 }
 
-func (b *Client) read(length int) (buf []byte, err error) {
-	i := 0
-	for length > 0 {
-		tmp := make([]byte, length)
-		if i, err = b.connection.Read(tmp); err != nil {
-			if err.Error() != "EOF" {
-				return
-			}
-			<-time.After(5 * time.Millisecond)
-		}
-		if i > 0 {
-			buf = append(buf, tmp...)
-			length = length - i
-		}
-	}
+func (b *Client) read(n int) (buf []byte, err error) {
+	buf = make([]byte, n)
+	_, err = io.ReadFull(b.connection, buf)
 	return
 }
 


### PR DESCRIPTION
This CL uses io.ReadFull to make sure exactly n bytes are read, and
correctly handle io.EOF and co.

Fixes #343.