### PR TITLE
Feature/pwm period

### DIFF
--- a/drivers/gpio/angular_servo_driver.go
+++ b/drivers/gpio/angular_servo_driver.go
@@ -1,0 +1,94 @@
+package gpio
+
+import "gobot.io/x/gobot"
+
+// AngularServoDriver Represents a Servo
+type AngularServoDriver struct {
+	name       string
+	pin        string
+	connection PwmWriter
+	gobot.Commander
+	CurrentAngle float64
+	MaxAngle     float64
+	minPeriod    float64
+	maxPeriod    float64
+}
+
+// NewAngularServoDriver returns a new ServoDriver given a ServoWriter and pin.
+//
+// Adds the following API Commands:
+// 	"Move" - See ServoDriver.Move
+//	"Min" - See ServoDriver.Min
+//	"Center" - See ServoDriver.Center
+//	"Max" - See ServoDriver.Max
+func NewAngularServoDriver(a PwmWriter, pin string, maxAngle float64, minPeriod float64, maxPeriod float64) *AngularServoDriver {
+	s := &AngularServoDriver{
+		name:         gobot.DefaultName("AngularServo"),
+		connection:   a,
+		pin:          pin,
+		Commander:    gobot.NewCommander(),
+		CurrentAngle: 0,
+		MaxAngle:     maxAngle,
+		minPeriod:    minPeriod,
+		maxPeriod:    maxPeriod,
+	}
+
+	s.AddCommand("Move", func(params map[string]interface{}) interface{} {
+		angle := params["angle"].(float64)
+		return s.Move(angle)
+	})
+	s.AddCommand("Min", func(params map[string]interface{}) interface{} {
+		return s.Min()
+	})
+	s.AddCommand("Center", func(params map[string]interface{}) interface{} {
+		return s.Center()
+	})
+	s.AddCommand("Max", func(params map[string]interface{}) interface{} {
+		return s.Max()
+	})
+
+	return s
+}
+
+// Name returns the ServoDrivers name
+func (s *AngularServoDriver) Name() string { return s.name }
+
+// SetName sets the ServoDrivers name
+func (s *AngularServoDriver) SetName(n string) { s.name = n }
+
+// Pin returns the ServoDrivers pin
+func (s *AngularServoDriver) Pin() string { return s.pin }
+
+// Connection returns the ServoDrivers connection
+func (s *AngularServoDriver) Connection() gobot.Connection { return s.connection.(gobot.Connection) }
+
+// Start implements the Driver interface
+func (s *AngularServoDriver) Start() (err error) { return }
+
+// Halt implements the Driver interface
+func (s *AngularServoDriver) Halt() (err error) { return }
+
+// Move sets the servo to the specified angle. Acceptable angles are 0-180
+func (s *AngularServoDriver) Move(angle float64) (err error) {
+	if !(angle >= 0 && angle <= s.MaxAngle) {
+		return ErrServoOutOfRange
+	}
+	s.CurrentAngle = angle
+	period := s.minPeriod + (s.maxPeriod-s.minPeriod)*angle/s.MaxAngle
+	return s.connection.SetPwmPeriod(s.Pin(), period)
+}
+
+// Min sets the servo to it's minimum position
+func (s *AngularServoDriver) Min() (err error) {
+	return s.Move(0)
+}
+
+// Center sets the servo to it's center position
+func (s *AngularServoDriver) Center() (err error) {
+	return s.Move(s.MaxAngle / 2.0)
+}
+
+// Max sets the servo to its maximum position
+func (s *AngularServoDriver) Max() (err error) {
+	return s.Move(s.MaxAngle)
+}

