### PR TITLE
Initial support for MAX7219 & MAX7221 led drivers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: required
 dist: trusty
 go_import_path: gobot.io/x/gobot
 go:
-   - 1.8.7
    - 1.9.4
+   - "1.10"
    - tip
 matrix:
    allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+1.9.0
+---
+* **beaglebone**
+  * update pin naming, docs, and examples for the latest Debian OS releases
+* **opencv**
+  * update build settings needed to build OpenCV/GoCV as part of test suite
+  * deps for latest GoCV v0.9.0
+* **build**
+  * update Travis build to use very latest Go versions
+* **docs**
+  * add references to new drivers for ADXL345, BH1750, and TM1638.
+  * improve docs for installation and use of OpenCV/GoCV from Gobot
+  * update copyright date to 2018
+* **gpio**
+  * Initial support for TM1638 modules
+* **i2c**
+  * Added basic driver for BH1750 (light sensor), board GY-302
+  * support for accel ADXL345
+* **bb8/ollie/sprkplus**
+  * add Boost command
+  * add Set Back LED Output command
+  * add Set Raw Motor Values command
+  * add Set Rotation Rate command
+  * add Set Stabilization command
+* **test** 
+  * Refactor TestAdaptorDigitalPinConcurrency test
+
 1.8.0
 ---
 * **sysfs** 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,6 @@ https://github.com/hybridgroup/gobot/issues
 
 - ensure that SMBUS operations are working as expected.
 - add support for the following i2c devices:
-   - ADXL345
    - HMC5883L
    - LSM303DLHC
    - MAG3110

