### PR TITLE
Change to make I2C support more than one bus and other access methods than "block"

### DIFF
--- a/drivers/i2c/helpers_test.go
+++ b/drivers/i2c/helpers_test.go
@@ -17,21 +17,74 @@ var blue = castColor("blue")
 type i2cTestAdaptor struct {
 	name         string
 	written      []byte
+	pos          int
 	i2cReadImpl  func() ([]byte, error)
 	i2cWriteImpl func() error
 	i2cStartImpl func() error
 }
 
 func (t *i2cTestAdaptor) I2cStart(int) (err error) {
+	t.pos = 0
 	return t.i2cStartImpl()
 }
+
 func (t *i2cTestAdaptor) I2cRead(int, int) (data []byte, err error) {
 	return t.i2cReadImpl()
 }
+
 func (t *i2cTestAdaptor) I2cWrite(address int, b []byte) (err error) {
 	t.written = append(t.written, b...)
 	return t.i2cWriteImpl()
 }
+
+func (t *i2cTestAdaptor) ReadByte() (val uint8, err error) {
+	bytes, err := t.i2cReadImpl()
+	val = bytes[t.pos]
+	t.pos++
+	return
+}
+
+func (t *i2cTestAdaptor) ReadByteData(reg uint8) (val uint8, err error) {
+	bytes, err := t.i2cReadImpl()
+	return bytes[reg], err
+}
+
+func (t *i2cTestAdaptor) ReadWordData(reg uint8) (val uint16, err error) {
+	bytes, err := t.i2cReadImpl()
+	low, high := bytes[reg], bytes[reg + 1]
+	return (uint16(high) << 8) | uint16(low), err
+}
+
+func (t *i2cTestAdaptor) ReadBlockData(b []byte) (n int, err error) {
+	reg := b[0]
+	bytes, err := t.i2cReadImpl()
+	copy(b, bytes[reg:])
+	return len(b), err
+}
+
+func (t *i2cTestAdaptor) WriteByte(val uint8) (err error) {
+	t.pos = int(val)
+	t.written = append(t.written, val)
+	return t.i2cWriteImpl()
+}
+
+func (t *i2cTestAdaptor) WriteByteData(reg uint8, val uint8) (err error) {
+	t.pos = int(reg)
+	t.written = append(t.written, reg)
+	t.written = append(t.written, val)
+	return t.i2cWriteImpl()
+}
+
+func (t *i2cTestAdaptor) WriteBlockData(b []byte) (err error) {
+	t.pos = int(b[0])
+	t.written = append(t.written, b...)
+	return t.i2cWriteImpl()
+}
+
+func (t *i2cTestAdaptor) I2cGetConnection( /* address */ int /* bus */, int) (connection I2cConnection, err error) {
+	return t, nil
+}
+
 func (t *i2cTestAdaptor) Name() string          { return t.name }
 func (t *i2cTestAdaptor) SetName(n string)      { t.name = n }
 func (t *i2cTestAdaptor) Connect() (err error)  { return }

