### PR TITLE
Log with Logrus; allow for logger injection

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -37,18 +37,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/go-ble/ble"
-  packages = [
-    ".",
-    "darwin",
-    "linux",
-    "linux/adv",
-    "linux/att",
-    "linux/gatt",
-    "linux/hci",
-    "linux/hci/cmd",
-    "linux/hci/evt",
-    "linux/hci/socket"
-  ]
+  packages = [".","darwin","linux","linux/adv","linux/att","linux/gatt","linux/hci","linux/hci/cmd","linux/hci/evt","linux/hci/socket"]
   revision = "788214691384e85e345bff9fd5eeb046f5983594"
 
 [[projects]]
@@ -66,11 +55,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/hybridgroup/go-ardrone"
-  packages = [
-    "client",
-    "client/commands",
-    "client/navdata"
-  ]
+  packages = ["client","client/commands","client/navdata"]
   revision = "b9750d8d7b78f9638e5fdd899835e99d46b5a56c"
 
 [[projects]]
@@ -99,10 +84,7 @@
 
 [[projects]]
   name = "github.com/nats-io/go-nats"
-  packages = [
-    "encoders/builtin",
-    "util"
-  ]
+  packages = ["encoders/builtin","util"]
   revision = "29f9728a183bf3fa7e809e14edac00b33be72088"
   version = "v1.3.0"
 
@@ -143,6 +125,12 @@
   revision = "f19e41f79f8f006116f682c1af454591bc278ad4"
 
 [[projects]]
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
+  version = "v1.0.5"
+
+[[projects]]
   branch = "master"
   name = "github.com/tarm/serial"
   packages = ["."]
@@ -157,10 +145,7 @@
 [[projects]]
   branch = "master"
   name = "go.bug.st/serial.v1"
-  packages = [
-    ".",
-    "unixutils"
-  ]
+  packages = [".","unixutils"]
   revision = "eae1344f9f90101f887b08d13391c34399f97873"
 
 [[projects]]
@@ -171,39 +156,26 @@
 
 [[projects]]
   branch = "master"
+  name = "golang.org/x/crypto"
+  packages = ["ssh/terminal"]
+  revision = "2d027ae1dddd4694d54f7a8b6cbe78dca8720226"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/net"
-  packages = [
-    "proxy",
-    "websocket"
-  ]
+  packages = ["proxy","websocket"]
   revision = "01c190206fbdffa42f334f4b2bf2220f50e64920"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = [
-    "unix",
-    "windows"
-  ]
+  packages = ["unix","windows"]
   revision = "8eb05f94d449fdf134ec24630ce69ada5b469c1c"
 
 [[projects]]
   branch = "master"
   name = "periph.io/x/periph"
-  packages = [
-    ".",
-    "conn",
-    "conn/gpio",
-    "conn/gpio/gpioreg",
-    "conn/i2c",
-    "conn/i2c/i2creg",
-    "conn/pin",
-    "conn/spi",
-    "conn/spi/spireg",
-    "devices",
-    "host/fs",
-    "host/sysfs"
-  ]
+  packages = [".","conn","conn/gpio","conn/gpio/gpioreg","conn/i2c","conn/i2c/i2creg","conn/pin","conn/spi","conn/spi/spireg","devices","host/fs","host/sysfs"]
   revision = "a8b45e63d61cc00328dfe54149cfe7abd7115a7f"
 
 [solve-meta]

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 excluding_vendor := $(shell go list ./... | grep -v /vendor/)
 
+
 # Run tests on all non-vendor directories
 test:
 	go test -v $(excluding_vendor)
@@ -17,6 +18,9 @@ fmt_check:
 # Test and generate coverage
 test_with_coverage:
 	./ci/test.sh
+
+build:
+	go build
 
 deps:
 ifeq (,$(shell which dep))

--- a/api/api.go
+++ b/api/api.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,7 +11,10 @@ import (
 	"github.com/bmizerany/pat"
 	"gobot.io/x/gobot"
 	"gobot.io/x/gobot/api/robeaux"
+	log "github.com/sirupsen/logrus"
 )
