### PR TITLE
littlewire.cc links changed to littlewire.github.io

### DIFF
--- a/platforms/digispark/README.md
+++ b/platforms/digispark/README.md
@@ -2,7 +2,7 @@
 
 The Digispark is an Attiny85 based microcontroller development board similar to the Arduino line, only cheaper, smaller, and a bit less powerful. With a whole host of shields to extend its functionality and the ability to use the familiar Arduino IDE the Digispark is a great way to jump into electronics, or perfect for when an Arduino is too big or too much.
 
-This package provides the Gobot adaptor for the [Digispark](http://digistump.com/products/1) ATTiny-based USB development board with the [Little Wire](http://littlewire.cc/) protocol firmware installed.
+This package provides the Gobot adaptor for the [Digispark](http://digistump.com/products/1) ATTiny-based USB development board with the [Little Wire](http://littlewire.github.io/) protocol firmware installed.
 
 ## How to Install
 

--- a/platforms/digispark/littleWire.c
+++ b/platforms/digispark/littleWire.c
@@ -1,7 +1,7 @@
 /*
   Cross platform computer interface library for Little Wire project
 
-  http://littlewire.cc
+  http://littlewire.github.io
 
   Copyright (C) <2013> ihsan Kehribar <ihsan@kehribar.me>
   Copyright (C) <2013> Omer Kilic <omerkilic@gmail.com>

--- a/platforms/digispark/littleWire.h
+++ b/platforms/digispark/littleWire.h
@@ -4,7 +4,7 @@
 /*
   Cross platform computer interface library for Little Wire project
 
-  http://littlewire.cc
+  http://littlewire.github.io
 
   Copyright (C) <2013> ihsan Kehribar <ihsan@kehribar.me>
   Copyright (C) <2013> Omer Kilic <omerkilic@gmail.com>


### PR DESCRIPTION
Hi,

Little-Wire author here. 

I decided *not* to renew littlewire.cc domain this year. I forked the repo and renamed the domain names to reflect the change.

Best,
ihsan.