--- a/drivers/gpio/angular_servo_driver.go
+++ b/drivers/gpio/angular_servo_driver.go
@@ -9,6 +9,7 @@ type AngularServoDriver struct {
 	connection PwmWriter
 	gobot.Commander
 	CurrentAngle float64
+	MinAngle     float64
 	MaxAngle     float64
 	minPeriod    float64
 	maxPeriod    float64
@@ -21,16 +22,21 @@ type AngularServoDriver struct {
 //	"Min" - See ServoDriver.Min
 //	"Center" - See ServoDriver.Center
 //	"Max" - See ServoDriver.Max
-func NewAngularServoDriver(a PwmWriter, pin string, maxAngle float64, minPeriod float64, maxPeriod float64) *AngularServoDriver {
+func NewAngularServoDriver(a PwmWriter, pin string, options ...func(*AngularServoDriver)) *AngularServoDriver {
 	s := &AngularServoDriver{
 		name:         gobot.DefaultName("AngularServo"),
 		connection:   a,
 		pin:          pin,
 		Commander:    gobot.NewCommander(),
-		CurrentAngle: 0,
-		MaxAngle:     maxAngle,
-		minPeriod:    minPeriod,
-		maxPeriod:    maxPeriod,
+		CurrentAngle: 0.0,
+		MinAngle:     0.0,
+		MaxAngle:     180.0,
+		minPeriod:    1.0 / 1000.0,
+		maxPeriod:    2.0 / 1000.0,
+	}
+
+	for _, option := range options {
+		option(s)
 	}
 
 	s.AddCommand("Move", func(params map[string]interface{}) interface{} {
@@ -48,6 +54,33 @@ func NewAngularServoDriver(a PwmWriter, pin string, maxAngle float64, minPeriod 
 	})
 
 	return s
+}
+
+// WithServoAngles sets the range of acceptable angles.
+// Note that the min can be less than the max to reverse servo operation.
+func (s *AngularServoDriver) WithServoAngles(minAngle float64, maxAngle float64) {
+	s.MinAngle = minAngle
+	s.MaxAngle = maxAngle
+}
+
+// WithServoAngles sets the range of acceptable angles.
+func WithServoAngles(minAngle float64, maxAngle float64) func(*AngularServoDriver) {
+	return func(s *AngularServoDriver) {
+		s.WithServoAngles(minAngle, maxAngle)
+	}
+}
+
+// WithPeriodRange sets the range of acceptable periods.
+func (s *AngularServoDriver) WithPeriodRange(minPeriod float64, maxPeriod float64) {
+	s.minPeriod = minPeriod
+	s.maxPeriod = maxPeriod
+}
+
+// WithPeriodRange sets the range of acceptable periods.
+func WithPeriodRange(minPeriod float64, maxPeriod float64) func(*AngularServoDriver) {
+	return func(s *AngularServoDriver) {
+		s.WithPeriodRange(minPeriod, maxPeriod)
+	}
 }
 
 // Name returns the ServoDrivers name
@@ -68,24 +101,26 @@ func (s *AngularServoDriver) Start() (err error) { return }
 // Halt implements the Driver interface
 func (s *AngularServoDriver) Halt() (err error) { return }
 
-// Move sets the servo to the specified angle. Acceptable angles are 0-180
+// Move sets the servo to the specified angle. Acceptable angles are defined at setup time
 func (s *AngularServoDriver) Move(angle float64) (err error) {
-	if !(angle >= 0 && angle <= s.MaxAngle) {
+	if !((angle >= s.MinAngle && angle <= s.MaxAngle) ||
+		(angle <= s.MinAngle && angle >= s.MaxAngle)) {
+		// We need to support the case were minAngle>maxAngle, to reverse the servo
 		return ErrServoOutOfRange
 	}
 	s.CurrentAngle = angle
-	period := s.minPeriod + (s.maxPeriod-s.minPeriod)*angle/s.MaxAngle
+	period := s.minPeriod + (s.maxPeriod-s.minPeriod)*(angle-s.MinAngle)/(s.MaxAngle-s.MinAngle)
 	return s.connection.SetPwmPeriod(s.Pin(), period)
 }
 
 // Min sets the servo to it's minimum position
 func (s *AngularServoDriver) Min() (err error) {
-	return s.Move(0)
+	return s.Move(s.MinAngle)
 }
 
 // Center sets the servo to it's center position
 func (s *AngularServoDriver) Center() (err error) {
-	return s.Move(s.MaxAngle / 2.0)
+	return s.Move((s.MaxAngle - s.MinAngle) / 2.0)
 }
 
 // Max sets the servo to its maximum position

--- a/drivers/gpio/gpio.go
+++ b/drivers/gpio/gpio.go
@@ -48,6 +48,7 @@ const (
 type PwmWriter interface {
 	gobot.Adaptor
 	PwmWrite(string, byte) (err error)
+	SetPwmPeriod(string, float64) (err error)
 }
 
 // ServoWriter interface represents an Adaptor which has Servo capabilities

--- a/platforms/raspi/raspi_adaptor.go
+++ b/platforms/raspi/raspi_adaptor.go
@@ -190,6 +190,22 @@ func (r *Adaptor) PwmWrite(pin string, val byte) (err error) {
 	return r.piBlaster(fmt.Sprintf("%v=%v\n", sysfsPin, gobot.FromScale(float64(val), 0, 255)))
 }
 
+// SetPwmPeriod writes a PWM signal of the given period to the specified pin
+func (r *Adaptor) SetPwmPeriod(pin string, period float64) (err error) {
+	sysfsPin, err := r.pwmPin(pin)
+	if err != nil {
+		return err
+	}
+	const maxPeriod float64 = 0.01 //10000us
+	const minPeriod float64 = 0    //10us
+	if period < minPeriod || period > maxPeriod {
+		return errors.New("Out of bound: the PWM value must be between 0 and 1")
+	}
+
+	val := (period - minPeriod) / (maxPeriod - minPeriod)
+	return r.piBlaster(fmt.Sprintf("%v=%v\n", sysfsPin, val))
+}
+
 // ServoWrite writes a servo signal to the specified pin
 func (r *Adaptor) ServoWrite(pin string, angle byte) (err error) {
 	sysfsPin, err := r.pwmPin(pin)


### PR DESCRIPTION
Hello,

I've been trying to use servos with Gobot on the Raspberry Pi, and I think it's currently a bit too limited to support all cases. I'm proposing this change to offer better support. The improvements are:
* Support for custom angle range (you can say that you servo can go from -140 to +150 degrees)
* Support for custom PWM timings, as servos are not using the same periods for the signal.
* Added interface to set the PWM signal period in seconds which removes the need for a ServoWriter interface. It means that any platform which supports PWM supports servos, with less code.
* That change also improves the precision of the positioning, as described in issue #287 

The last point is a breaking change, and currently only works on Raspberry Pi - I don't know the other platforms. You have to consider that this is a work in progress.

The creation of a new instance would be like that:
`servo := gpio.NewAngularServoDriver(r, "40", gpio.WithServoAngles(-80.0, 80.0), gpio.WithPeriodRange(0.7/1000.0, 2.3/1000.0))`
With the gpio.WithServoAngles and gpio.WithPeriodRange being optional, defaulting to current values in the servo implementation.

And the interface to move the servo remains unchanged (except that angles are float):
`servo.Move(45.8)`

What do you think? Do you think it could be a good change for Gobot?
