### PR TITLE
Removing SMBus block operations from I2C layer

### DIFF
--- a/drivers/i2c/i2c.go
+++ b/drivers/i2c/i2c.go
@@ -103,14 +103,6 @@ func (c *i2cConnection) ReadWordData(reg uint8) (val uint16, err error) {
 	return c.bus.ReadWordData(reg)
 }
 
-// ReadBlockData reads a block of bytes for a register on the i2c device.
-func (c *i2cConnection) ReadBlockData(reg uint8, b []byte) (n int, err error) {
-	if err := c.bus.SetAddress(c.address); err != nil {
-		return 0, err
-	}
-	return c.bus.ReadBlockData(reg, b)
-}
-
 // WriteByte writes a single byte to the i2c device.
 func (c *i2cConnection) WriteByte(val byte) (err error) {
 	if err := c.bus.SetAddress(c.address); err != nil {

--- a/drivers/i2c/i2c_test.go
+++ b/drivers/i2c/i2c_test.go
@@ -53,12 +53,6 @@ func TestI2CReadWordData(t *testing.T) {
 	gobottest.Assert(t, v, uint16(0))
 }
 
-func TestI2CReadBlockData(t *testing.T) {
-	c := NewConnection(initI2CDevice(), 0x06)
-	i, _ := c.ReadBlockData(0x01, []byte{})
-	gobottest.Assert(t, i, 0)
-}
-
 func TestI2CWriteByte(t *testing.T) {
 	c := NewConnection(initI2CDevice(), 0x06)
 	err := c.WriteByte(0x01)
@@ -77,8 +71,8 @@ func TestI2CWriteWordData(t *testing.T) {
 	gobottest.Assert(t, err, nil)
 }
 
-func TestI2CWriteBlockDataErrNotSupported(t *testing.T) {
+func TestI2CWriteBlockData(t *testing.T) {
 	c := NewConnection(initI2CDevice(), 0x06)
 	err := c.WriteBlockData(0x01, []byte{0x01, 0x02})
-	gobottest.Refute(t, err, nil)
+	gobottest.Assert(t, err, nil)
 }

--- a/sysfs/i2c_device.go
+++ b/sysfs/i2c_device.go
@@ -9,6 +9,7 @@ import (
 )
 
 const (
+	// From  /usr/include/linux/i2c-dev.h:
 	// ioctl signals
 	I2C_SLAVE = 0x0703
 	I2C_FUNCS = 0x0705
@@ -16,7 +17,15 @@ const (
 	// Read/write markers
 	I2C_SMBUS_READ  = 1
 	I2C_SMBUS_WRITE = 0
+
+	// From  /usr/include/linux/i2c.h:
 	// Adapter functionality
+	I2C_FUNC_SMBUS_READ_BYTE        = 0x00020000
+	I2C_FUNC_SMBUS_WRITE_BYTE       = 0x00040000
+	I2C_FUNC_SMBUS_READ_BYTE_DATA   = 0x00080000
+	I2C_FUNC_SMBUS_WRITE_BYTE_DATA  = 0x00100000
+	I2C_FUNC_SMBUS_READ_WORD_DATA   = 0x00200000
+	I2C_FUNC_SMBUS_WRITE_WORD_DATA  = 0x00400000
 	I2C_FUNC_SMBUS_READ_BLOCK_DATA  = 0x01000000
 	I2C_FUNC_SMBUS_WRITE_BLOCK_DATA = 0x02000000
 	// Transaction types
@@ -108,35 +117,59 @@ func (d *i2cDevice) Close() (err error) {
 }
 
 func (d *i2cDevice) ReadByte() (val uint8, err error) {
+	if d.funcs&I2C_FUNC_SMBUS_READ_BYTE == 0 {
+		return 0, fmt.Errorf("SMBus read byte not supported")
+	}
+
 	var data uint8
 	err = d.smbusAccess(I2C_SMBUS_READ, 0, I2C_SMBUS_BYTE, uintptr(unsafe.Pointer(&data)))
 	return data, err
 }
 
 func (d *i2cDevice) ReadByteData(reg uint8) (val uint8, err error) {
+	if d.funcs&I2C_FUNC_SMBUS_READ_BYTE_DATA == 0 {
+		return 0, fmt.Errorf("SMBus read byte data not supported")
+	}
+
 	var data uint8
 	err = d.smbusAccess(I2C_SMBUS_READ, reg, I2C_SMBUS_BYTE_DATA, uintptr(unsafe.Pointer(&data)))
 	return data, err
 }
 
 func (d *i2cDevice) ReadWordData(reg uint8) (val uint16, err error) {
+	if d.funcs&I2C_FUNC_SMBUS_READ_WORD_DATA == 0 {
+		return 0, fmt.Errorf("SMBus read word data not supported")
+	}
+
 	var data uint16
 	err = d.smbusAccess(I2C_SMBUS_READ, reg, I2C_SMBUS_WORD_DATA, uintptr(unsafe.Pointer(&data)))
 	return data, err
 }
 
 func (d *i2cDevice) WriteByte(val uint8) (err error) {
+	if d.funcs&I2C_FUNC_SMBUS_WRITE_BYTE == 0 {
+		return fmt.Errorf("SMBus write byte not supported")
+	}
+
 	err = d.smbusAccess(I2C_SMBUS_WRITE, val, I2C_SMBUS_BYTE, uintptr(0))
 	return err
 }
 
 func (d *i2cDevice) WriteByteData(reg uint8, val uint8) (err error) {
+	if d.funcs&I2C_FUNC_SMBUS_WRITE_BYTE_DATA == 0 {
+		return fmt.Errorf("SMBus write byte data not supported")
+	}
+
 	var data = val
 	err = d.smbusAccess(I2C_SMBUS_WRITE, reg, I2C_SMBUS_BYTE_DATA, uintptr(unsafe.Pointer(&data)))
 	return err
 }
 
 func (d *i2cDevice) WriteWordData(reg uint8, val uint16) (err error) {
+	if d.funcs&I2C_FUNC_SMBUS_WRITE_WORD_DATA == 0 {
+		return fmt.Errorf("SMBus write word data not supported")
+	}
+
 	var data = val
 	err = d.smbusAccess(I2C_SMBUS_WRITE, reg, I2C_SMBUS_WORD_DATA, uintptr(unsafe.Pointer(&data)))
 	return err

--- a/sysfs/syscall.go
+++ b/sysfs/syscall.go
@@ -13,7 +13,9 @@ type SystemCaller interface {
 type NativeSyscall struct{}
 
 // MockSyscall represents the mock Syscall
-type MockSyscall struct{}
+type MockSyscall struct {
+	Impl func(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err syscall.Errno)
+}
 
 var sys SystemCaller = &NativeSyscall{}
 
@@ -34,5 +36,9 @@ func (sys *NativeSyscall) Syscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err
 
 // Syscall implements the SystemCaller interface
 func (sys *MockSyscall) Syscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err syscall.Errno) {
-	return 0, 0, 0
+	if sys.Impl != nil {
+		return sys.Impl(trap, a1, a2, a3)
+	} else {
+		return 0, 0, 0
+	}
 }


### PR DESCRIPTION
This is a PR to resolve issue #372, by removing SMBus block operations from the sysfs I2C implementation. 
Also includes a tweak to the sysfs mocking layer to allow implementation of tests depending on syscall responses.