### PR TITLE
fix godoc typo (Name->SetName) in mqtt driver

### DIFF
--- a/platforms/mqtt/mqtt_driver.go
+++ b/platforms/mqtt/mqtt_driver.go
@@ -38,7 +38,7 @@ func NewDriver(a *Adaptor, topic string) *Driver {
 // Name returns name for the Driver
 func (m *Driver) Name() string { return m.name }
 
-// Name sets name for the Driver
+// SetName sets name for the Driver
 func (m *Driver) SetName(name string) { m.name = name }
 
 // Connection returns Connections used by the Driver


### PR DESCRIPTION
fixes function name typo in a mqtt driver documentation comment

my IDE found this when I was fixing the MQTT test