### PR TITLE
Hardware PWM support for the C.H.I.P

### DIFF
--- a/platforms/chip/README.md
+++ b/platforms/chip/README.md
@@ -11,6 +11,9 @@ For documentation about the C.H.I.P. platform click [here](http://docs.getchip.c
 go get -d -u gobot.io/x/gobot/... && go install gobot.io/x/gobot/platforms/chip
 ```
 
+Note that PWM might not be available in your kernel and you might need to load the right overlays
+to expose PWM on the PWM0 pin.
+
 ## How to Use
 
 The pin numbering used by your Gobot program should match the way your board is labeled right on the board itself.

--- a/platforms/chip/README.md
+++ b/platforms/chip/README.md
@@ -11,8 +11,23 @@ For documentation about the C.H.I.P. platform click [here](http://docs.getchip.c
 go get -d -u gobot.io/x/gobot/... && go install gobot.io/x/gobot/platforms/chip
 ```
 
-Note that PWM might not be available in your kernel and you might need to load the right overlays
-to expose PWM on the PWM0 pin.
+### PWM support
+Note that PWM might not be available in your kernel. In that case, you can install the required device tree overlay
+from the command line using [Gort](https://gobot.io/x/gort) CLI commands on the C.H.I.P device.
+Here are the steps:
+
+Install the required patched device tree compiler as described in the [C.H.I.P docs](https://docs.getchip.com/dip.html#make-a-dtbo-device-tree-overlay-blob):
+```
+gort chip install dtc
+```
+
+Now, install the pwm overlay to activate pwm on the PWM0 pin:
+```
+gort chip install pwm
+```
+
+Reboot the device to make sure the init script loads the overlay on boot.
+
 
 ## How to Use
 

--- a/platforms/chip/chip_adaptor_test.go
+++ b/platforms/chip/chip_adaptor_test.go
@@ -15,6 +15,7 @@ import (
 var _ gobot.Adaptor = (*Adaptor)(nil)
 var _ gpio.DigitalReader = (*Adaptor)(nil)
 var _ gpio.DigitalWriter = (*Adaptor)(nil)
+var _ gpio.ServoWriter = (*Adaptor)(nil)
 var _ i2c.Connector = (*Adaptor)(nil)
 
 type NullReadWriteCloser struct {
@@ -89,4 +90,14 @@ func TestChipAdaptorI2c(t *testing.T) {
 	gobottest.Assert(t, data, []byte{0x00, 0x01})
 
 	gobottest.Assert(t, a.Finalize(), nil)
+}
+
+func TestChipAdaptorInvalidPWMPin(t *testing.T) {
+	a := initTestChipAdaptor()
+
+	err := a.PwmWrite("LCD-D2", 42)
+	gobottest.Refute(t, err, nil)
+
+	err = a.ServoWrite("LCD-D2", 120)
+	gobottest.Refute(t, err, nil)
 }

--- a/platforms/chip/chip_pwm.go
+++ b/platforms/chip/chip_pwm.go
@@ -4,15 +4,17 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"gobot.io/x/gobot/sysfs"
 )
 
 const pwmSysfsPath = "/sys/class/pwm/pwmchip0"
 
 type pwmControl struct {
-	periodFile   *os.File
-	dutyFile     *os.File
-	polarityFile *os.File
-	enableFile   *os.File
+	periodFile   sysfs.File
+	dutyFile     sysfs.File
+	polarityFile sysfs.File
+	enableFile   sysfs.File
 
 	duty        uint32
 	periodNanos uint32
@@ -20,7 +22,7 @@ type pwmControl struct {
 }
 
 func exportPWM() (err error) {
-	exporter, err := os.OpenFile(pwmSysfsPath+"/export", os.O_WRONLY, 0666)
+	exporter, err := sysfs.OpenFile(pwmSysfsPath+"/export", os.O_WRONLY, 0666)
 	if err != nil {
 		return err
 	}
@@ -29,7 +31,7 @@ func exportPWM() (err error) {
 }
 
 func unexportPWM() (err error) {
-	exporter, err := os.OpenFile(pwmSysfsPath+"/unexport", os.O_WRONLY, 0666)
+	exporter, err := sysfs.OpenFile(pwmSysfsPath+"/unexport", os.O_WRONLY, 0666)
 	if err != nil {
 		return err
 	}
@@ -40,7 +42,7 @@ func unexportPWM() (err error) {
 func (c *Adaptor) initPWM(pwmFrequency float64) (err error) {
 	const basePath = pwmSysfsPath + "/pwm0"
 
-	if _, err = os.Stat(basePath); err != nil {
+	if _, err = sysfs.Stat(basePath); err != nil {
 		if os.IsNotExist(err) {
 			if err = exportPWM(); err != nil {
 				return
@@ -50,10 +52,10 @@ func (c *Adaptor) initPWM(pwmFrequency float64) (err error) {
 		}
 	}
 
-	var enableFile *os.File
-	var periodFile *os.File
-	var dutyFile *os.File
-	var polarityFile *os.File
+	var enableFile sysfs.File
+	var periodFile sysfs.File
+	var dutyFile sysfs.File
+	var polarityFile sysfs.File
 
 	defer func() {
 		if enableFile != nil {
@@ -70,16 +72,16 @@ func (c *Adaptor) initPWM(pwmFrequency float64) (err error) {
 		}
 	}()
 
-	if enableFile, err = os.OpenFile(basePath+"/enable", os.O_WRONLY, 0666); err != nil {
+	if enableFile, err = sysfs.OpenFile(basePath+"/enable", os.O_WRONLY, 0666); err != nil {
 		return
 	}
-	if periodFile, err = os.OpenFile(basePath+"/period", os.O_WRONLY, 0666); err != nil {
+	if periodFile, err = sysfs.OpenFile(basePath+"/period", os.O_WRONLY, 0666); err != nil {
 		return
 	}
-	if dutyFile, err = os.OpenFile(basePath+"/duty_cycle", os.O_WRONLY, 0666); err != nil {
+	if dutyFile, err = sysfs.OpenFile(basePath+"/duty_cycle", os.O_WRONLY, 0666); err != nil {
 		return
 	}
-	if polarityFile, err = os.OpenFile(basePath+"/polarity", os.O_WRONLY, 0666); err != nil {
+	if polarityFile, err = sysfs.OpenFile(basePath+"/polarity", os.O_WRONLY, 0666); err != nil {
 		return
 	}
 

--- a/platforms/chip/chip_pwm.go
+++ b/platforms/chip/chip_pwm.go
@@ -37,8 +37,6 @@ func unexportPWM() (err error) {
 	return err
 }
 
-//	return fmt.Errorf("PWM is not available, check device tree setup")
-
 func (c *Adaptor) initPWM(pwmFrequency float64) (err error) {
 	const basePath = pwmSysfsPath + "/pwm0"
 

--- a/platforms/chip/chip_pwm.go
+++ b/platforms/chip/chip_pwm.go
@@ -1,0 +1,188 @@
+package chip
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+const pwmSysfsPath = "/sys/class/pwm/pwmchip0"
+
+type pwmControl struct {
+	periodFile   *os.File
+	dutyFile     *os.File
+	polarityFile *os.File
+	enableFile   *os.File
+
+	duty        uint32
+	periodNanos uint32
+	enabled     bool
+}
+
+func exportPWM() (err error) {
+	exporter, err := os.OpenFile(pwmSysfsPath+"/export", os.O_WRONLY, 0666)
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(exporter, "0")
+	return err
+}
+
+func unexportPWM() (err error) {
+	exporter, err := os.OpenFile(pwmSysfsPath+"/unexport", os.O_WRONLY, 0666)
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(exporter, "0")
+	return err
+}
+
+//	return fmt.Errorf("PWM is not available, check device tree setup")
+
+func (c *Adaptor) initPWM(pwmFrequency float64) (err error) {
+	const basePath = pwmSysfsPath + "/pwm0"
+
+	if _, err = os.Stat(basePath); err != nil {
+		if os.IsNotExist(err) {
+			if err = exportPWM(); err != nil {
+				return
+			}
+		} else {
+			return
+		}
+	}
+
+	var enableFile *os.File
+	var periodFile *os.File
+	var dutyFile *os.File
+	var polarityFile *os.File
+
+	defer func() {
+		if enableFile != nil {
+			enableFile.Close()
+		}
+		if periodFile != nil {
+			periodFile.Close()
+		}
+		if dutyFile != nil {
+			dutyFile.Close()
+		}
+		if polarityFile != nil {
+			polarityFile.Close()
+		}
+	}()
+
+	if enableFile, err = os.OpenFile(basePath+"/enable", os.O_WRONLY, 0666); err != nil {
+		return
+	}
+	if periodFile, err = os.OpenFile(basePath+"/period", os.O_WRONLY, 0666); err != nil {
+		return
+	}
+	if dutyFile, err = os.OpenFile(basePath+"/duty_cycle", os.O_WRONLY, 0666); err != nil {
+		return
+	}
+	if polarityFile, err = os.OpenFile(basePath+"/polarity", os.O_WRONLY, 0666); err != nil {
+		return
+	}
+
+	c.pwm = &pwmControl{
+		enableFile:   enableFile,
+		periodFile:   periodFile,
+		dutyFile:     dutyFile,
+		polarityFile: polarityFile,
+	}
+
+	enableFile = nil
+	periodFile = nil
+	dutyFile = nil
+	polarityFile = nil
+
+	// Set up some sane PWM defaults to make servo functions
+	// work out of the box.
+	if err = c.pwm.setPolarityInverted(false); err != nil {
+		return
+	}
+	if err = c.pwm.setEnable(true); err != nil {
+		return
+	}
+	if err = c.pwm.setFrequency(pwmFrequency); err != nil {
+		return
+	}
+	if err = c.pwm.setDutycycle(0); err != nil {
+		return
+	}
+
+	return nil
+}
+
+func (c *Adaptor) closePWM() error {
+	pwm := c.pwm
+	if pwm != nil {
+		pwm.setFrequency(0)
+		pwm.setDutycycle(0)
+		pwm.setEnable(false)
+
+		if pwm.enableFile != nil {
+			pwm.enableFile.Close()
+		}
+		if pwm.periodFile != nil {
+			pwm.periodFile.Close()
+		}
+		if pwm.dutyFile != nil {
+			pwm.dutyFile.Close()
+		}
+		if pwm.polarityFile != nil {
+			pwm.polarityFile.Close()
+		}
+		if err := unexportPWM(); err != nil {
+			return err
+		}
+		c.pwm = nil
+	}
+	return nil
+}
+
+func (p *pwmControl) setPolarityInverted(invPolarity bool) error {
+	if !p.enabled {
+		polarityString := "normal"
+		if invPolarity {
+			polarityString = "inverted"
+		}
+		_, err := io.WriteString(p.polarityFile, polarityString)
+		return err
+	}
+	return fmt.Errorf("Cannot set PWM polarity when enabled")
+}
+
+func (p *pwmControl) setDutycycle(duty float64) error {
+	p.duty = uint32((float64(p.periodNanos) * (duty / 100.0)))
+	if p.enabled {
+		//fmt.Printf("PWM: Setting duty cycle to %v (%v)\n", p.duty, duty)
+		_, err := io.WriteString(p.dutyFile, fmt.Sprintf("%v", p.duty))
+		return err
+	}
+	return fmt.Errorf("Cannot set PWM duty cycle when disabled")
+}
+
+func (p *pwmControl) setFrequency(freq float64) error {
+	periodNanos := uint32(1e9 / freq)
+	if p.enabled && (p.periodNanos != periodNanos) {
+		p.periodNanos = periodNanos
+		_, err := io.WriteString(p.periodFile, fmt.Sprintf("%v", periodNanos))
+		return err
+	}
+	return fmt.Errorf("Cannot set PWM frequency when disabled")
+}
+
+func (p *pwmControl) setEnable(enabled bool) error {
+	if p.enabled != enabled {
+		p.enabled = enabled
+		enableVal := 0
+		if enabled {
+			enableVal = 1
+		}
+		_, err := io.WriteString(p.enableFile, fmt.Sprintf("%v", enableVal))
+		return err
+	}
+	return nil
+}

--- a/sysfs/fs.go
+++ b/sysfs/fs.go
@@ -19,6 +19,7 @@ type File interface {
 // Filesystem opens files and returns either a native file system or user defined
 type Filesystem interface {
 	OpenFile(name string, flag int, perm os.FileMode) (file File, err error)
+	Stat(name string) (os.FileInfo, error)
 }
 
 // NativeFilesystem represents the native file system implementation
@@ -37,7 +38,17 @@ func (fs *NativeFilesystem) OpenFile(name string, flag int, perm os.FileMode) (f
 	return os.OpenFile(name, flag, perm)
 }
 
+// Stat calls os.Stat()
+func (fs *NativeFilesystem) Stat(name string) (os.FileInfo, error) {
+	return os.Stat(name)
+}
+
 // OpenFile calls either the NativeFilesystem or user defined OpenFile
 func OpenFile(name string, flag int, perm os.FileMode) (file File, err error) {
 	return fs.OpenFile(name, flag, perm)
+}
+
+// Stat call either the NativeFilesystem of user defined Stat
+func Stat(name string) (os.FileInfo, error) {
+	return fs.Stat(name)
 }

--- a/sysfs/fs_mock_test.go
+++ b/sysfs/fs_mock_test.go
@@ -26,6 +26,21 @@ func TestMockFilesystemOpen(t *testing.T) {
 	gobottest.Refute(t, f4.Fd(), f1.Fd())
 }
 
+func TestMockFilesystemStat(t *testing.T) {
+	fs := NewMockFilesystem([]string{"foo", "bar/baz"})
+
+	fileStat, err := fs.Stat("foo")
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, fileStat.IsDir(), false)
+
+	dirStat, err := fs.Stat("bar")
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, dirStat.IsDir(), true)
+
+	_, err = fs.Stat("plonk")
+	gobottest.Refute(t, err, nil)
+}
+
 func TestMockFilesystemWrite(t *testing.T) {
 	fs := NewMockFilesystem([]string{"bar"})
 	f1 := fs.Files["bar"]


### PR DESCRIPTION
This PR adds support for PWM0 on the C.H.I.P.

Second attempt, including the core PWM functionality only, leaving out device tree overlay management.
