### PR TITLE
Support for more commands in Ollie driver

### DIFF
--- a/examples/ollie_boost.go
+++ b/examples/ollie_boost.go
@@ -1,0 +1,39 @@
+// +build example
+//
+// Do not build by default.
+
+package main
+
+import (
+	"os"
+	"time"
+
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/platforms/ble"
+	"gobot.io/x/gobot/platforms/sphero/ollie"
+)
+
+func main() {
+	bleAdaptor := ble.NewClientAdaptor(os.Args[1])
+	ollieBot := ollie.NewDriver(bleAdaptor)
+
+	work := func() {
+		head := 90
+		ollieBot.SetRGB(255, 0, 0)
+		ollieBot.Boost(true)
+		gobot.Every(1*time.Second, func() {
+			ollieBot.Roll(0, uint16(head))
+			time.Sleep(1 * time.Second)
+			head += 90
+			head = head % 360
+		})
+	}
+
+	robot := gobot.NewRobot("ollieBot",
+		[]gobot.Connection{bleAdaptor},
+		[]gobot.Device{ollieBot},
+		work,
+	)
+
+	robot.Start()
+}

--- a/examples/ollie_crazy.go
+++ b/examples/ollie_crazy.go
@@ -1,0 +1,35 @@
+// +build example
+//
+// Do not build by default.
+
+package main
+
+import (
+	"os"
+	"time"
+
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/platforms/ble"
+	"gobot.io/x/gobot/platforms/sphero/ollie"
+)
+
+func main() {
+	bleAdaptor := ble.NewClientAdaptor(os.Args[1])
+	ollieBot := ollie.NewDriver(bleAdaptor)
+
+	work := func() {
+		ollieBot.SetRGB(255, 0, 255)
+		gobot.Every(1*time.Second, func() {
+			// Ollie performs 'crazy-ollie' trick
+			ollieBot.SetRawMotorValues(ollie.Forward, uint8(255), ollie.Forward, uint8(255))
+		})
+	}
+
+	robot := gobot.NewRobot("ollieBot",
+		[]gobot.Connection{bleAdaptor},
+		[]gobot.Device{ollieBot},
+		work,
+	)
+
+	robot.Start()
+}

--- a/examples/ollie_spin.go
+++ b/examples/ollie_spin.go
@@ -1,0 +1,35 @@
+// +build example
+//
+// Do not build by default.
+
+package main
+
+import (
+	"os"
+	"time"
+
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/platforms/ble"
+	"gobot.io/x/gobot/platforms/sphero/ollie"
+)
+
+func main() {
+	bleAdaptor := ble.NewClientAdaptor(os.Args[1])
+	ollieBot := ollie.NewDriver(bleAdaptor)
+
+	work := func() {
+		ollieBot.SetRGB(255, 0, 255)
+		gobot.Every(1*time.Second, func() {
+			// Ollie performs 360 spin trick
+			ollieBot.SetRawMotorValues(ollie.Forward, uint8(255), ollie.Reverse, uint8(255))
+		})
+	}
+
+	robot := gobot.NewRobot("ollieBot",
+		[]gobot.Connection{bleAdaptor},
+		[]gobot.Device{ollieBot},
+		work,
+	)
+
+	robot.Start()
+}


### PR DESCRIPTION
Referring to Sphero API documentation: https://github.com/orbotix/DeveloperResources/blob/master/docs/Sphero_API_1.50.pdf, I have added support of following commands in Ollie driver
        - Set Stabilization
	- Set Rotation Rate
	- Boost
	- Set Raw Motor Values
	- Set Back LED Output

Tested on 'Sphero Ollie 2B-B4F0' bot and added examples for tricks.