### PR TITLE
Fixed raspi adaptor race conditions

### DIFF
--- a/platforms/raspi/raspi_adaptor.go
+++ b/platforms/raspi/raspi_adaptor.go
@@ -12,6 +12,7 @@ import (
 	"gobot.io/x/gobot"
 	"gobot.io/x/gobot/drivers/i2c"
 	"gobot.io/x/gobot/sysfs"
+	"sync"
 )
 
 var readFile = func() ([]byte, error) {
@@ -20,6 +21,7 @@ var readFile = func() ([]byte, error) {
 
 // Adaptor is the Gobot Adaptor for the Raspberry Pi
 type Adaptor struct {
+	mutex         *sync.Mutex
 	name          string
 	revision      string
 	digitalPins   map[int]sysfs.DigitalPin
@@ -31,6 +33,7 @@ type Adaptor struct {
 // NewAdaptor creates a Raspi Adaptor
 func NewAdaptor() *Adaptor {
 	r := &Adaptor{
+		mutex:       &sync.Mutex{},
 		name:        gobot.DefaultName("RaspberryPi"),
 		digitalPins: make(map[int]sysfs.DigitalPin),
 		pwmPins:     []int{},
@@ -56,10 +59,20 @@ func NewAdaptor() *Adaptor {
 }
 
 // Name returns the Adaptor's name
-func (r *Adaptor) Name() string { return r.name }
+func (r *Adaptor) Name() string {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	return r.name
+}
 
 // SetName sets the Adaptor's name
-func (r *Adaptor) SetName(n string) { r.name = n }
+func (r *Adaptor) SetName(n string) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.name = n
+}
 
 // Connect starts connection with board and creates
 // digitalPins and pwmPins adaptor maps
@@ -69,6 +82,9 @@ func (r *Adaptor) Connect() (err error) {
 
 // Finalize closes connection to board and pins
 func (r *Adaptor) Finalize() (err error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
 	for _, pin := range r.digitalPins {
 		if pin != nil {
 			if perr := pin.Unexport(); err != nil {
@@ -109,17 +125,16 @@ func (r *Adaptor) pwmPin(pin string) (i int, err error) {
 		return
 	}
 
-	newPin := true
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
 	for _, pin := range r.pwmPins {
 		if i == pin {
-			newPin = false
 			return
 		}
 	}
 
-	if newPin {
-		r.pwmPins = append(r.pwmPins, i)
-	}
+	r.pwmPins = append(r.pwmPins, i)
 
 	return
 }
@@ -132,18 +147,31 @@ func (r *Adaptor) digitalPin(pin string, dir string) (sysfsPin sysfs.DigitalPin,
 		return
 	}
 
-	if r.digitalPins[i] == nil {
-		r.digitalPins[i] = sysfs.NewDigitalPin(i)
-		if err = r.digitalPins[i].Export(); err != nil {
+	currentPin, err := r.getExportedDigitalPin(i, dir)
+
+	if err != nil {
+		return
+	}
+
+	if err = currentPin.Direction(dir); err != nil {
+		return
+	}
+
+	return currentPin, nil
+}
+
+func (r *Adaptor) getExportedDigitalPin(translatedPin int, dir string) (sysfsPin sysfs.DigitalPin, err error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if r.digitalPins[translatedPin] == nil {
+		r.digitalPins[translatedPin] = sysfs.NewDigitalPin(translatedPin)
+		if err = r.digitalPins[translatedPin].Export(); err != nil {
 			return
 		}
 	}
 
-	if err = r.digitalPins[i].Direction(dir); err != nil {
-		return
-	}
-
-	return r.digitalPins[i], nil
+	return r.digitalPins[translatedPin], nil
 }
 
 // DigitalRead reads digital value from pin
@@ -170,10 +198,21 @@ func (r *Adaptor) GetConnection(address int, bus int) (connection i2c.Connection
 	if (bus < 0) || (bus > 1) {
 		return nil, fmt.Errorf("Bus number %d out of range", bus)
 	}
+
+	device, err := r.getI2cBus(bus)
+
+	return i2c.NewConnection(device, address), err
+}
+
+func (r *Adaptor) getI2cBus(bus int) (_ sysfs.I2cDevice, err error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
 	if r.i2cBuses[bus] == nil {
 		r.i2cBuses[bus], err = sysfs.NewI2cDevice(fmt.Sprintf("/dev/i2c-%d", bus))
 	}
-	return i2c.NewConnection(r.i2cBuses[bus], address), err
+
+	return r.i2cBuses[bus], err
 }
 
 // GetDefaultBus returns the default i2c bus for this platform


### PR DESCRIPTION
(my first PR for this repo, I hope I did everything right. Since it is an hotfix, I'm pulling into the master :crossed_fingers:)

# TL;DR

Since raspi adaptor is accessed concurrently, it must be thread safe

# The problem

I'm developing a Raspberry 3 project that uses Gobot to read from digital input pins. 
This project uses many concurrent goroutines, so I set `runtime.GOMAXPROCS(4)`.
When I ran it sometimes I got: 

```
fatal error: concurrent map writes

goroutine 38 [running]:
runtime.throw(0x39b4e9, 0x15)
	/usr/local/go/src/runtime/panic.go:596 +0x70 fp=0x108f3ecc sp=0x108f3ec0
runtime.mapassign(0x353d08, 0x108117c0, 0x108f3f3c, 0x0)
	/usr/local/go/src/runtime/hashmap.go:589 +0x274 fp=0x108f3f1c sp=0x108f3ecc
gobot.io/x/gobot/platforms/raspi.(*Adaptor).digitalPin(0x1084e940, 0x108afa68, 0x2, 0x395a07, 0x2, 0x0, 0x0, 0x0, 0x0)
	/home/pi/go/src/gobot.io/x/gobot/platforms/raspi/raspi_adaptor.go:136 +0x1c0 fp=0x108f3f4c sp=0x108f3f1c
gobot.io/x/gobot/platforms/raspi.(*Adaptor).DigitalRead(0x1084e940, 0x108afa68, 0x2, 0x0, 0x0, 0x0)
	/home/pi/go/src/gobot.io/x/gobot/platforms/raspi/raspi_adaptor.go:151 +0x3c fp=0x108f3f74 sp=0x108f3f4c
gobot.io/x/gobot/drivers/gpio.(*ButtonDriver).Start.func1(0x10816510, 0x10904430)
	/home/pi/go/src/gobot.io/x/gobot/drivers/gpio/button_driver.go:57 +0x38 fp=0x108f3fe4 sp=0x108f3f74
runtime.goexit()
	/usr/local/go/src/runtime/asm_arm.s:1017 +0x4 fp=0x108f3fe4 sp=0x108f3fe4
created by gobot.io/x/gobot/drivers/gpio.(*ButtonDriver).Start
	/home/pi/go/src/gobot.io/x/gobot/drivers/gpio/button_driver.go:70 +0x48
	
[... cut ...]
```

# The cause

When a `robot.Start()` is called, it starts the ButtonDrivers in a cycle. `buttonDriver.Start()` creates a goroutine that polls its pin; this way we have N concurrent accesses to the adaptor.
Raspi adaptor generates the pins in a lazy way, using a map to keep the references to the created ones.
Go panics when detects that a map is accessed concurrently (worse: it panics and exits the program and cannot be recovered)

# The solution

We have to properly synchronize the adaptor to avoid those kind of issues. Looking at the source code, we can found similar problems for pwmPins and i2cBuses (both backed by an array).
I added a couple of tests to verify two package internal functions. I know that many people dislike this white-box approach, but in this case the correctness is more important :) Please note that `TestAdaptor_concurrentDigitalPin` fails in a brutal way, since we cannot recover from a concurrent access to a map.
After that I added a `*sync.Mutex` to `Adaptor` that is used to protect the critical sections of every mutable variable, `name` included, to respect the memory model of the language.
I also refactored a bit the functions to make the code clearer and simpler.
When I had to choose between performance and safety, I preferred the latter thinking about the typical use case for this component: usually its component are accessed at the startup with low contention, so the mutex overhead is really negligible.