--- a/drivers/i2c/i2c.go
+++ b/drivers/i2c/i2c.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/sysfs"
 )
 
 var (
@@ -21,14 +22,27 @@ const (
 )
 
 type I2cStarter interface {
+	// I2cStart initializes I2C communication to a device at a specified address
+	// on the default bus for further access using I2cRead() and I2cWrite().
 	I2cStart(address int) (err error)
 }
 
 type I2cReader interface {
+	// I2cStart reads len bytes from a device at the specified address using
+	// block reads.
+	//
+	// Note: There is no way to specify command/register to read from using
+	// this interface, it always starts reading from register 0.
+	// To read register 42 you have to read 43 bytes (0 to 42)
+	// and throw away the first 42 bytes.
 	I2cRead(address int, len int) (data []byte, err error)
 }
 
 type I2cWriter interface {
+	// I2cWrite writes a buffer of bytes to the device at the specified address
+	// using block writes.
+	// Note that the first byte in the buffer is interpreted as the target
+	// command/register.
 	I2cWrite(address int, buf []byte) (err error)
 }
 
@@ -37,4 +51,76 @@ type I2c interface {
 	I2cStarter
 	I2cReader
 	I2cWriter
+}
+
+// I2cConnection is a connection to an I2C device with a specified address
+// on a specific bus. Used as an alternative to the I2c interface.
+// Implements sysfs.SMBusOperations to talk to the device, wrapping the
+// calls in SetAddress to always target the specified device.
+// Provided by an Adaptor by implementing the I2cConnector interface.
+type I2cConnection sysfs.SMBusOperations
+
+type i2cConnection struct {
+	bus     sysfs.I2cDevice
+	address int
+}
+
+func NewI2cConnection(bus sysfs.I2cDevice, address int) (connection *i2cConnection) {
+	return &i2cConnection{bus: bus, address: address}
+}
+
+func (c *i2cConnection) ReadByte() (val uint8, err error) {
+	if err := c.bus.SetAddress(c.address); err != nil {
+		return 0, err
+	}
+	return c.bus.ReadByte()
+}
+
+func (c *i2cConnection) ReadByteData(reg uint8) (val uint8, err error) {
+	if err := c.bus.SetAddress(c.address); err != nil {
+		return 0, err
+	}
+	return c.bus.ReadByteData(reg)
+}
+
+func (c *i2cConnection) ReadWordData(reg uint8) (val uint16, err error) {
+	if err := c.bus.SetAddress(c.address); err != nil {
+		return 0, err
+	}
+	return c.bus.ReadWordData(reg)
+}
+
+func (c *i2cConnection) ReadBlockData(b []byte) (n int, err error) {
+	if err := c.bus.SetAddress(c.address); err != nil {
+		return 0, err
+	}
+	return c.bus.ReadBlockData(b)
+}
+
+func (c *i2cConnection) WriteByte(val uint8) (err error) {
+	if err := c.bus.SetAddress(c.address); err != nil {
+		return err
+	}
+	return c.bus.WriteByte(val)
+}
+
+func (c *i2cConnection) WriteByteData(reg uint8, val uint8) (err error) {
+	if err := c.bus.SetAddress(c.address); err != nil {
+		return err
+	}
+	return c.bus.WriteByteData(reg, val)
+}
+
+func (c *i2cConnection) WriteBlockData(b []byte) (err error) {
+	if err := c.bus.SetAddress(c.address); err != nil {
+		return err
+	}
+	return c.bus.WriteBlockData(b)
+}
+
+// I2cConnector is a replacement to the I2c interface, providing
+// access to more than one I2C bus per adaptor, and a more
+// fine grained interface to the I2C bus.
+type I2cConnector interface {
+	I2cGetConnection(address int, bus int) (device I2cConnection, err error)
 }

--- a/platforms/chip/chip_adaptor.go
+++ b/platforms/chip/chip_adaptor.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	multierror "github.com/hashicorp/go-multierror"
+	"gobot.io/x/gobot/drivers/i2c"
 	"gobot.io/x/gobot/sysfs"
 )
 
@@ -17,7 +18,7 @@ type Adaptor struct {
 	name        string
 	digitalPins map[int]sysfs.DigitalPin
 	pinMap      map[string]int
-	i2cDevice   sysfs.I2cDevice
+	i2cBuses    [3]sysfs.I2cDevice
 }
 
 var fixedPins = map[string]int{
@@ -102,9 +103,11 @@ func (c *Adaptor) Finalize() (err error) {
 			}
 		}
 	}
