### PR TITLE
examples: correct events used by XBox360 joystick example

### DIFF
--- a/examples/joystick_xbox360.go
+++ b/examples/joystick_xbox360.go
@@ -28,16 +28,16 @@ func main() {
 		stick.On(joystick.BRelease, func(data interface{}) {
 			fmt.Println("b_release")
 		})
-		stick.On(joystick.Up, func(data interface{}) {
+		stick.On(joystick.UpPress, func(data interface{}) {
 			fmt.Println("up", data)
 		})
-		stick.On(joystick.Down, func(data interface{}) {
+		stick.On(joystick.DownPress, func(data interface{}) {
 			fmt.Println("down", data)
 		})
-		stick.On(joystick.Left, func(data interface{}) {
+		stick.On(joystick.LeftPress, func(data interface{}) {
 			fmt.Println("left", data)
 		})
-		stick.On(joystick.Right, func(data interface{}) {
+		stick.On(joystick.RightPress, func(data interface{}) {
 			fmt.Println("right", data)
 		})
 		stick.On(joystick.LeftX, func(data interface{}) {


### PR DESCRIPTION
Commit 3c4c15b6d998a5784242ef7b510692b9f89d8256 changed the symbol names
for the joystick events. This commit tracks this change for the example
for the Xbox360 controller.