### PR TITLE
Issue #424: Enables humidity readings in the BME280 driver by enforci…

### DIFF
--- a/drivers/i2c/bme280_driver.go
+++ b/drivers/i2c/bme280_driver.go
@@ -7,6 +7,7 @@ import (
 )
 
 const bme280RegisterControlHumidity = 0xF2
+const bme280RegisterControl = 0xf4
 const bme280RegisterHumidityMSB = 0xFD
 const bme280RegisterCalibDigH1 = 0xa1
 const bme280RegisterCalibDigH2LSB = 0xe1
@@ -113,6 +114,7 @@ func (d *BME280Driver) initHumidity() (err error) {
 	d.hc.h5 = 0 + (int16(addrE6) << 4) | (int16(addrE5) >> 4)
 
 	d.connection.WriteByteData(bme280RegisterControlHumidity, 0x3F)
+	d.connection.WriteByteData(bmp280RegisterControl, 0x3F)
 
 	return nil
 }

--- a/drivers/i2c/bme280_driver.go
+++ b/drivers/i2c/bme280_driver.go
@@ -117,9 +117,10 @@ func (d *BME280Driver) initHumidity() (err error) {
 	// The 'ctrl_hum' register sets the humidity data acquisition options of
 	// the device. Changes to this register only become effective after a write
 	// operation to 'ctrl_meas'. Read the current value in, then write it back
-	cmr, err := d.connection.ReadByteData(bmp280RegisterControl)
-	if err != nil {
-		d.connection.WriteByteData(bmp280RegisterControl, cmr)
+	var cmr uint8
+	cmr, err = d.connection.ReadByteData(bmp280RegisterControl)
+	if err == nil {
+		err = d.connection.WriteByteData(bmp280RegisterControl, cmr)
 	}
 	return err
 }

--- a/drivers/i2c/bme280_driver_test.go
+++ b/drivers/i2c/bme280_driver_test.go
@@ -39,7 +39,12 @@ func TestBME280Driver(t *testing.T) {
 }
 
 func TestBME280DriverStart(t *testing.T) {
-	bme280, _ := initTestBME280DriverWithStubbedAdaptor()
+	bme280, adaptor := initTestBME280DriverWithStubbedAdaptor()
+	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+		// Simulate returning a single byte for the
+		// ReadByteData(bmp280RegisterControl) call in Start()
+		return 1, nil
+	}
 	gobottest.Assert(t, bme280.Start(), nil)
 }
 


### PR DESCRIPTION
…ng the write to the 'ctrl_meas' register, as per Section 5.4.3 of the BME280 data sheet

Signed-off-by: Graeme Cross <graeme@ceriumdesigns.com>