+
+var logger log.Logger
 
 // API represents an API server
 type API struct {
@@ -24,6 +26,10 @@ type API struct {
 	Key      string
 	handlers []func(http.ResponseWriter, *http.Request)
 	start    func(*API)
+}
+
+func RegisterLogger(l log.Logger)  {
+	logger = l
 }
 
 // NewAPI returns a new api instance

--- a/api/api.go
+++ b/api/api.go
@@ -14,11 +14,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var log *logrus.Logger
-
-func init(){
-	log = logrus.New()
-}
+var (
+	log = logrus.StandardLogger()
+	)
 
 // API represents an API server
 type API struct {
@@ -32,7 +30,7 @@ type API struct {
 	start    func(*API)
 }
 
-func RegisterLogger(l logrus.Logger)  {
+func RegisterLogger(l *logrus.Logger)  {
 	log = l
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -14,7 +14,11 @@ import (
 	logger "github.com/sirupsen/logrus"
 )
 
-var log logger.Logger
+var log *logger.Logger
+
+func init(){
+	log = logger.New()
+}
 
 // API represents an API server
 type API struct {

--- a/api/api.go
+++ b/api/api.go
@@ -11,13 +11,13 @@ import (
 	"github.com/bmizerany/pat"
 	"gobot.io/x/gobot"
 	"gobot.io/x/gobot/api/robeaux"
-	logger "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
-var log *logger.Logger
+var log *logrus.Logger
 
 func init(){
-	log = logger.New()
+	log = logrus.New()
 }
 
 // API represents an API server
@@ -32,7 +32,7 @@ type API struct {
 	start    func(*API)
 }
 
-func RegisterLogger(l logger.Logger)  {
+func RegisterLogger(l logrus.Logger)  {
 	log = l
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -11,10 +11,10 @@ import (
 	"github.com/bmizerany/pat"
 	"gobot.io/x/gobot"
 	"gobot.io/x/gobot/api/robeaux"
-	log "github.com/sirupsen/logrus"
+	logger "github.com/sirupsen/logrus"
 )
 
-var logger log.Logger
+var log logger.Logger
 
 // API represents an API server
 type API struct {
@@ -28,8 +28,8 @@ type API struct {
 	start    func(*API)
 }
 
-func RegisterLogger(l log.Logger)  {
-	logger = l
+func RegisterLogger(l logger.Logger)  {
+	log = l
 }
 
 // NewAPI returns a new api instance

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,10 +12,11 @@ import (
 
 	"gobot.io/x/gobot"
 	"gobot.io/x/gobot/gobottest"
+	"github.com/sirupsen/logrus"
 )
 
 func initTestAPI() *API {
-	log.SetOutput(NullReadWriteCloser{})
+	logrus.SetOutput(NullReadWriteCloser{})
 	g := gobot.NewMaster()
 	a := NewAPI(g)
 	a.start = func(m *API) {}

--- a/connection.go
+++ b/connection.go
@@ -4,11 +4,11 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/go-multierror"
-	log "github.com/sirupsen/logrus"
+	logger "github.com/sirupsen/logrus"
 )
 
 // package-global logger
-var logger log.Logger
+var log logger.Logger
 
 // JSONConnection is a JSON representation of a Connection.
 type JSONConnection struct {
@@ -24,8 +24,8 @@ func NewJSONConnection(connection Connection) *JSONConnection {
 	}
 }
 
-func RegisterLogger(l log.Logger)  {
-	logger = l
+func RegisterLogger(l logger.Logger)  {
+	log = l
 }
 
 // A Connection is an instance of an Adaptor

--- a/connection.go
+++ b/connection.go
@@ -7,12 +7,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// package-global logger
-var log *logrus.Logger
-
-func init(){
-	log = logrus.New()
-}
+var (
+	log = logrus.StandardLogger()
+)
 
 // JSONConnection is a JSON representation of a Connection.
 type JSONConnection struct {
@@ -28,7 +25,7 @@ func NewJSONConnection(connection Connection) *JSONConnection {
 	}
 }
 
-func RegisterLogger(l *logrus.Logger)  {
+func RegisterLogger(l *logrus.Logger) {
 	log = l
 }
 

--- a/connection.go
+++ b/connection.go
@@ -8,7 +8,11 @@ import (
 )
 
 // package-global logger
-var log logger.Logger
+var log *logger.Logger
+
+func init(){
+	log = logger.New()
+}
 
 // JSONConnection is a JSON representation of a Connection.
 type JSONConnection struct {

--- a/connection.go
+++ b/connection.go
@@ -1,11 +1,14 @@
 package gobot
 
 import (
-	"log"
 	"reflect"
 
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
+	log "github.com/sirupsen/logrus"
 )
+
+// package-global logger
+var logger log.Logger
 
 // JSONConnection is a JSON representation of a Connection.
 type JSONConnection struct {
@@ -19,6 +22,10 @@ func NewJSONConnection(connection Connection) *JSONConnection {
 		Name:    connection.Name(),
 		Adaptor: reflect.TypeOf(connection).String(),
 	}
+}
+
+func RegisterLogger(l log.Logger)  {
+	logger = l
 }
 
 // A Connection is an instance of an Adaptor

--- a/connection.go
+++ b/connection.go
@@ -4,14 +4,14 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/go-multierror"
-	logger "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // package-global logger
-var log *logger.Logger
+var log *logrus.Logger
 
 func init(){
-	log = logger.New()
+	log = logrus.New()
 }
 
 // JSONConnection is a JSON representation of a Connection.
@@ -28,7 +28,7 @@ func NewJSONConnection(connection Connection) *JSONConnection {
 	}
 }
 
-func RegisterLogger(l logger.Logger)  {
+func RegisterLogger(l *logrus.Logger)  {
 	log = l
 }
 

--- a/device.go
+++ b/device.go
@@ -1,7 +1,6 @@
 package gobot
 
 import (
-	"log"
 	"reflect"
 
 	multierror "github.com/hashicorp/go-multierror"

--- a/drivers/i2c/adafruit_driver.go
+++ b/drivers/i2c/adafruit_driver.go
@@ -2,7 +2,7 @@ package i2c
 
 import (
 	"errors"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math"
 	"time"
 

--- a/drivers/i2c/mcp23017_driver.go
+++ b/drivers/i2c/mcp23017_driver.go
@@ -18,7 +18,7 @@ package i2c
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"gobot.io/x/gobot"

--- a/drivers/i2c/mcp23017_driver_test.go
+++ b/drivers/i2c/mcp23017_driver_test.go
@@ -3,7 +3,7 @@ package i2c
 import (
 	"errors"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"testing"
 

--- a/examples/ble_firmata_curie_imu.go
+++ b/examples/ble_firmata_curie_imu.go
@@ -14,7 +14,7 @@
 package main
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"time"
 

--- a/examples/firmata_curie_imu.go
+++ b/examples/firmata_curie_imu.go
@@ -12,7 +12,7 @@
 package main
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"time"
 

--- a/examples/firmata_curie_imu_shock_detect.go
+++ b/examples/firmata_curie_imu_shock_detect.go
@@ -12,7 +12,7 @@
 package main
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"time"
 

--- a/examples/firmata_curie_imu_step_counter.go
+++ b/examples/firmata_curie_imu_step_counter.go
@@ -12,7 +12,7 @@
 package main
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"time"
 

--- a/examples/firmata_curie_imu_tap_detect.go
+++ b/examples/firmata_curie_imu_tap_detect.go
@@ -12,7 +12,7 @@
 package main
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"time"
 

--- a/examples/raspi_adafruit_dcmotor.go
+++ b/examples/raspi_adafruit_dcmotor.go
@@ -5,7 +5,7 @@
 package main
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"gobot.io/x/gobot"

--- a/examples/raspi_adafruit_servo.go
+++ b/examples/raspi_adafruit_servo.go
@@ -5,7 +5,7 @@
 package main
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"gobot.io/x/gobot"

--- a/examples/raspi_adafruit_stepper.go
+++ b/examples/raspi_adafruit_stepper.go
@@ -5,7 +5,7 @@
 package main
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"gobot.io/x/gobot"

--- a/master_test.go
+++ b/master_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 	"gobot.io/x/gobot/gobottest"
 )
 

--- a/master_test.go
+++ b/master_test.go
@@ -2,7 +2,6 @@ package gobot
 
 import (
 	"errors"
-	"log"
 	"os"
 	"testing"
 	"time"
@@ -12,7 +11,6 @@ import (
 )
 
 func initTestMaster() *Master {
-	log.SetOutput(&NullReadWriteCloser{})
 	g := NewMaster()
 	g.trap = func(c chan os.Signal) {
 		c <- os.Interrupt
@@ -24,7 +22,6 @@ func initTestMaster() *Master {
 }
 
 func initTestMaster1Robot() *Master {
-	log.SetOutput(&NullReadWriteCloser{})
 	g := NewMaster()
 	g.trap = func(c chan os.Signal) {
 		c <- os.Interrupt

--- a/platforms/audio/audio_adaptor.go
+++ b/platforms/audio/audio_adaptor.go
@@ -3,7 +3,7 @@ package audio
 
 import (
 	"errors"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"os/exec"
 	"path"

--- a/platforms/ble/ble_client_adaptor.go
+++ b/platforms/ble/ble_client_adaptor.go
@@ -2,7 +2,7 @@ package ble
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"sync"
 

--- a/platforms/intel-iot/curie/README.md
+++ b/platforms/intel-iot/curie/README.md
@@ -20,7 +20,7 @@ go get -d -u gobot.io/x/gobot/...
 package main
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"gobot.io/x/gobot"

--- a/platforms/keyboard/keyboard_driver.go
+++ b/platforms/keyboard/keyboard_driver.go
@@ -1,7 +1,7 @@
 package keyboard
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 
 	"gobot.io/x/gobot"

--- a/robot.go
+++ b/robot.go
@@ -2,7 +2,6 @@ package gobot
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"sync/atomic"


### PR DESCRIPTION
Fixes #508

## What
* Adds Logrus to the build
* Replaces usage of `log` package from std lib with Logrus
* Adds `RegisterLogger` functions to `api` and `gobot` packages

## Why
* Requested in #508 
* Logrus has more features than std lib
* Using a `RegisterLogger` function allows for injecting a common logger

## Questions
* Does this solve the request in #508? (cc @FerventGeek)
* Should we leave the `examples` directory alone on the theory that it's best to show only Gobot packages and stdlib there? I opted to change b/c of the injection behavior's availability, but could see an argument for keeping it pure stdlib.