### PR TITLE
Hardware PWM support for the C.H.I.P

### DIFF
--- a/platforms/chip/README.md
+++ b/platforms/chip/README.md
@@ -53,6 +53,63 @@ func main() {
 }
 ```
 
+## Using the overlay manager
+
+The C.H.I.P platform adapter includes an overlay manager for building
+and installing device tree overlays for optional features PWM0 and SPI2.
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+    "time"
+
+    "gobot.io/x/gobot"
+    "gobot.io/x/gobot/drivers/gpio"
+    "gobot.io/x/gobot/platforms/chip"
+)
+
+func main() {
+    chipAdaptor := chip.NewAdaptor()
+
+    if err := chip.BuildAndInstallOverlays(); err != nil {
+        log.Println(err)
+        log.Fatal("Failed to build and install overlays")
+    }
+
+    if err := chip.LoadOverlay("PWM0"); err != nil {
+        fmt.Printf("Failed to load overlay: %v\n", err)
+        log.Fatal(err)
+    }
+
+    servo := gpio.NewServoDriver(chipAdaptor, "PWM0")
+
+    work := func() {
+        gobot.Every(10*time.Second, func() {
+            err := servo.Move(0)
+            if err != nil {
+                fmt.Printf("Failed to move servo: %v\n", err)
+                return
+            }
+            time.Sleep(1 * time.Second)
+            err = servo.Move(180)
+            time.Sleep(1 * time.Second)
+        })
+    }
+
+    robot := gobot.NewRobot("servoBot",
+        []gobot.Connection{chipAdaptor},
+        []gobot.Device{servo},
+        work,
+    )
+
+    robot.Start()
+}
+
+```
+
 ## How to Connect
 
 ### Compiling

