### PR TITLE
Update the Firmata homepage in platform README

### DIFF
--- a/platforms/firmata/README.md
+++ b/platforms/firmata/README.md
@@ -2,7 +2,7 @@
 
 Arduino is an open-source electronics prototyping platform based on flexible, easy-to-use hardware and software. It's intended for artists, designers, hobbyists and anyone interested in creating interactive objects or environments.
 
-This package provides the adaptor for microcontrollers such as Arduino that support the [Firmata](http://firmata.org/wiki/Main_Page) protocol
+This package provides the adaptor for microcontrollers such as Arduino that support the [Firmata](https://github.com/firmata/protocol) protocol
 
 You can connect to the microcontroller using either a serial connection, or a TCP connection to a WiFi-connected microcontroller such as the ESP8266.
 


### PR DESCRIPTION
The previously-linked Firmata homepage is no longer available. I found the official repo on GitHub which seems to be as good of a place to link to as any.

(this was [initially submitted](https://github.com/hybridgroup/gobot-site/pull/62) incorrectly to to the gobot-site repo)