### PR TITLE
Small bugfix for the DRV2605 driver

### DIFF
--- a/drivers/i2c/drv2605l_driver.go
+++ b/drivers/i2c/drv2605l_driver.go
@@ -183,7 +183,7 @@ func (d *DRV2605LDriver) SetMode(newMode DRV2605Mode) (err error) {
 	}
 
 	// clear mode bits (lower three bits)
-	mode &= 0xf1
+	mode &= 0xf8
 	// set new mode bits
 	mode |= uint8(newMode)
 
@@ -264,7 +264,7 @@ func (d *DRV2605LDriver) Halt() (err error) {
 		}
 
 		// enter standby
-		return d.connection.WriteByteData(drv2605RegMode, 1)
+		return d.SetStandbyMode(true)
 	}
 	return
 }

--- a/drivers/i2c/drv2605l_driver_test.go
+++ b/drivers/i2c/drv2605l_driver_test.go
@@ -42,7 +42,7 @@ func TestDRV2605LDriverHalt(t *testing.T) {
 	gobottest.Assert(t, d.Start(), nil)
 	adaptor.written = []byte{}
 	gobottest.Assert(t, d.Halt(), nil)
-	gobottest.Assert(t, adaptor.written, []byte{drv2605RegGo, 0, drv2605RegMode, 1})
+	gobottest.Assert(t, adaptor.written, []byte{drv2605RegGo, 0, drv2605RegMode, 42 | drv2605Standby})
 }
 
 func TestDRV2605LDriverGetPause(t *testing.T) {


### PR DESCRIPTION
This PR fixes a problem where closing the driver could leave it in a repeatedly self-triggering state.