--- a/platforms/chip/README.md
+++ b/platforms/chip/README.md
@@ -11,6 +11,9 @@ For documentation about the C.H.I.P. platform click [here](http://docs.getchip.c
 go get -d -u gobot.io/x/gobot/... && go install gobot.io/x/gobot/platforms/chip
 ```
 
+To be able to use the built in device tree overlay manager, you need to install the required
+modified device tree compiler "dtc" from https://github.com/atenart/dtc.
+
 ## How to Use
 
 The pin numbering used by your Gobot program should match the way your board is labeled right on the board itself.

--- a/platforms/chip/chip_adaptor.go
+++ b/platforms/chip/chip_adaptor.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -98,7 +99,7 @@ func (c *Adaptor) Connect() (err error) {
 	err = c.initPWM()
 	if err != nil {
 		// Let adaptor proceed without PWM, might not be available in the current setup
-		fmt.Printf("Failed to init PWM: %v\n", err)
+		log.Printf("Failed to init PWM: %v\n", err)
 	} else {
 		// Set up some sane PWM defaults to make servo functions
 		// work out of the box.
@@ -229,9 +230,8 @@ func (c *Adaptor) PwmWrite(pin string, val byte) (err error) {
 	if c.pwm != nil {
 		val := gobot.ToScale(gobot.FromScale(float64(val), 0, 255), 0, 100)
 		return c.pwm.setDutycycle(val)
-	} else {
-		return fmt.Errorf("PWM is not available, check device tree setup")
 	}
+	return fmt.Errorf("PWM is not available, check device tree setup")
 }
 
 // ServoWrite writes a servo signal to the specified pin
@@ -247,9 +247,8 @@ func (c *Adaptor) ServoWrite(pin string, angle byte) (err error) {
 		const maxDuty = 100 * 0.0020 * pwmFrequency
 		val := gobot.ToScale(gobot.FromScale(float64(angle), 0, 180), minDuty, maxDuty)
 		return c.pwm.setDutycycle(val)
-	} else {
-		return fmt.Errorf("PWM is not available, check device tree setup")
 	}
+	return fmt.Errorf("PWM is not available, check device tree setup")
 }
 
 func getXIOBase() (baseAddr int, err error) {

--- a/platforms/chip/chip_pwm.go
+++ b/platforms/chip/chip_pwm.go
@@ -126,7 +126,7 @@ func (c *Adaptor) closePWM() error {
 }
 
 func (p *pwmControl) setPolarityInverted(invPolarity bool) error {
-	if p.enabled {
+	if !p.enabled {
 		polarityString := "normal"
 		if invPolarity {
 			polarityString = "inverted"
@@ -134,7 +134,7 @@ func (p *pwmControl) setPolarityInverted(invPolarity bool) error {
 		_, err := io.WriteString(p.polarityFile, polarityString)
 		return err
 	} else {
-		return nil
+		return fmt.Errorf("Cannot set PWM polarity when enabled")
 	}
 }
 
@@ -145,7 +145,7 @@ func (p *pwmControl) setDutycycle(duty float64) error {
 		_, err := io.WriteString(p.dutyFile, fmt.Sprintf("%v", p.duty))
 		return err
 	} else {
-		return nil
+		return fmt.Errorf("Cannot set PWM duty cycle when disabled")
 	}
 }
 
@@ -156,7 +156,7 @@ func (p *pwmControl) setFrequency(freq float64) error {
 		_, err := io.WriteString(p.periodFile, fmt.Sprintf("%v", periodNanos))
 		return err
 	} else {
-		return nil
+		return fmt.Errorf("Cannot set PWM frequency when disabled")
 	}
 }
 

--- a/platforms/chip/chip_pwm.go
+++ b/platforms/chip/chip_pwm.go
@@ -1,0 +1,175 @@
+package chip
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+const pwmSysfsPath = "/sys/class/pwm/pwmchip0"
+
+type pwmControl struct {
+	periodFile   *os.File
+	dutyFile     *os.File
+	polarityFile *os.File
+	enableFile   *os.File
+
+	duty        uint32
+	periodNanos uint32
+	enabled     bool
+}
+
+func exportPWM() (err error) {
+	exporter, err := os.OpenFile(pwmSysfsPath + "/export", os.O_WRONLY, 0666)
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(exporter, "0")
+	return err
+}
+
+func unexportPWM() (err error) {
+	exporter, err := os.OpenFile(pwmSysfsPath + "/unexport", os.O_WRONLY, 0666)
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(exporter, "0")
+	return err
+}
+
+func (c *Adaptor) initPWM() (err error) {
+	const basePath = pwmSysfsPath + "/pwm0"
+
+	if _, err = os.Stat(basePath); err != nil {
+		if os.IsNotExist(err) {
+			if err = exportPWM(); err != nil {
+				return
+			}
+		} else {
+			return
+		}
+	}
+
+	var enableFile *os.File
+	var periodFile *os.File
+	var dutyFile *os.File
+	var polarityFile *os.File
+
+	defer func() {
+		if enableFile != nil {
+			enableFile.Close()
+		}
+		if periodFile != nil {
+			periodFile.Close()
+		}
+		if dutyFile != nil {
+			dutyFile.Close()
+		}
+		if polarityFile != nil {
+			polarityFile.Close()
+		}
+	}()
+
+	if enableFile, err = os.OpenFile(basePath + "/enable", os.O_WRONLY, 0666); err != nil {
+		return
+	}
+	if periodFile, err = os.OpenFile(basePath + "/period", os.O_WRONLY, 0666); err != nil {
+		return
+	}
+	if dutyFile, err = os.OpenFile(basePath + "/duty_cycle", os.O_WRONLY, 0666); err != nil {
+		return
+	}
+	if polarityFile, err = os.OpenFile(basePath + "/polarity", os.O_WRONLY, 0666); err != nil {
+		return
+	}
+
+	c.pwm = &pwmControl{
+		enableFile:   enableFile,
+		periodFile:   periodFile,
+		dutyFile:     dutyFile,
+		polarityFile: polarityFile,
+	}
+
+	enableFile = nil
+	periodFile = nil
+	dutyFile = nil
+	polarityFile = nil
+
+	return nil
+}
+
+func (c *Adaptor) closePWM() error {
+	pwm := c.pwm
+	if pwm != nil {
+		pwm.setFrequency(0)
+		pwm.setDutycycle(0)
+		pwm.setEnable(false)
+
+		if pwm.enableFile != nil {
+			pwm.enableFile.Close()
+		}
+		if pwm.periodFile != nil {
+			pwm.periodFile.Close()
+		}
+		if pwm.dutyFile != nil {
+			pwm.dutyFile.Close()
+		}
+		if pwm.polarityFile != nil {
+			pwm.polarityFile.Close()
+		}
+		if err := unexportPWM(); err != nil {
+			return err
+		}
+		c.pwm = nil
+	}
+	return nil
+}
+
+func (p *pwmControl) setPolarityInverted(invPolarity bool) error {
+	if p.enabled {
+		polarityString := "normal"
+		if invPolarity {
+			polarityString = "inverted"
+		}
+		_, err := io.WriteString(p.polarityFile, polarityString)
+		return err
+	} else {
+		return nil
+	}
+}
+
+func (p *pwmControl) setDutycycle(duty float64) error {
+	p.duty = uint32((float64(p.periodNanos) * (duty / 100.0)))
+	if p.enabled {
+		fmt.Printf("PWM: Setting duty cycle to %v (%v)\n", p.duty, duty)
+		_, err := io.WriteString(p.dutyFile, fmt.Sprintf("%v", p.duty))
+		return err
+	} else {
+		return nil
+	}
+}
+
+func (p *pwmControl) setFrequency(freq float64) error {
+	periodNanos := uint32(1e9 / freq)
+	if p.enabled && (p.periodNanos != periodNanos) {
+		p.periodNanos = periodNanos
+		_, err := io.WriteString(p.periodFile, fmt.Sprintf("%v", periodNanos))
+		return err
+	} else {
+		return nil
+	}
+}
+
+func (p *pwmControl) setEnable(enabled bool) error {
+	if p.enabled != enabled {
+		p.enabled = enabled
+		enableVal := 0
+		if enabled {
+			enableVal = 1
+		}
+		_, err := io.WriteString(p.enableFile, fmt.Sprintf("%v", enableVal))
+		return err
+	} else {
+		return nil
+	}
+}

--- a/platforms/chip/overlay_builder.go
+++ b/platforms/chip/overlay_builder.go
@@ -1,0 +1,72 @@
+package chip
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"io/ioutil"
+)
+
+// BuildAndInstallOverlays uses the modified 'dtc' device tree compiler binary
+// from https://github.com/atenart/dtc to build device tree overlay blobs and
+// installs them for the overlay manager.
+// Does not overwrite already existing dtbos.
+// Requires root permissions.
+func BuildAndInstallOverlays() (err error) {
+
+	for _, info := range(overlays) {
+		blobPath := overlayInstallPath + "/" + info.dtbo
+		if _, err = os.Stat(blobPath); err == nil {
+			// this blob is in place, check next
+			continue
+		}
+		if os.IsNotExist(err) {
+			tmpDir, err := ioutil.TempDir("", "dtbo")
+			defer os.RemoveAll(tmpDir)
+
+			err = buildOverlay(tmpDir, info.source)
+			if err != nil {
+				return fmt.Errorf("Failed to build overlay: %v", err)
+			}
+			err = installOverlay(tmpDir, info.dtbo)
+			if err != nil {
+				return fmt.Errorf("Failed to install overlay: %v", err)
+			}
+		} else {
+			return fmt.Errorf("Failed to check for installed overlay: %v", err)
+		}
+	}
+
+	return err
+}
+
+func buildOverlay(tmpDir string, source string) (err error) {
+	path, err := exec.LookPath("dtc")
+	if err != nil {
+		return fmt.Errorf("Failed to find 'dtc' command on path")
+	}
+
+	sourcePath := tmpDir + "/overlay.dts"
+	blobPath := tmpDir + "/overlay.dtbo"
+
+	if err = ioutil.WriteFile(sourcePath, []byte(source), 0666); err != nil {
+		return err
+	}
+
+	dtc := exec.Command(path, "-O", "dtb", "-o", blobPath, "-b", "o", "-@", sourcePath)
+	if err = dtc.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func installOverlay(tmpDir string, blobFile string) (err error) {
+	if err = os.MkdirAll(overlayInstallPath, 0777); err != nil {
+		return err
+	}
+	blobSource := tmpDir + "/overlay.dtbo"
+	blobTarget := overlayInstallPath + "/" + blobFile
+	err = copyFile(blobSource, blobTarget)
+	return err
+}

--- a/platforms/chip/overlay_manager.go
+++ b/platforms/chip/overlay_manager.go
@@ -5,23 +5,25 @@ import (
 	"os"
 	"os/exec"
 	"time"
+	ol "gobot.io/x/gobot/platforms/chip/overlays"
 )
 
-const overlayInstallPath = "/lib/firmware/chip_io"
+const overlayInstallPath = "/lib/firmware/gobot.io"
 const overlayConfigPath = "/sys/kernel/config/device-tree/overlays"
 
 type overlayInfo struct {
 	dtbo   string
 	folder string
 	sysfs  string
+	source string
 }
 
 var overlays = map[string]overlayInfo{
 	"PWM0": {
-		"chip-pwm0.dtbo", "chip-pwm", "/sys/class/pwm/pwmchip0",
+		"chip-pwm0.dtbo", "chip-pwm", "/sys/class/pwm/pwmchip0", ol.PWM0Overlay,
 	},
 	"SPI2": {
-		"chip-spi2.dtbo", "chip-spi", "/sys/class/spi_master/",
+		"chip-spi2.dtbo", "chip-spi", "/sys/class/spi_master/", ol.SPI2Overlay,
 	},
 }
 
@@ -62,6 +64,9 @@ func copyFile(sourcePath string, destPath string) (err error) {
 	return err
 }
 
+// LoadOverlay loads the required device tree overlay for "SPI2" or
+// "PWM0". Note that these have to be built and installed prior to
+// being loaded.
 func LoadOverlay(key string) (err error) {
 	overlay, err := keyToOverlay(key)
 	if err != nil {
@@ -98,6 +103,7 @@ func LoadOverlay(key string) (err error) {
 	return nil
 }
 
+// UnloadOverlay unloads the overlay for "SPI2" or "PWM0"
 func UnloadOverlay(key string) (err error) {
 	overlay, err := keyToOverlay(key)
 	if err != nil {

--- a/platforms/chip/overlay_manager.go
+++ b/platforms/chip/overlay_manager.go
@@ -1,0 +1,109 @@
+package chip
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+const overlayInstallPath = "/lib/firmware/chip_io"
+const overlayConfigPath = "/sys/kernel/config/device-tree/overlays"
+
+type overlayInfo struct {
+	dtbo   string
+	folder string
+	sysfs  string
+}
+
+var overlays = map[string]overlayInfo{
+	"PWM0": {
+		"chip-pwm0.dtbo", "chip-pwm", "/sys/class/pwm/pwmchip0",
+	},
+	"SPI2": {
+		"chip-spi2.dtbo", "chip-spi", "/sys/class/spi_master/",
+	},
+}
+
+func isLoaded(key string) (loaded bool, err error) {
+	overlay, _ := keyToOverlay(key)
+	configPath, _ := overlayToPaths(overlay)
+
+	if _, err = os.Stat(configPath); err == nil {
+		if _, err = os.Stat(overlay.sysfs); err == nil {
+			return true, nil
+		}
+	}
+
+	if os.IsNotExist(err) {
+		return false, nil
+	} else {
+		return false, err
+	}
+}
+
+func overlayToPaths(overlay overlayInfo) (configPath string, overlayPath string) {
+	configPath = overlayConfigPath + "/" + overlay.folder
+	overlayPath = overlayInstallPath + "/" + overlay.dtbo
+	return
+}
+
+func keyToOverlay(key string) (overlay overlayInfo, err error) {
+	overlay, ok := overlays[key]
+	if !ok {
+		err = fmt.Errorf("Invalid overlay key %v", key)
+	}
+	return overlay, err
+}
+
+func copyFile(sourcePath string, destPath string) (err error) {
+	cmd := exec.Command("cp", sourcePath, destPath)
+	err = cmd.Run()
+	return err
+}
+
+func LoadOverlay(key string) (err error) {
+	overlay, err := keyToOverlay(key)
+	if err != nil {
+		return err
+	}
+	configPath, overlayPath := overlayToPaths(overlay)
+	loaded, err := isLoaded(key)
+	if err != nil {
+		return err
+	}
+	if loaded {
+		return fmt.Errorf("Overlay for %v already loaded!", key)
+	}
+
+	if err := os.MkdirAll(configPath, 0777); err != nil {
+		return fmt.Errorf("Failed to create device tree path: %v", err)
+	}
+
+	err = copyFile(overlayPath, configPath+"/dtbo")
+	if err != nil {
+		return err
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	loaded, err = isLoaded(key)
+	if err != nil {
+		return err
+	}
+	if !loaded {
+		return fmt.Errorf("Failed to load overlay for %v", key)
+	}
+
+	return nil
+}
+
+func UnloadOverlay(key string) (err error) {
+	overlay, err := keyToOverlay(key)
+	if err != nil {
+		return err
+	}
+	configPath, _ := overlayToPaths(overlay)
+	err = os.Remove(configPath)
+	return err
+}

--- a/platforms/chip/overlays/chip-pwm0.go
+++ b/platforms/chip/overlays/chip-pwm0.go
@@ -1,0 +1,67 @@
+package overlays
+
+const PWM0Overlay = `
+
+/*
+ * Copyright 2016 Free Electrons
+ * Copyright 2016 NextThing Co
+ *
+ * Maxime Ripard <maxime.ripard@free-electrons.com>
+ *
+ * This file is dual-licensed: you can use it either under the terms
+ * of the GPL or the X11 license, at your option. Note that this dual
+ * licensing only applies to this file, and not this project as a
+ * whole.
+ *
+ *  a) This file is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU General Public License as
+ *     published by the Free Software Foundation; either version 2 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This file is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ * Or, alternatively,
+ *
+ *  b) Permission is hereby granted, free of charge, to any person
+ *     obtaining a copy of this software and associated documentation
+ *     files (the "Software"), to deal in the Software without
+ *     restriction, including without limitation the rights to use,
+ *     copy, modify, merge, publish, distribute, sublicense, and/or
+ *     sell copies of the Software, and to permit persons to whom the
+ *     Software is furnished to do so, subject to the following
+ *     conditions:
+ *
+ *     The above copyright notice and this permission notice shall be
+ *     included in all copies or substantial portions of the Software.
+ *
+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *     OTHER DEALINGS IN THE SOFTWARE.
+ */
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "nextthing,chip", "allwinner,sun5i-r8";
+
+	/* Enable the PWM */
+	fragment@0 {
+		target = <&pwm>;
+
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&pwm0_pins>;
+			status = "okay";
+		};
+	};
+};
+
+`

--- a/platforms/chip/overlays/chip-spi2.go
+++ b/platforms/chip/overlays/chip-spi2.go
@@ -1,0 +1,98 @@
+package overlays
+
+const SPI2Overlay = `
+
+/*
+ * Copyright 2016, Robert Wolterman
+ * This file is an amalgamation of stuff from Kolja Windeler, Maxime Ripard, and Renzo.
+ *
+ * This file is dual-licensed: you can use it either under the terms
+ * of the GPL or the X11 license, at your option. Note that this dual
+ * licensing only applies to this file, and not this project as a
+ * whole.
+ *
+ *  a) This file is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU General Public License as
+ *     published by the Free Software Foundation; either version 2 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This file is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ * Or, alternatively,
+ *
+ *  b) Permission is hereby granted, free of charge, to any person
+ *     obtaining a copy of this software and associated documentation
+ *     files (the "Software"), to deal in the Software without
+ *     restriction, including without limitation the rights to use,
+ *     copy, modify, merge, publish, distribute, sublicense, and/or
+ *     sell copies of the Software, and to permit persons to whom the
+ *     Software is furnished to do so, subject to the following
+ *     conditions:
+ *
+ *     The above copyright notice and this permission notice shall be
+ *     included in all copies or substantial portions of the Software.
+ *
+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *     OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+    compatible = "nextthing,chip", "allwinner,sun5i-r8";
+
+    /* activate the gpio for interrupt */
+    fragment@0 {
+        target-path = <&pio>;
+
+        __overlay__ {
+            chip_spi2_pins: spi2@0 {
+                allwinner,pins = "PE1", "PE2", "PE3";
+                allwinner,function = "spi2";
+                allwinner,drive = "0"; //<SUN4I_PINCTRL_10_MA>;
+                allwinner,pull = "0"; //<SUN4I_PINCTRL_NO_PULL>;
+            };
+
+            chip_spi2_cs0_pins: spi2_cs0@0 {
+                allwinner,pins = "PE0";
+                allwinner,function = "spi2";
+                allwinner,drive = "0"; //<SUN4I_PINCTRL_10_MA>;
+                allwinner,pull = "0"; //<SUN4I_PINCTRL_NO_PULL>;
+            };
+        };
+    };
+
+    /*
+     * Enable our SPI device, with an spidev device connected
+     * to it
+    */
+    fragment@1 {
+        target = <&spi2>;
+
+        __overlay__ {
+            #address-cells = <1>;
+            #size-cells = <0>;
+            pinctrl-names = "default";
+            pinctrl-0 = <&chip_spi2_pins>, <&chip_spi2_cs0_pins>;
+            status = "okay";
+
+            spi2@0 {
+                compatible = "rohm,dh2228fv";
+                reg = <0>;
+                spi-max-frequency = <24000000>;
+            };
+        };
+    };
+};
+
+`


### PR DESCRIPTION
This PR adds support for PWM0 on the C.H.I.P.

This is one way of doing it, and I have some questions, not sure if the implementation is ok for gobot.

To be able to use PWM0, a device tree overlay is needed in most cases (unless you have a modified kernel). The PR includes an overlay manager that compiles and installs the required overlays.

Now the questions, is this OK?
- The overlay manager depends on the external `dtc` command, as described in the README.md
- The overlay sources files are included as string constants with license info and all
- Using the overlay manager requires root access
- Don't know how to write tests for the overlay or pwm parts, since they operate directly with the file system. Are there examples in gobot where this is done?
