### PR TITLE
change timestamp to uint64 to fix #516

### DIFF
--- a/platforms/leap/leap_motion_driver_test.go
+++ b/platforms/leap/leap_motion_driver_test.go
@@ -89,7 +89,7 @@ func TestLeapMotionDriverParser(t *testing.T) {
 		t.Errorf("ParseFrame incorrectly parsed frame")
 	}
 
-	gobottest.Assert(t, parsedFrame.Timestamp, 4729292670)
+	gobottest.Assert(t, parsedFrame.Timestamp, uint64(4729292670))
 	gobottest.Assert(t, parsedFrame.Hands[0].X(), 117.546)
 	gobottest.Assert(t, parsedFrame.Hands[0].Y(), 236.007)
 	gobottest.Assert(t, parsedFrame.Hands[0].Z(), 76.3394)

--- a/platforms/leap/parser.go
+++ b/platforms/leap/parser.go
@@ -66,7 +66,7 @@ type Frame struct {
 	R                [][]float64    `json:"r"`
 	S                float64        `json:"s"`
 	T                []float64      `json:"t"`
-	Timestamp        int            `json:"timestamp"`
+	Timestamp        uint64         `json:"timestamp"`
 }
 
 // X returns hand x value


### PR DESCRIPTION
This pull request should fix the leapmotion timestamp part of issue #516. This was tested with `GOARCH=386 go test -v`.