### PR TITLE
Add Linux specific step to Intel Curie docs

### DIFF
--- a/platforms/intel-iot/curie/README.md
+++ b/platforms/intel-iot/curie/README.md
@@ -93,6 +93,12 @@ To setup your Arduino environment:
 
 	Once you have downloaded the FirmataCurieIMU library, install it by using the "Library Manager". You can find it in the Arduino IDE under the "Sketch" menu. Choose "Include Library > Add .ZIP Library". Select the ZIP file for the FirmataCurieIMU library that you just downloaded.
 
+- Linux only: On some Linux distributions, additional device rules are required in order to connect to the board. Run the following command then unplug the board and plug it back in before proceeding:
+
+  ```sh
+  curl -sL https://raw.githubusercontent.com/01org/corelibs-arduino101/master/scripts/create_dfu_udev_rule | sudo -E bash -
+  ```
+
 Now you are ready to install your firmware. You must decide if you want to connect via the serial port, or using Bluetooth LE.
 
 ### Serial Port


### PR DESCRIPTION
- My Ubuntu 16.04 installation was initially unable to communicate with
  the intel TinyTile with "unable to connect. Perhaps you need to flash
  your Arduino with Firmata?"
- After digging through some forums, the fix is to add some `udev`
  rules. Although I'm not sure of the specific effect of these rules, I can
  confirm the running `sudo go run main.go` is not sufficient to connect to the board.
- After running the included script, unplugging the board and plugging back in, the board connected as expected.
- Rule script:
  https://raw.githubusercontent.com/01org/corelibs-arduino101/master/scripts/create_dfu_udev_rule