### PR TITLE
Fix neurosky example

### DIFF
--- a/examples/neurosky.go
+++ b/examples/neurosky.go
@@ -35,7 +35,7 @@ func main() {
 			fmt.Println("Wave", data)
 		})
 		neuro.On(neuro.Event("eeg"), func(data interface{}) {
-			eeg := data.(neurosky.EEG)
+			eeg := data.(neurosky.EEGData)
 			fmt.Println("Delta", eeg.Delta)
 			fmt.Println("Theta", eeg.Theta)
 			fmt.Println("LoAlpha", eeg.LoAlpha)

--- a/platforms/neurosky/README.md
+++ b/platforms/neurosky/README.md
@@ -80,7 +80,7 @@ func main() {
 			fmt.Println("Wave", data)
 		})
 		gobot.On(neuro.Event("eeg"), func(data interface{}) {
-			eeg := data.(neurosky.EEG)
+			eeg := data.(neurosky.EEGData)
 			fmt.Println("Delta", eeg.Delta)
 			fmt.Println("Theta", eeg.Theta)
 			fmt.Println("LoAlpha", eeg.LoAlpha)

--- a/platforms/neurosky/doc.go
+++ b/platforms/neurosky/doc.go
@@ -40,7 +40,7 @@ Example:
 				fmt.Println("Wave", data)
 			})
 			neuro.On(neuro.Event("eeg"), func(data interface{}) {
-				eeg := data.(neurosky.EEG)
+				eeg := data.(neurosky.EEGData)
 				fmt.Println("Delta", eeg.Delta)
 				fmt.Println("Theta", eeg.Theta)
 				fmt.Println("LoAlpha", eeg.LoAlpha)


### PR DESCRIPTION
Fix `go run examples/neurosky.go` error: ``examples/neurosky.go:34: neurosky.EEG is not a type``

neurosky.EEG struct was renamed to neurosky.EEGData : [neurosky_driver.go](https://github.com/hybridgroup/gobot/blob/953c3254e77c4f4a7dd0a03ef7afd25cf463879a/platforms/neurosky/neurosky_driver.go#L67)