--- a/cli/generate.go
+++ b/cli/generate.go
@@ -31,7 +31,7 @@ func Generate() cli.Command {
 				}
 			}
 			if valid == false {
-				fmt.Println("Invalid/no subcommand supplied.\n")
+				fmt.Println("Invalid/no subcommand supplied.")
 				fmt.Println("Usage:")
 				fmt.Println(" gobot generate adaptor <name> [package] # generate a new Gobot adaptor")
 				fmt.Println(" gobot generate driver  <name> [package] # generate a new Gobot driver")

--- a/drivers/gpio/max72xx_driver.go
+++ b/drivers/gpio/max72xx_driver.go
@@ -5,14 +5,14 @@ import (
 )
 
 const (
-	MAX72xxDigit0  = 0x01
-	MAX72xxDigit1  = 0x02
-	MAX72xxDigit2  = 0x03
-	MAX72xxDigit3  = 0x04
-	MAX72xxDigit4  = 0x05
-	MAX72xxDigit5  = 0x06
-	MAX72xxDigit6  = 0x07
-	MAX72xxDigit7  = 0x08
+	MAX72xxDigit0 = 0x01
+	MAX72xxDigit1 = 0x02
+	MAX72xxDigit2 = 0x03
+	MAX72xxDigit3 = 0x04
+	MAX72xxDigit4 = 0x05
+	MAX72xxDigit5 = 0x06
+	MAX72xxDigit6 = 0x07
+	MAX72xxDigit7 = 0x08
 
 	MAX72xxDecodeMode  = 0x09
 	MAX72xxIntensity   = 0x0a

--- a/drivers/gpio/max72xx_driver.go
+++ b/drivers/gpio/max72xx_driver.go
@@ -5,6 +5,15 @@ import (
 )
 
 const (
+	MAX72xxDigit0  = 0x01
+	MAX72xxDigit1  = 0x02
+	MAX72xxDigit2  = 0x03
+	MAX72xxDigit3  = 0x04
+	MAX72xxDigit4  = 0x05
+	MAX72xxDigit5  = 0x06
+	MAX72xxDigit6  = 0x07
+	MAX72xxDigit7  = 0x08
+
 	MAX72xxDecodeMode  = 0x09
 	MAX72xxIntensity   = 0x0a
 	MAX72xxScanLimit   = 0x0b

--- a/drivers/gpio/max72xx_driver.go
+++ b/drivers/gpio/max72xx_driver.go
@@ -1,0 +1,146 @@
+package gpio
+
+import (
+	"gobot.io/x/gobot"
+)
+
+const (
+	MAX72xxDecodeMode  = 0x09
+	MAX72xxIntensity   = 0x0a
+	MAX72xxScanLimit   = 0x0b
+	MAX72xxShutdown    = 0x0c
+	MAX72xxDisplayTest = 0x0f
+)
+
+// MAX72xxDriver is the gobot driver for the MAX7219 & MAX7221 LED drivers
+//
+// Datasheet: https://datasheets.maximintegrated.com/en/ds/MAX7219-MAX7221.pdf
+type MAX72xxDriver struct {
+	pinClock   *DirectPinDriver
+	pinData    *DirectPinDriver
+	pinCS      *DirectPinDriver
+	name       string
+	count      uint
+	connection gobot.Connection
+	gobot.Commander
+}
+
+// NewMAX72xxDriver return a new MAX72xxDriver given a gobot.Connection, pins and how many chips are chained
+func NewMAX72xxDriver(a gobot.Connection, clockPin string, dataPin string, csPin string, count uint) *MAX72xxDriver {
+	t := &MAX72xxDriver{
+		name:       gobot.DefaultName("MAX72xxDriver"),
+		pinClock:   NewDirectPinDriver(a, clockPin),
+		pinData:    NewDirectPinDriver(a, dataPin),
+		pinCS:      NewDirectPinDriver(a, csPin),
+		count:      count,
+		connection: a,
+		Commander:  gobot.NewCommander(),
+	}
+
+	/* TODO : Add commands */
+
+	return t
+}
+
+// Start initializes the max72xx, it uses a SPI-like communication protocol
+func (a *MAX72xxDriver) Start() (err error) {
+	a.pinData.On()
+	a.pinClock.On()
+	a.pinCS.On()
+
+	a.All(MAX72xxScanLimit, 0x07)
+	a.All(MAX72xxDecodeMode, 0x00)
+	a.All(MAX72xxShutdown, 0x01)
+	a.All(MAX72xxDisplayTest, 0x00)
+	a.ClearAll()
+	a.All(MAX72xxIntensity, 0x0f&0x0f)
+
+	return
+}
+
+// Halt implements the Driver interface
+func (a *MAX72xxDriver) Halt() (err error) { return }
+
+// Name returns the MAX72xxDrivers name
+func (a *MAX72xxDriver) Name() string { return a.name }
+
+// SetName sets the MAX72xxDrivers name
+func (a *MAX72xxDriver) SetName(n string) { a.name = n }
+
+// Connection returns the MAX72xxDriver Connection
+func (a *MAX72xxDriver) Connection() gobot.Connection {
+	return a.connection
+}
+
+// SetIntensity changes the intensity (from 1 to 7) of the display
+func (a *MAX72xxDriver) SetIntensity(level byte) {
+	if level > 15 {
+		level = 15
+	}
+	a.All(MAX72xxIntensity, level&level)
+}
+
+// ClearAll turns off all LEDs of all modules
+func (a *MAX72xxDriver) ClearAll() {
+	for i := 1; i <= 8; i++ {
+		a.All(byte(i), 0)
+	}
+}
+
+// ClearAll turns off all LEDs of the given module
+func (a *MAX72xxDriver) ClearOne(which uint) {
+	for i := 1; i <= 8; i++ {
+		a.One(which, byte(i), 0)
+	}
+}
+
+// sendData is an auxiliary function to send data to the MAX72xxDriver module
+func (a *MAX72xxDriver) sendData(address byte, data byte) {
+	a.pinCS.Off()
+	a.send(address)
+	a.send(data)
+	a.pinCS.On()
+}
+
+// send writes data on the module
+func (a *MAX72xxDriver) send(data byte) {
+	var i byte
+	for i = 8; i > 0; i-- {
+		mask := byte(0x01 << (i - 1))
+
+		a.pinClock.Off()
+		if data&mask > 0 {
+			a.pinData.On()
+		} else {
+			a.pinData.Off()
+		}
+		a.pinClock.On()
+	}
+}
+
+// All sends the same data to all the modules
+func (a *MAX72xxDriver) All(address byte, data byte) {
+	a.pinCS.Off()
+	var c uint
+	for c = 0; c < a.count; c++ {
+		a.send(address)
+		a.send(data)
+	}
+	a.pinCS.On()
+}
+
+// One sends data to a specific module
+func (a *MAX72xxDriver) One(which uint, address byte, data byte) {
+	a.pinCS.Off()
+	var c uint
+	for c = 0; c < a.count; c++ {
+		if c == which {
+			a.send(address)
+			a.send(data)
+		} else {
+			a.send(0)
+			a.send(0)
+		}
+	}
+	a.pinCS.On()
+}

--- a/drivers/gpio/max72xx_driver_test.go
+++ b/drivers/gpio/max72xx_driver_test.go
@@ -1,0 +1,53 @@
+package gpio
+
+import (
+	"strings"
+	"testing"
+
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/gobottest"
+)
+
+var _ gobot.Driver = (*MAX72xxDriver)(nil)
+
+// --------- HELPERS
+func initTestMAX72xxDriver() (driver *MAX72xxDriver) {
+	driver, _ = initTestMAX72xxDriverWithStubbedAdaptor()
+	return
+}
+
+func initTestMAX72xxDriverWithStubbedAdaptor() (*MAX72xxDriver, *gpioTestAdaptor) {
+	adaptor := newGpioTestAdaptor()
+	return NewMAX72xxDriver(adaptor, "1", "2", "3", 1), adaptor
+}
+
+// --------- TESTS
+func TestMAX72xxDriver(t *testing.T) {
+	var a interface{} = initTestMAX72xxDriver()
+	_, ok := a.(*MAX72xxDriver)
+	if !ok {
+		t.Errorf("NewMAX72xxDriver() should have returned a *MAX72xxDriver")
+	}
+}
+
+func TestMAX72xxDriverStart(t *testing.T) {
+	d := initTestMAX72xxDriver()
+	gobottest.Assert(t, d.Start(), nil)
+}
+
+func TestMAX72xxDriverHalt(t *testing.T) {
+	d := initTestMAX72xxDriver()
+	gobottest.Assert(t, d.Halt(), nil)
+}
+
+func TestMAX72xxDriverDefaultName(t *testing.T) {
+	d := initTestMAX72xxDriver()
+	gobottest.Assert(t, strings.HasPrefix(d.Name(), "MAX72xxDriver"), true)
+}
+
+func TestMAX72xxDriverSetName(t *testing.T) {
+	d := initTestMAX72xxDriver()
+	d.SetName("mybot")
+	gobottest.Assert(t, d.Name(), "mybot")
+}
+

--- a/examples/firmata_max72xx.go
+++ b/examples/firmata_max72xx.go
@@ -1,0 +1,68 @@
+// +build example
+//
+// Do not build by default.
+
+/*
+ How to setup
+ This examples requires you to daisy-chain 4 led matrices based on either MAX7219 or MAX7221.
+ It will turn on one led at a time, from the first led at the first matrix to the last led of the last matrix.
+
+ How to run
+ Pass serial port to use as the first param:
+
+	go run examples/firmata_max72xx.go /dev/ttyACM0
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/drivers/i2c"
+	"gobot.io/x/gobot/platforms/firmata"
+)
+
+func main() {
+	firmataAdaptor := firmata.NewAdaptor(os.Args[1])
+	max := gpio.NewMAX72xxDriver(firmataAdaptor, "11", "10", "9", 4)
+
+	var row byte = 1
+	var bits byte = 1
+	var module uint
+	count := 0
+
+	work := func() {
+		gobot.Every(100*time.Millisecond, func() {
+			max.ClearAll()
+			max.One(module, row, bits)
+			bits = bits << 1
+
+			count++
+			if count > 7 {
+				count = 0
+				row++
+				bits = 1
+				if row > 8 {
+					row = 1
+					module++
+					if module >= 4 {
+						module = 0
+						count = 0
+					}
+				}
+			}
+		})
+	}
+
+	robot := gobot.NewRobot("Max72xxBot",
+		[]gobot.Connection{esp8266},
+		[]gobot.Device{max},
+		work,
+	)
+
+
+	robot.Start()
+}

--- a/examples/firmata_max72xx.go
+++ b/examples/firmata_max72xx.go
@@ -16,12 +16,11 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"time"
 
 	"gobot.io/x/gobot"
-	"gobot.io/x/gobot/drivers/i2c"
+	"gobot.io/x/gobot/drivers/gpio"
 	"gobot.io/x/gobot/platforms/firmata"
 )
 
@@ -62,7 +61,6 @@ func main() {
 		[]gobot.Device{max},
 		work,
 	)
-
 
 	robot.Start()
 }

--- a/examples/firmata_max72xx.go
+++ b/examples/firmata_max72xx.go
@@ -29,7 +29,7 @@ func main() {
 	firmataAdaptor := firmata.NewAdaptor(os.Args[1])
 	max := gpio.NewMAX72xxDriver(firmataAdaptor, "11", "10", "9", 4)
 
-	var row byte = 1
+	var digit byte = 1 // digit address goes from 0x01 (MAX72xxDigit0) to 0x08 (MAX72xxDigit8)
 	var bits byte = 1
 	var module uint
 	count := 0
@@ -37,16 +37,16 @@ func main() {
 	work := func() {
 		gobot.Every(100*time.Millisecond, func() {
 			max.ClearAll()
-			max.One(module, row, bits)
+			max.One(module, digit, bits)
 			bits = bits << 1
 
 			count++
 			if count > 7 {
 				count = 0
-				row++
+				digit++
 				bits = 1
-				if row > 8 {
-					row = 1
+				if digit > 8 {
+					digit = 1
 					module++
 					if module >= 4 {
 						module = 0

--- a/platforms/ble/ble_client_adaptor.go
+++ b/platforms/ble/ble_client_adaptor.go
@@ -28,7 +28,7 @@ type BLEConnector interface {
 	ReadCharacteristic(string) ([]byte, error)
 	WriteCharacteristic(string, []byte) error
 	Subscribe(string, func([]byte, error)) error
-	WithoutReponses(bool)
+	WithoutResponses(bool)
 }
 
 // ClientAdaptor represents a Client Connection to a BLE Peripheral
@@ -42,19 +42,19 @@ type ClientAdaptor struct {
 	client  blelib.Client
 	profile *blelib.Profile
 
-	connected       bool
-	ready           chan struct{}
-	withoutReponses bool
+	connected        bool
+	ready            chan struct{}
+	withoutResponses bool
 }
 
 // NewClientAdaptor returns a new ClientAdaptor given an address or peripheral name
 func NewClientAdaptor(address string) *ClientAdaptor {
 	return &ClientAdaptor{
-		name:            gobot.DefaultName("BLEClient"),
-		address:         address,
-		DeviceName:      "default",
-		connected:       false,
-		withoutReponses: false,
+		name:             gobot.DefaultName("BLEClient"),
+		address:          address,
+		DeviceName:       "default",
+		connected:        false,
+		withoutResponses: false,
 	}
 }
 
@@ -67,9 +67,9 @@ func (b *ClientAdaptor) SetName(n string) { b.name = n }
 // Address returns the Bluetooth LE address for the adaptor
 func (b *ClientAdaptor) Address() string { return b.address }
 
-// WithoutReponses sets if the adaptor should expect responses after
+// WithoutResponses sets if the adaptor should expect responses after
 // writing characteristics for this device
-func (b *ClientAdaptor) WithoutReponses(use bool) { b.withoutReponses = use }
+func (b *ClientAdaptor) WithoutResponses(use bool) { b.withoutResponses = use }
 
 // Connect initiates a connection to the BLE peripheral. Returns true on successful connection.
 func (b *ClientAdaptor) Connect() (err error) {
@@ -152,7 +152,7 @@ func (b *ClientAdaptor) WriteCharacteristic(cUUID string, data []byte) (err erro
 	uuid, _ := blelib.Parse(cUUID)
 
 	if u := b.profile.Find(blelib.NewCharacteristic(uuid)); u != nil {
-		err = b.client.WriteCharacteristic(u.(*blelib.Characteristic), data, b.withoutReponses)
+		err = b.client.WriteCharacteristic(u.(*blelib.Characteristic), data, b.withoutResponses)
 	}
 
 	return

--- a/platforms/ble/helpers_test.go
+++ b/platforms/ble/helpers_test.go
@@ -5,23 +5,23 @@ import "sync"
 var _ BLEConnector = (*bleTestClientAdaptor)(nil)
 
 type bleTestClientAdaptor struct {
-	name            string
-	address         string
-	mtx             sync.Mutex
-	withoutReponses bool
+	name             string
+	address          string
+	mtx              sync.Mutex
+	withoutResponses bool
 
 	testReadCharacteristic  func(string) ([]byte, error)
 	testWriteCharacteristic func(string, []byte) error
 }
 
-func (t *bleTestClientAdaptor) Connect() (err error)     { return }
-func (t *bleTestClientAdaptor) Reconnect() (err error)   { return }
-func (t *bleTestClientAdaptor) Disconnect() (err error)  { return }
-func (t *bleTestClientAdaptor) Finalize() (err error)    { return }
-func (t *bleTestClientAdaptor) Name() string             { return t.name }
-func (t *bleTestClientAdaptor) SetName(n string)         { t.name = n }
-func (t *bleTestClientAdaptor) Address() string          { return t.address }
-func (t *bleTestClientAdaptor) WithoutReponses(use bool) { t.withoutReponses = use }
+func (t *bleTestClientAdaptor) Connect() (err error)      { return }
+func (t *bleTestClientAdaptor) Reconnect() (err error)    { return }
+func (t *bleTestClientAdaptor) Disconnect() (err error)   { return }
+func (t *bleTestClientAdaptor) Finalize() (err error)     { return }
+func (t *bleTestClientAdaptor) Name() string              { return t.name }
+func (t *bleTestClientAdaptor) SetName(n string)          { t.name = n }
+func (t *bleTestClientAdaptor) Address() string           { return t.address }
+func (t *bleTestClientAdaptor) WithoutResponses(use bool) { t.withoutResponses = use }
 
 func (t *bleTestClientAdaptor) ReadCharacteristic(cUUID string) (data []byte, err error) {
 	t.mtx.Lock()

--- a/platforms/microbit/helpers_test.go
+++ b/platforms/microbit/helpers_test.go
@@ -9,24 +9,24 @@ import (
 var _ ble.BLEConnector = (*bleTestClientAdaptor)(nil)
 
 type bleTestClientAdaptor struct {
-	name            string
-	address         string
-	mtx             sync.Mutex
-	withoutReponses bool
+	name             string
+	address          string
+	mtx              sync.Mutex
+	withoutResponses bool
 
 	testSubscribe           func([]byte, error)
 	testReadCharacteristic  func(string) ([]byte, error)
 	testWriteCharacteristic func(string, []byte) error
 }
 
-func (t *bleTestClientAdaptor) Connect() (err error)     { return }
-func (t *bleTestClientAdaptor) Reconnect() (err error)   { return }
-func (t *bleTestClientAdaptor) Disconnect() (err error)  { return }
-func (t *bleTestClientAdaptor) Finalize() (err error)    { return }
-func (t *bleTestClientAdaptor) Name() string             { return t.name }
-func (t *bleTestClientAdaptor) SetName(n string)         { t.name = n }
-func (t *bleTestClientAdaptor) Address() string          { return t.address }
-func (t *bleTestClientAdaptor) WithoutReponses(use bool) { t.withoutReponses = use }
+func (t *bleTestClientAdaptor) Connect() (err error)      { return }
+func (t *bleTestClientAdaptor) Reconnect() (err error)    { return }
+func (t *bleTestClientAdaptor) Disconnect() (err error)   { return }
+func (t *bleTestClientAdaptor) Finalize() (err error)     { return }
+func (t *bleTestClientAdaptor) Name() string              { return t.name }
+func (t *bleTestClientAdaptor) SetName(n string)          { t.name = n }
+func (t *bleTestClientAdaptor) Address() string           { return t.address }
+func (t *bleTestClientAdaptor) WithoutResponses(use bool) { t.withoutResponses = use }
 
 func (t *bleTestClientAdaptor) ReadCharacteristic(cUUID string) (data []byte, err error) {
 	t.mtx.Lock()

--- a/platforms/parrot/minidrone/helpers_test.go
+++ b/platforms/parrot/minidrone/helpers_test.go
@@ -12,19 +12,19 @@ type bleTestClientAdaptor struct {
 	name                    string
 	address                 string
 	mtx                     sync.Mutex
-	withoutReponses         bool
+	withoutResponses        bool
 	testReadCharacteristic  func(string) ([]byte, error)
 	testWriteCharacteristic func(string, []byte) error
 }
 
-func (t *bleTestClientAdaptor) Connect() (err error)     { return }
-func (t *bleTestClientAdaptor) Reconnect() (err error)   { return }
-func (t *bleTestClientAdaptor) Disconnect() (err error)  { return }
-func (t *bleTestClientAdaptor) Finalize() (err error)    { return }
-func (t *bleTestClientAdaptor) Name() string             { return t.name }
-func (t *bleTestClientAdaptor) SetName(n string)         { t.name = n }
-func (t *bleTestClientAdaptor) Address() string          { return t.address }
-func (t *bleTestClientAdaptor) WithoutReponses(use bool) { t.withoutReponses = use }
+func (t *bleTestClientAdaptor) Connect() (err error)      { return }
+func (t *bleTestClientAdaptor) Reconnect() (err error)    { return }
+func (t *bleTestClientAdaptor) Disconnect() (err error)   { return }
+func (t *bleTestClientAdaptor) Finalize() (err error)     { return }
+func (t *bleTestClientAdaptor) Name() string              { return t.name }
+func (t *bleTestClientAdaptor) SetName(n string)          { t.name = n }
+func (t *bleTestClientAdaptor) Address() string           { return t.address }
+func (t *bleTestClientAdaptor) WithoutResponses(use bool) { t.withoutResponses = use }
 
 func (t *bleTestClientAdaptor) ReadCharacteristic(cUUID string) (data []byte, err error) {
 	t.mtx.Lock()

--- a/platforms/parrot/minidrone/minidrone_driver.go
+++ b/platforms/parrot/minidrone/minidrone_driver.go
@@ -152,7 +152,7 @@ func (b *Driver) adaptor() ble.BLEConnector {
 
 // Start tells driver to get ready to do work
 func (b *Driver) Start() (err error) {
-	b.adaptor().WithoutReponses(true)
+	b.adaptor().WithoutResponses(true)
 	b.Init()
 	b.FlatTrim()
 	b.StartPcmd()

--- a/platforms/sphero/bb8/helpers_test.go
+++ b/platforms/sphero/bb8/helpers_test.go
@@ -9,23 +9,23 @@ import (
 var _ ble.BLEConnector = (*bleTestClientAdaptor)(nil)
 
 type bleTestClientAdaptor struct {
-	name            string
-	address         string
-	mtx             sync.Mutex
-	withoutReponses bool
+	name             string
+	address          string
+	mtx              sync.Mutex
+	withoutResponses bool
 
 	testReadCharacteristic  func(string) ([]byte, error)
 	testWriteCharacteristic func(string, []byte) error
 }
 
-func (t *bleTestClientAdaptor) Connect() (err error)     { return }
-func (t *bleTestClientAdaptor) Reconnect() (err error)   { return }
-func (t *bleTestClientAdaptor) Disconnect() (err error)  { return }
-func (t *bleTestClientAdaptor) Finalize() (err error)    { return }
-func (t *bleTestClientAdaptor) Name() string             { return t.name }
-func (t *bleTestClientAdaptor) SetName(n string)         { t.name = n }
-func (t *bleTestClientAdaptor) Address() string          { return t.address }
-func (t *bleTestClientAdaptor) WithoutReponses(use bool) { t.withoutReponses = use }
+func (t *bleTestClientAdaptor) Connect() (err error)      { return }
+func (t *bleTestClientAdaptor) Reconnect() (err error)    { return }
+func (t *bleTestClientAdaptor) Disconnect() (err error)   { return }
+func (t *bleTestClientAdaptor) Finalize() (err error)     { return }
+func (t *bleTestClientAdaptor) Name() string              { return t.name }
+func (t *bleTestClientAdaptor) SetName(n string)          { t.name = n }
+func (t *bleTestClientAdaptor) Address() string           { return t.address }
+func (t *bleTestClientAdaptor) WithoutResponses(use bool) { t.withoutResponses = use }
 
 func (t *bleTestClientAdaptor) ReadCharacteristic(cUUID string) (data []byte, err error) {
 	t.mtx.Lock()

--- a/platforms/sphero/ollie/helpers_test.go
+++ b/platforms/sphero/ollie/helpers_test.go
@@ -9,23 +9,23 @@ import (
 var _ ble.BLEConnector = (*bleTestClientAdaptor)(nil)
 
 type bleTestClientAdaptor struct {
-	name            string
-	address         string
-	mtx             sync.Mutex
-	withoutReponses bool
+	name             string
+	address          string
+	mtx              sync.Mutex
+	withoutResponses bool
 
 	testReadCharacteristic  func(string) ([]byte, error)
 	testWriteCharacteristic func(string, []byte) error
 }
 
-func (t *bleTestClientAdaptor) Connect() (err error)     { return }
-func (t *bleTestClientAdaptor) Reconnect() (err error)   { return }
-func (t *bleTestClientAdaptor) Disconnect() (err error)  { return }
-func (t *bleTestClientAdaptor) Finalize() (err error)    { return }
-func (t *bleTestClientAdaptor) Name() string             { return t.name }
-func (t *bleTestClientAdaptor) SetName(n string)         { t.name = n }
-func (t *bleTestClientAdaptor) Address() string          { return t.address }
-func (t *bleTestClientAdaptor) WithoutReponses(use bool) { t.withoutReponses = use }
+func (t *bleTestClientAdaptor) Connect() (err error)      { return }
+func (t *bleTestClientAdaptor) Reconnect() (err error)    { return }
+func (t *bleTestClientAdaptor) Disconnect() (err error)   { return }
+func (t *bleTestClientAdaptor) Finalize() (err error)     { return }
+func (t *bleTestClientAdaptor) Name() string              { return t.name }
+func (t *bleTestClientAdaptor) SetName(n string)          { t.name = n }
+func (t *bleTestClientAdaptor) Address() string           { return t.address }
+func (t *bleTestClientAdaptor) WithoutResponses(use bool) { t.withoutResponses = use }
 
 func (t *bleTestClientAdaptor) ReadCharacteristic(cUUID string) (data []byte, err error) {
 	t.mtx.Lock()

--- a/platforms/sphero/sprkplus/helpers_test.go
+++ b/platforms/sphero/sprkplus/helpers_test.go
@@ -9,23 +9,23 @@ import (
 var _ ble.BLEConnector = (*bleTestClientAdaptor)(nil)
 
 type bleTestClientAdaptor struct {
-	name            string
-	address         string
-	mtx             sync.Mutex
-	withoutReponses bool
+	name             string
+	address          string
+	mtx              sync.Mutex
+	withoutResponses bool
 
 	testReadCharacteristic  func(string) ([]byte, error)
 	testWriteCharacteristic func(string, []byte) error
 }
 
-func (t *bleTestClientAdaptor) Connect() (err error)     { return }
-func (t *bleTestClientAdaptor) Reconnect() (err error)   { return }
-func (t *bleTestClientAdaptor) Disconnect() (err error)  { return }
-func (t *bleTestClientAdaptor) Finalize() (err error)    { return }
-func (t *bleTestClientAdaptor) Name() string             { return t.name }
-func (t *bleTestClientAdaptor) SetName(n string)         { t.name = n }
-func (t *bleTestClientAdaptor) Address() string          { return t.address }
-func (t *bleTestClientAdaptor) WithoutReponses(use bool) { t.withoutReponses = use }
+func (t *bleTestClientAdaptor) Connect() (err error)      { return }
+func (t *bleTestClientAdaptor) Reconnect() (err error)    { return }
+func (t *bleTestClientAdaptor) Disconnect() (err error)   { return }
+func (t *bleTestClientAdaptor) Finalize() (err error)     { return }
+func (t *bleTestClientAdaptor) Name() string              { return t.name }
+func (t *bleTestClientAdaptor) SetName(n string)          { t.name = n }
+func (t *bleTestClientAdaptor) Address() string           { return t.address }
+func (t *bleTestClientAdaptor) WithoutResponses(use bool) { t.withoutResponses = use }
 
 func (t *bleTestClientAdaptor) ReadCharacteristic(cUUID string) (data []byte, err error) {
 	t.mtx.Lock()

--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package gobot
 
-const version = "1.8.0"
+const version = "1.9.0"
 
 // Version returns the current Gobot version
 func Version() string {


### PR DESCRIPTION
** Read before merging **
This is the driver for MAX 7219 / 7221 LED drivers, but I was only able to test it with MAX 7219 (don't have any 7221), but it's supposed to work with it too.

The official datasheets mentions that only the MAX7221 supports SPI (not the 7219), but most of the libraries available for Arduino use a mix of SPI and direct control of the SS/CS pin. I opted for direct control of pins instead of SPI because it's more versatile (works on TCPFirmata for example), but the speed might be slower than using SPI.

At this point, I'm not sure if I should rename the driver to max7219 only and make a SPI one for max7221, make a spi for both of them in replacement of this or make a spi driver in addition to this, so you will be able to use whatever suits you better (gpio or spi). I think this is fine for most cases.


Additionally, the driver is pretty simple as it's usually sold separately and the led arrangement (if in a matrix) is not always the same (it doesn't even has to be a matrix, it could be a 7-segment display).
