### PR TITLE
Fix for broken PWM on C.H.I.P

### DIFF
--- a/platforms/chip/chip_adaptor.go
+++ b/platforms/chip/chip_adaptor.go
@@ -179,6 +179,10 @@ func (c *Adaptor) PWMPin(pin string) (sysfsPin sysfs.PWMPinner, err error) {
 			if err = newPin.Export(); err != nil {
 				return
 			}
+			// Make sure pwm is disabled when setting polarity
+			if err = newPin.Enable(false); err != nil {
+				return
+			}
 			if err = newPin.InvertPolarity(false); err != nil {
 				return
 			}

--- a/platforms/chip/chip_adaptor.go
+++ b/platforms/chip/chip_adaptor.go
@@ -179,13 +179,13 @@ func (c *Adaptor) PWMPin(pin string) (sysfsPin sysfs.PWMPinner, err error) {
 			if err = newPin.Export(); err != nil {
 				return
 			}
+			if err = newPin.InvertPolarity(false); err != nil {
+				return
+			}
 			if err = newPin.Enable(true); err != nil {
 				return
 			}
 			if err = newPin.SetPeriod(10000000); err != nil {
-				return
-			}
-			if err = newPin.InvertPolarity(false); err != nil {
 				return
 			}
 			c.pwmPins[sysPin.pwmPin] = newPin

--- a/platforms/chip/chip_adaptor.go
+++ b/platforms/chip/chip_adaptor.go
@@ -212,9 +212,6 @@ func (c *Adaptor) PwmWrite(pin string, val byte) (err error) {
 	return pwmPin.SetDutyCycle(uint32(float64(period) * duty))
 }
 
-// TODO: take into account the actual period setting, not just assume default
-const pwmPeriod = 10000000
-
 // ServoWrite writes a servo signal to the specified pin
 func (c *Adaptor) ServoWrite(pin string, angle byte) (err error) {
 	pwmPin, err := c.PWMPin(pin)
@@ -225,8 +222,10 @@ func (c *Adaptor) ServoWrite(pin string, angle byte) (err error) {
 	// 0.5 ms => -90
 	// 1.5 ms =>   0
 	// 2.0 ms =>  90
-	const minDuty = 100 * 0.0005 * pwmPeriod
-	const maxDuty = 100 * 0.0020 * pwmPeriod
+	//
+	// Duty cycle is in nanos
+	const minDuty = 0.0005 * 1e9
+	const maxDuty = 0.0020 * 1e9
 	duty := uint32(gobot.ToScale(gobot.FromScale(float64(angle), 0, 180), minDuty, maxDuty))
 	return pwmPin.SetDutyCycle(duty)
 }

--- a/platforms/tinkerboard/adaptor.go
+++ b/platforms/tinkerboard/adaptor.go
@@ -174,13 +174,17 @@ func (c *Adaptor) PWMPin(pin string) (sysfsPin sysfs.PWMPinner, err error) {
 		if err = newPin.Export(); err != nil {
 			return
 		}
+		// Make sure pwm is disabled when setting polarity
+		if err = newPin.Enable(false); err != nil {
+			return
+		}
+		if err = newPin.InvertPolarity(false); err != nil {
+			return
+		}
 		if err = newPin.Enable(true); err != nil {
 			return
 		}
 		if err = newPin.SetPeriod(10000000); err != nil {
-			return
-		}
-		if err = newPin.InvertPolarity(false); err != nil {
 			return
 		}
 		c.pwmPins[i] = newPin

--- a/sysfs/pwm_pin.go
+++ b/sysfs/pwm_pin.go
@@ -102,12 +102,14 @@ func (p *PWMPin) Polarity() (polarity string, err error) {
 
 // InvertPolarity writes value to pwm polarity path
 func (p *PWMPin) InvertPolarity(invert bool) (err error) {
-	if p.enabled {
+	if !p.enabled {
 		polarity := "normal"
 		if invert {
 			polarity = "inverted"
 		}
 		_, err = p.write(p.pwmPolarityPath(), []byte(polarity))
+	} else {
+		err = fmt.Errorf("Cannot set PWM polarity when enabled")
 	}
 	return
 }

--- a/sysfs/pwm_pin_test.go
+++ b/sysfs/pwm_pin_test.go
@@ -33,6 +33,15 @@ func TestPwmPin(t *testing.T) {
 	gobottest.Assert(t, err, nil)
 	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/export"].Contents, "10")
 
+	gobottest.Assert(t, pin.InvertPolarity(true), nil)
+	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm10/polarity"].Contents, "inverted")
+	pol, _ := pin.Polarity()
+	gobottest.Assert(t, pol, "inverted")
+	gobottest.Assert(t, pin.InvertPolarity(false), nil)
+	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm10/polarity"].Contents, "normal")
+	pol, _ = pin.Polarity()
+	gobottest.Assert(t, pol, "normal")
+
 	gobottest.Refute(t, fs.Files["/sys/class/pwm/pwmchip0/pwm10/enable"].Contents, "1")
 	err = pin.Enable(true)
 	gobottest.Assert(t, err, nil)
@@ -44,15 +53,6 @@ func TestPwmPin(t *testing.T) {
 	gobottest.Assert(t, pin.SetPeriod(100000), nil)
 	data, _ = pin.Period()
 	gobottest.Assert(t, data, uint32(100000))
-
-	gobottest.Assert(t, pin.InvertPolarity(true), nil)
-	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm10/polarity"].Contents, "inverted")
-	pol, _ := pin.Polarity()
-	gobottest.Assert(t, pol, "inverted")
-	gobottest.Assert(t, pin.InvertPolarity(false), nil)
-	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm10/polarity"].Contents, "normal")
-	pol, _ = pin.Polarity()
-	gobottest.Assert(t, pol, "normal")
 
 	gobottest.Refute(t, fs.Files["/sys/class/pwm/pwmchip0/pwm10/duty_cycle"].Contents, "1")
 	err = pin.SetDutyCycle(100)


### PR DESCRIPTION
This PR fixes the PWM implementation after the recent refactoring:
  * Changed init order to set polarity in "disabled" state
  * Fixed `ServoWrite` to handle the change from frequency to duration