### PR TITLE
fix typo and use actual error

### DIFF
--- a/platforms/ble/ble_client_adaptor.go
+++ b/platforms/ble/ble_client_adaptor.go
@@ -39,7 +39,7 @@ func (b *ClientAdaptor) Peripheral() gatt.Peripheral { return b.peripheral }
 func (b *ClientAdaptor) Connect() (err error) {
 	device, e := gatt.NewDevice(DefaultClientOptions...)
 	if e != nil {
-		log.Fatalf("Failed to open BLE device, err: %s\n", err)
+		log.Fatalf("Failed to open BLE device, err: %s\n", e)
 		return e
 	}
 


### PR DESCRIPTION
Hello. While trying out gobot, got the following error:

```
2017/02/07 01:25:44 Failed to open BLE device, err: %!s(<nil>)
```

this patch fixes it to
```
2017/02/07 02:03:11 Failed to open BLE device, err: no supported devices available
```