### PR TITLE
joystick: removed double release event

### DIFF
--- a/platforms/joystick/joystick_driver.go
+++ b/platforms/joystick/joystick_driver.go
@@ -157,8 +157,9 @@ func (j *Driver) handleEvent(event sdl.Event) error {
 			}
 			if data.State == 1 {
 				j.Publish(j.Event(fmt.Sprintf("%s_press", button)), nil)
+			} else {
+				j.Publish(j.Event(fmt.Sprintf("%s_release", button)), nil)
 			}
-			j.Publish(j.Event(fmt.Sprintf("%s_release", button)), nil)
 		}
 	case *sdl.JoyHatEvent:
 		if data.Which == j.adaptor().joystick.InstanceID() {


### PR DESCRIPTION
The `_release` event for joysticks is issued twice.

The `_press` event is immediately followed by a r`_release` event always. When the button is afterwards released the event is (properly now) re-issued.

This pull request removes the first `_release` event.