### PR TITLE
Fix go test ./...

### DIFF
--- a/examples/ardrone.go
+++ b/examples/ardrone.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/ardrone_face_tracking.go
+++ b/examples/ardrone_face_tracking.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (
@@ -7,10 +11,10 @@ import (
 	"runtime"
 	"time"
 
+	cv "github.com/lazywei/go-opencv/opencv"
 	"gobot.io/x/gobot"
 	"gobot.io/x/gobot/platforms/opencv"
 	"gobot.io/x/gobot/platforms/parrot/ardrone"
-	cv "github.com/lazywei/go-opencv/opencv"
 )
 
 func main() {

--- a/examples/ardrone_ps3.go
+++ b/examples/ardrone_ps3.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/audio.go
+++ b/examples/audio.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/batty.go
+++ b/examples/batty.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/bb8-collision.go
+++ b/examples/bb8-collision.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/bb8.go
+++ b/examples/bb8.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/beaglebone_basic_direct_pin.go
+++ b/examples/beaglebone_basic_direct_pin.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/beaglebone_blink.go
+++ b/examples/beaglebone_blink.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/beaglebone_blink_usr_led.go
+++ b/examples/beaglebone_blink_usr_led.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/beaglebone_blinkm.go
+++ b/examples/beaglebone_blinkm.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/beaglebone_button.go
+++ b/examples/beaglebone_button.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/beaglebone_direct_pin.go
+++ b/examples/beaglebone_direct_pin.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/beaglebone_grove_accelerometer.go
+++ b/examples/beaglebone_grove_accelerometer.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/beaglebone_led_brightness.go
+++ b/examples/beaglebone_led_brightness.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/beaglebone_led_brightness_with_analog_input.go
+++ b/examples/beaglebone_led_brightness_with_analog_input.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/beaglebone_makey_button.go
+++ b/examples/beaglebone_makey_button.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/beaglebone_servo.go
+++ b/examples/beaglebone_servo.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/bebop.go
+++ b/examples/bebop.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/bebop_ps3.go
+++ b/examples/bebop_ps3.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/bebop_ps3_video.go
+++ b/examples/bebop_ps3_video.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 /*
 	This example will connect to the Parrot Bebop allowing you to control
 	it using a PS3 controller.

--- a/examples/bebop_rtp_video.go
+++ b/examples/bebop_rtp_video.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 /*
 	This example will connect to the Parrot Bebop and streams the drone video
 	via the RTP protocol.

--- a/examples/ble_battery.go
+++ b/examples/ble_battery.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/ble_device_info.go
+++ b/examples/ble_device_info.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/ble_firmata_blink.go
+++ b/examples/ble_firmata_blink.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 /*
  To run this example, pass the BLE address or BLE name as first param:
 

--- a/examples/ble_generic_access.go
+++ b/examples/ble_generic_access.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/ble_multiple_generic.go
+++ b/examples/ble_multiple_generic.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 /*
  To run this example, pass the BLE addresses or BLE names as first param:
 

--- a/examples/ble_multiple_info.go
+++ b/examples/ble_multiple_info.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 /*
  To run this example, pass the BLE addresses or BLE names as first param:
 

--- a/examples/chip_blink.go
+++ b/examples/chip_blink.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/chip_blinkm.go
+++ b/examples/chip_blinkm.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/chip_button.go
+++ b/examples/chip_button.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/chip_button_led.go
+++ b/examples/chip_button_led.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/chip_drv2605l.go
+++ b/examples/chip_drv2605l.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/chip_grove_accelerometer.go
+++ b/examples/chip_grove_accelerometer.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/chip_grove_lcd.go
+++ b/examples/chip_grove_lcd.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/chip_mpu6050.go
+++ b/examples/chip_mpu6050.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/chip_tsl2561.go
+++ b/examples/chip_tsl2561.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/chip_wiichuck.go
+++ b/examples/chip_wiichuck.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/digispark_api.go
+++ b/examples/digispark_api.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/digispark_blink.go
+++ b/examples/digispark_blink.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/digispark_led_brightness.go
+++ b/examples/digispark_led_brightness.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/digispark_servo.go
+++ b/examples/digispark_servo.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/dragonboard_button.go
+++ b/examples/dragonboard_button.go
@@ -1,32 +1,36 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (
-    "fmt"
+	"fmt"
 
-    "gobot.io/x/gobot"
-    "gobot.io/x/gobot/drivers/gpio"
-    "gobot.io/x/gobot/platforms/dragonboard"
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/drivers/gpio"
+	"gobot.io/x/gobot/platforms/chip"
 )
 
 func main() {
-    dragonAdaptor := chip.NewAdaptor()
-    button := gpio.NewButtonDriver(dragonAdaptor, "GPIO_A")
+	dragonAdaptor := chip.NewAdaptor()
+	button := gpio.NewButtonDriver(dragonAdaptor, "GPIO_A")
 
-    work := func() {
-        gobot.On(button.Event("push"), func(data interface{}) {
-            fmt.Println("button pressed")
-        })
+	work := func() {
+		gobot.On(button.Event("push"), func(data interface{}) {
+			fmt.Println("button pressed")
+		})
 
-        gobot.On(button.Event("release"), func(data interface{}) {
-            fmt.Println("button released")
-        })
-    }
+		gobot.On(button.Event("release"), func(data interface{}) {
+			fmt.Println("button released")
+		})
+	}
 
-    robot := gobot.NewRobot("buttonBot",
-        []gobot.Connection{chipAdaptor},
-        []gobot.Device{button},
-        work,
-    )
+	robot := gobot.NewRobot("buttonBot",
+		[]gobot.Connection{chipAdaptor},
+		[]gobot.Device{button},
+		work,
+	)
 
-    robot.Start()
+	robot.Start()
 }

--- a/examples/edison_blink.go
+++ b/examples/edison_blink.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_blink_without_all_gobot_framework.go
+++ b/examples/edison_blink_without_all_gobot_framework.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_blinkm.go
+++ b/examples/edison_blinkm.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_button.go
+++ b/examples/edison_button.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_button_led.go
+++ b/examples/edison_button_led.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_button_led_api.go
+++ b/examples/edison_button_led_api.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_grove_accelerometer.go
+++ b/examples/edison_grove_accelerometer.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_grove_blink.go
+++ b/examples/edison_grove_blink.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_grove_button.go
+++ b/examples/edison_grove_button.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_grove_buzzer.go
+++ b/examples/edison_grove_buzzer.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_grove_lcd.go
+++ b/examples/edison_grove_lcd.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_grove_led.go
+++ b/examples/edison_grove_led.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_grove_light_sensor.go
+++ b/examples/edison_grove_light_sensor.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_grove_piezo_vibration.go
+++ b/examples/edison_grove_piezo_vibration.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_grove_rotary_sensor.go
+++ b/examples/edison_grove_rotary_sensor.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_grove_sound_sensor.go
+++ b/examples/edison_grove_sound_sensor.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_grove_temperature_sensor.go
+++ b/examples/edison_grove_temperature_sensor.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_grove_touch.go
+++ b/examples/edison_grove_touch.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_led_brightness.go
+++ b/examples/edison_led_brightness.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_led_brightness_with_analog_input.go
+++ b/examples/edison_led_brightness_with_analog_input.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_miniboard_grove_accelerometer.go
+++ b/examples/edison_miniboard_grove_accelerometer.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/edison_rgb_led.go
+++ b/examples/edison_rgb_led.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/every_done.go
+++ b/examples/every_done.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_blink.go
+++ b/examples/firmata_blink.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_blink_api.go
+++ b/examples/firmata_blink_api.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_blink_metal.go
+++ b/examples/firmata_blink_metal.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_blink_robot.go
+++ b/examples/firmata_blink_robot.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_blinkm.go
+++ b/examples/firmata_blinkm.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_button.go
+++ b/examples/firmata_button.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_buzzer.go
+++ b/examples/firmata_buzzer.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_cat_toy.go
+++ b/examples/firmata_cat_toy.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_direct_pin.go
+++ b/examples/firmata_direct_pin.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_hmc6352.go
+++ b/examples/firmata_hmc6352.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_integration.go
+++ b/examples/firmata_integration.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_led_brightness.go
+++ b/examples/firmata_led_brightness.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_led_brightness_with_analog_input.go
+++ b/examples/firmata_led_brightness_with_analog_input.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_lidarlite.go
+++ b/examples/firmata_lidarlite.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_makey_button.go
+++ b/examples/firmata_makey_button.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_metal_button.go
+++ b/examples/firmata_metal_button.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 // TO RUN:
 //	firmata_metal_button <PORT>
 //

--- a/examples/firmata_mma7660.go
+++ b/examples/firmata_mma7660.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_motor.go
+++ b/examples/firmata_motor.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_mpl115a2.go
+++ b/examples/firmata_mpl115a2.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_mpu6050.go
+++ b/examples/firmata_mpu6050.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_pir_motion.go
+++ b/examples/firmata_pir_motion.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_rgb_led.go
+++ b/examples/firmata_rgb_led.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_servo.go
+++ b/examples/firmata_servo.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_temp36.go
+++ b/examples/firmata_temp36.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_travis.go
+++ b/examples/firmata_travis.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/firmata_wiichuck.go
+++ b/examples/firmata_wiichuck.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/hello.go
+++ b/examples/hello.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/hello_api.go
+++ b/examples/hello_api.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/hello_api_auth.go
+++ b/examples/hello_api_auth.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/joule_blink.go
+++ b/examples/joule_blink.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/joule_blinkm.go
+++ b/examples/joule_blinkm.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/joule_grove_lcd.go
+++ b/examples/joule_grove_lcd.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/joule_leds.go
+++ b/examples/joule_leds.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/joule_rgb_led.go
+++ b/examples/joule_rgb_led.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/joystick_ps3.go
+++ b/examples/joystick_ps3.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/joystick_ps4.go
+++ b/examples/joystick_ps4.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/joystick_xbox360.go
+++ b/examples/joystick_xbox360.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/keyboard.go
+++ b/examples/keyboard.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/keyboard_mqtt.go
+++ b/examples/keyboard_mqtt.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/leap_motion.go
+++ b/examples/leap_motion.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/leap_motion_gestures.go
+++ b/examples/leap_motion_gestures.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/leap_motion_hands.go
+++ b/examples/leap_motion_hands.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/leap_servos.go
+++ b/examples/leap_servos.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/leap_sphero.go
+++ b/examples/leap_sphero.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/mavlink.go
+++ b/examples/mavlink.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/megapi_motor.go
+++ b/examples/megapi_motor.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/metal_button.go
+++ b/examples/metal_button.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/minidrone.go
+++ b/examples/minidrone.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/minidrone_events.go
+++ b/examples/minidrone_events.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/minidrone_ps3.go
+++ b/examples/minidrone_ps3.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/mqtt_driver_ping.go
+++ b/examples/mqtt_driver_ping.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 // TO RUN:
 //  go run ./examples/mqtt_driver_ping.go <SERVER>
 //

--- a/examples/mqtt_firmata_blink.go
+++ b/examples/mqtt_firmata_blink.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/mqtt_ping.go
+++ b/examples/mqtt_ping.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/nats.go
+++ b/examples/nats.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/nats_driver_ping.go
+++ b/examples/nats_driver_ping.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 // TO RUN:
 //  go run ./examples/nats_driver_ping.go <SERVER>
 //

--- a/examples/neurosky.go
+++ b/examples/neurosky.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/ollie.go
+++ b/examples/ollie.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/ollie_mqtt.go
+++ b/examples/ollie_mqtt.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/ollie_multiple.go
+++ b/examples/ollie_multiple.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 /*
  To run this example, pass the BLE address or BLE name as first param:
 

--- a/examples/ollie_roll.go
+++ b/examples/ollie_roll.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/opencv_face_detect.go
+++ b/examples/opencv_face_detect.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (
@@ -5,9 +9,9 @@ import (
 	"runtime"
 	"time"
 
+	cv "github.com/lazywei/go-opencv/opencv"
 	"gobot.io/x/gobot"
 	"gobot.io/x/gobot/platforms/opencv"
-	cv "github.com/lazywei/go-opencv/opencv"
 )
 
 func main() {

--- a/examples/opencv_window.go
+++ b/examples/opencv_window.go
@@ -1,9 +1,13 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (
+	cv "github.com/lazywei/go-opencv/opencv"
 	"gobot.io/x/gobot"
 	"gobot.io/x/gobot/platforms/opencv"
-	cv "github.com/lazywei/go-opencv/opencv"
 )
 
 func main() {

--- a/examples/particle_api.go
+++ b/examples/particle_api.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 /*
  To run this example, pass the device ID as first param,
  and the access token as the second param:

--- a/examples/particle_blink.go
+++ b/examples/particle_blink.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 /*
  To run this example, pass the device ID as first param,
  and the access token as the second param:

--- a/examples/particle_button.go
+++ b/examples/particle_button.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 /*
  To run this example, pass the device ID as first param,
  and the access token as the second param:

--- a/examples/particle_events.go
+++ b/examples/particle_events.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 /*
  To run this example, pass the device ID as first param,
  and the access token as the second param:

--- a/examples/particle_function.go
+++ b/examples/particle_function.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 /*
  To run this example, pass the device ID as first param,
  and the access token as the second param:

--- a/examples/particle_led_brightness.go
+++ b/examples/particle_led_brightness.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 /*
  To run this example, pass the device ID as first param,
  and the access token as the second param:

--- a/examples/particle_variable.go
+++ b/examples/particle_variable.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 /*
  To run this example, pass the device ID as first param,
  and the access token as the second param:

--- a/examples/pebble.go
+++ b/examples/pebble.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/pebble_accelerometer.go
+++ b/examples/pebble_accelerometer.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/raspi_adafruit_dcmotor.go
+++ b/examples/raspi_adafruit_dcmotor.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/raspi_adafruit_servo.go
+++ b/examples/raspi_adafruit_servo.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/raspi_adafruit_stepper.go
+++ b/examples/raspi_adafruit_stepper.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/raspi_blink.go
+++ b/examples/raspi_blink.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/raspi_blinkm.go
+++ b/examples/raspi_blinkm.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/raspi_button.go
+++ b/examples/raspi_button.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/raspi_sht3x.go
+++ b/examples/raspi_sht3x.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/sphero.go
+++ b/examples/sphero.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/sphero_api.go
+++ b/examples/sphero_api.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/sphero_conways.go
+++ b/examples/sphero_conways.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/sphero_dpad.go
+++ b/examples/sphero_dpad.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/sphero_master.go
+++ b/examples/sphero_master.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/sphero_multiple.go
+++ b/examples/sphero_multiple.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/square.go
+++ b/examples/square.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/square_fire.go
+++ b/examples/square_fire.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/examples/wifi_firmata_blink.go
+++ b/examples/wifi_firmata_blink.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 /*
  To run this example, pass the IP address/port as first param:
 

--- a/platforms/firmata/client/examples/blink.go
+++ b/platforms/firmata/client/examples/blink.go
@@ -1,11 +1,15 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (
 	"fmt"
 	"time"
 
-	"gobot.io/x/gobot/platforms/firmata/client"
 	"github.com/tarm/serial"
+	"gobot.io/x/gobot/platforms/firmata/client"
 )
 
 func main() {

--- a/platforms/parrot/bebop/client/examples/takeoff.go
+++ b/platforms/parrot/bebop/client/examples/takeoff.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 package main
 
 import (

--- a/platforms/parrot/bebop/client/examples/video.go
+++ b/platforms/parrot/bebop/client/examples/video.go
@@ -1,3 +1,7 @@
+// +build example
+//
+// Do not build by default.
+
 /*
 	This example will connect to the Bebop and stream its video to a webpage
 	via ffserver. This requires you to have both ffmpeg and ffserver installed


### PR DESCRIPTION
Make all examples to not be built by default by adding the build tag 'example'.
Some files were automatically reformatted by goimports upon saving.