-	if c.i2cDevice != nil {
-		if e := c.i2cDevice.Close(); e != nil {
-			err = multierror.Append(err, e)
+	for _, bus := range c.i2cBuses {
+		if bus != nil {
+			if e := bus.Close(); e != nil {
+				err = multierror.Append(err, e)
+			}
 		}
 	}
 	return
@@ -174,28 +177,28 @@ func (c *Adaptor) DigitalWrite(pin string, val byte) (err error) {
 // This assumes that the bus used is /dev/i2c-1, which corresponds to
 // pins labeled TWI1-SDA and TW1-SCK (pins 9 and 11 on header 13).
 func (c *Adaptor) I2cStart(address int) (err error) {
-	if c.i2cDevice == nil {
-		c.i2cDevice, err = sysfs.NewI2cDevice("/dev/i2c-1", address)
+	if c.i2cBuses[1] == nil {
+		c.i2cBuses[1], err = sysfs.NewI2cDevice("/dev/i2c-1", address)
 	}
 	return err
 }
 
 // I2cWrite writes data to i2c device
 func (c *Adaptor) I2cWrite(address int, data []byte) (err error) {
-	if err = c.i2cDevice.SetAddress(address); err != nil {
+	if err = c.i2cBuses[1].SetAddress(address); err != nil {
 		return
 	}
-	_, err = c.i2cDevice.Write(data)
+	_, err = c.i2cBuses[1].Write(data)
 	return
 }
 
 // I2cRead returns value from i2c device using specified size
 func (c *Adaptor) I2cRead(address int, size int) (data []byte, err error) {
-	if err = c.i2cDevice.SetAddress(address); err != nil {
+	if err = c.i2cBuses[1].SetAddress(address); err != nil {
 		return
 	}
 	data = make([]byte, size)
-	_, err = c.i2cDevice.Read(data)
+	_, err = c.i2cBuses[1].Read(data)
 	return
 }
 
@@ -227,4 +230,16 @@ func getXIOBase() (baseAddr int, err error) {
 	}
 
 	return baseAddr, nil
+}
+
+// I2cGetConnection returns a connection to a device on a specified bus.
+// Valid bus number is [0..2] which corresponds to /dev/i2c-0 through /dev/i2c-2.
+func (c *Adaptor) I2cGetConnection(address int, bus int) (connection i2c.I2cConnection, err error) {
+	if (bus < 0) || (bus > 2) {
+		return nil, fmt.Errorf("Bus number %d out of range", bus)
+	}
+	if c.i2cBuses[bus] == nil {
+		c.i2cBuses[bus], err = sysfs.NewI2cDevice(fmt.Sprintf("/dev/i2c-%d", bus))
+	}
+	return i2c.NewI2cConnection(c.i2cBuses[bus], address), err
 }

--- a/platforms/chip/chip_adaptor_test.go
+++ b/platforms/chip/chip_adaptor_test.go
@@ -81,8 +81,6 @@ func TestChipAdaptorI2c(t *testing.T) {
 	sysfs.SetFilesystem(fs)
 	sysfs.SetSyscall(&sysfs.MockSyscall{})
 	a.I2cStart(0xff)
-	a.i2cDevice = &NullReadWriteCloser{}
-
 	a.I2cWrite(0xff, []byte{0x00, 0x01})
 	data, _ := a.I2cRead(0xff, 2)
 	gobottest.Assert(t, data, []byte{0x00, 0x01})

--- a/sysfs/i2c_device.go
+++ b/sysfs/i2c_device.go
@@ -9,16 +9,28 @@ import (
 )
 
 const (
-	I2C_SLAVE                = 0x0703
-	I2C_SMBUS                = 0x0720
-	I2C_SMBUS_WRITE          = 0
-	I2C_SMBUS_READ           = 1
-	I2C_SMBUS_I2C_BLOCK_DATA = 8
-
+	// ioctl signals
+	I2C_SLAVE = 0x0703
+	I2C_FUNCS = 0x0705
+	I2C_SMBUS = 0x0720
+	// Read/write markers
+	I2C_SMBUS_READ  = 1
+	I2C_SMBUS_WRITE = 0
 	// Adapter functionality
-	I2C_FUNCS                       = 0x0705
 	I2C_FUNC_SMBUS_READ_BLOCK_DATA  = 0x01000000
 	I2C_FUNC_SMBUS_WRITE_BLOCK_DATA = 0x02000000
+	// Transaction types
+	I2C_SMBUS_BYTE                = 1
+	I2C_SMBUS_BYTE_DATA           = 2
+	I2C_SMBUS_WORD_DATA           = 3
+	I2C_SMBUS_PROC_CALL           = 4
+	I2C_SMBUS_BLOCK_DATA          = 5
+	I2C_SMBUS_I2C_BLOCK_DATA      = 6
+	I2C_SMBUS_BLOCK_PROC_CALL     = 7  /* SMBus 2.0 */
+	I2C_SMBUS_BLOCK_DATA_PEC      = 8  /* SMBus 2.0 */
+	I2C_SMBUS_PROC_CALL_PEC       = 9  /* SMBus 2.0 */
+	I2C_SMBUS_BLOCK_PROC_CALL_PEC = 10 /* SMBus 2.0 */
+	I2C_SMBUS_WORD_DATA_PEC       = 11 /* SMBus 2.0 */
 )
 
 type i2cSmbusIoctlData struct {
@@ -28,9 +40,20 @@ type i2cSmbusIoctlData struct {
 	data      uintptr
 }
 
+type SMBusOperations interface {
+	ReadByte() (val uint8, err error)
+	ReadByteData(reg uint8) (val uint8, err error)
+	ReadWordData(reg uint8) (val uint16, err error)
+	ReadBlockData(b []byte) (n int, err error)
+	WriteByte(val uint8) (err error)
+	WriteByteData(reg uint8, val uint8) (err error)
+	WriteBlockData(b []byte) (err error)
+}
+
 // I2cDevice is the interface to a specific i2c bus
 type I2cDevice interface {
 	io.ReadWriteCloser
+	SMBusOperations
 	SetAddress(int) error
 }
 
@@ -40,8 +63,9 @@ type i2cDevice struct {
 }
 
 // NewI2cDevice returns an io.ReadWriteCloser with the proper ioctrl given
-// an i2c bus location and device address
-func NewI2cDevice(location string, address int) (d *i2cDevice, err error) {
+// an i2c bus location.
+// Device address parameter is optional and kept for compatibility reasons.
+func NewI2cDevice(location string, address ...int) (d *i2cDevice, err error) {
 	d = &i2cDevice{}
 
 	if d.file, err = OpenFile(location, os.O_RDWR, os.ModeExclusive); err != nil {
@@ -51,7 +75,9 @@ func NewI2cDevice(location string, address int) (d *i2cDevice, err error) {
 		return
 	}
 
-	err = d.SetAddress(address)
+	if len(address) > 0 {
+		err = d.SetAddress(address[0])
+	}
 
 	return
 }
@@ -89,63 +115,98 @@ func (d *i2cDevice) Close() (err error) {
 	return d.file.Close()
 }
 
+func (d *i2cDevice) ReadByte() (val uint8, err error) {
+	var data uint8
+	err = d.smbusAccess(I2C_SMBUS_READ, 0, I2C_SMBUS_BYTE, uintptr(unsafe.Pointer(&data)))
+	return data, err
+}
+
+func (d *i2cDevice) ReadByteData(reg uint8) (val uint8, err error) {
+	var data uint8
+	err = d.smbusAccess(I2C_SMBUS_READ, reg, I2C_SMBUS_BYTE_DATA, uintptr(unsafe.Pointer(&data)))
+	return data, err
+}
+
+func (d *i2cDevice) ReadWordData(reg uint8) (val uint16, err error) {
+	var data uint16
+	err = d.smbusAccess(I2C_SMBUS_READ, reg, I2C_SMBUS_WORD_DATA, uintptr(unsafe.Pointer(&data)))
+	return data, err
+}
+
+func (d *i2cDevice) ReadBlockData(b []byte) (n int, err error) {
+	// Command byte - a data byte which often selects a register on the device:
+	// 	https://www.kernel.org/doc/Documentation/i2c/smbus-protocol
+	command := byte(b[0])
+	buf := b[1:]
+
+	data := make([]byte, len(buf)+1)
+	data[0] = byte(len(buf))
+
+	copy(data[1:], buf)
+
+	err = d.smbusAccess(I2C_SMBUS_READ, command, I2C_SMBUS_I2C_BLOCK_DATA, uintptr(unsafe.Pointer(&data[0])))
+
+	copy(b, data[1:])
+	return int(data[0]), err
+}
+
+func (d *i2cDevice) WriteByte(val uint8) (err error) {
+	err = d.smbusAccess(I2C_SMBUS_WRITE, val, I2C_SMBUS_BYTE, uintptr(0))
+	return err
+}
+
+func (d *i2cDevice) WriteByteData(reg uint8, val uint8) (err error) {
+	var data uint8 = val
+	err = d.smbusAccess(I2C_SMBUS_WRITE, reg, I2C_SMBUS_BYTE_DATA, uintptr(unsafe.Pointer(&data)))
+	return err
+}
+
+func (d *i2cDevice) WriteBlockData(b []byte) (err error) {
+	// Command byte - a data byte which often selects a register on the device:
+	// 	https://www.kernel.org/doc/Documentation/i2c/smbus-protocol
+	command := byte(b[0])
+	buf := b[1:]
+
+	data := make([]byte, len(buf)+1)
+	data[0] = byte(len(buf))
+
+	copy(data[1:], buf)
+
+	err = d.smbusAccess(I2C_SMBUS_WRITE, command, I2C_SMBUS_I2C_BLOCK_DATA, uintptr(unsafe.Pointer(&data[0])))
+
+	return err
+}
+
+// Read implements the io.ReadWriteCloser method by SMBus block data reads.
+// If SMBus block read is not supported, direct read (i2c mode) is performed
+// instead.
 func (d *i2cDevice) Read(b []byte) (n int, err error) {
 	if d.funcs&I2C_FUNC_SMBUS_READ_BLOCK_DATA == 0 {
 		// Adapter doesn't support SMBus block read
 		return d.file.Read(b)
 	}
 
-	// Command byte - a data byte which often selects a register on the device:
-	// 	https://www.kernel.org/doc/Documentation/i2c/smbus-protocol
-	command := byte(b[0])
-	buf := b[1:]
-	data := make([]byte, len(buf)+1)
-	data[0] = byte(len(buf))
-	copy(data[1:], buf)
-
-	smbus := &i2cSmbusIoctlData{
-		readWrite: I2C_SMBUS_READ,
-		command:   command,
-		size:      I2C_SMBUS_I2C_BLOCK_DATA,
-		data:      uintptr(unsafe.Pointer(&data[0])),
-	}
-	_, _, errno := Syscall(
-		syscall.SYS_IOCTL,
-		d.file.Fd(),
-		I2C_SMBUS,
-		uintptr(unsafe.Pointer(smbus)),
-	)
-
-	if errno != 0 {
-		return n, fmt.Errorf("Read failed with syscall.Errno %v", errno)
-	}
-
-	copy(b, data[1:])
-
-	return int(data[0]), nil
+	return d.ReadBlockData(b)
 }
 
+// Write implements the io.ReadWriteCloser method by SMBus block data writes.
+// If SMBus block write is not supported, direct write (i2c mode) is performed
+// instead.
 func (d *i2cDevice) Write(b []byte) (n int, err error) {
 	if d.funcs&I2C_FUNC_SMBUS_WRITE_BLOCK_DATA == 0 {
 		// Adapter doesn't support SMBus block write
 		return d.file.Write(b)
 	}
 
-	// Command byte - a data byte which often selects a register on the device:
-	// 	https://www.kernel.org/doc/Documentation/i2c/smbus-protocol
-	command := byte(b[0])
-	buf := b[1:]
+	return len(b), d.WriteBlockData(b)
+}
 
-	data := make([]byte, len(buf)+1)
-	data[0] = byte(len(buf))
-
-	copy(data[1:], buf)
-
+func (d *i2cDevice) smbusAccess(readWrite byte, command byte, size uint32, data uintptr) error {
 	smbus := &i2cSmbusIoctlData{
-		readWrite: I2C_SMBUS_WRITE,
+		readWrite: readWrite,
 		command:   command,
-		size:      I2C_SMBUS_I2C_BLOCK_DATA,
-		data:      uintptr(unsafe.Pointer(&data[0])),
+		size:      size,
+		data:      data,
 	}
 
 	_, _, errno := Syscall(
@@ -156,8 +217,8 @@ func (d *i2cDevice) Write(b []byte) (n int, err error) {
 	)
 
 	if errno != 0 {
-		err = fmt.Errorf("Write failed with syscall.Errno %v", errno)
+		return fmt.Errorf("Failed with syscall.Errno %v", errno)
 	}
 
-	return len(b), err
+	return nil
 }


### PR DESCRIPTION
Hi there!

These are my suggested changes to the I2C interface.

Based on the changes discussed in https://github.com/hybridgroup/gobot/issues/247,
I started out with @abourget's changes to sysfs, and added a new layer in drivers/i2c
to support multiple buses.

The old interface is kept in parallel, I've only implemented the required platform
changes in the c.h.i.p adaptor.

For adaptors, there is a new interface, which replaces the I2c interface: 

```
type I2cConnector interface {
	I2cGetConnection(address int, bus int) (device I2cConnection, err error)
}
```

Driver implementations will then use this interface to get a connection to a
device at a given address + bus combination.

I've also added more fine grained I2C methods than just block read / write,
which simplifies driver implementation.

See https://github.com/erkkah/gobot/blob/tsl2561-driver/drivers/i2c/tsl2561_driver.go
for a driver example using the new interface.
