### PR TITLE
add support to multiple Tello drones thru multiple WiFi adapters

### DIFF
--- a/examples/tello_multipledrones.go
+++ b/examples/tello_multipledrones.go
@@ -1,0 +1,48 @@
+// +build example
+//
+// Do not build by default.
+
+/*
+How to run:
+Need 2 Tello drones and 2 WiFi adapters.
+Connect to the drone's Wi-Fi network from your computer. It will be named something like "TELLO-XXXXXX".
+
+Here is the trick:
+Manually setup IP address to 192.168.10.2  for first WiFi adapter, and 192.168.10.3 for second WiFi adapter.
+Once you are connected to both drones, you can run the Gobot code on your computer to control the drones.
+
+	go run examples/tello_multipledrones.go
+*/
+
+package main
+
+import (
+	"time"
+
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/platforms/dji/tello"
+)
+
+func main() {
+	drone := tello.NewDriver("192.168.10.2:8888")
+	drone2 := tello.NewDriver("192.168.10.3:8888")
+
+	work := func() {
+		drone.TakeOff()
+		drone2.TakeOff()
+
+		gobot.After(5*time.Second, func() {
+			drone.Land()
+			drone2.Land()
+		})
+	}
+
+	robot := gobot.NewRobot("tello",
+		[]gobot.Connection{},
+		[]gobot.Device{drone},
+		[]gobot.Device{drone2},
+		work,
+	)
+
+	robot.Start()
+}


### PR DESCRIPTION
By plug in multiple WiFi adapters and manually set up network interfaces with different IP addresses, I believe this gives us the ability to control multiple Tello drones in the same time. However, I don't have 2nd Tello drone, need someone to exam the idea for me.

1.Plug in USB WiFi adapters to your computer or connected USB Hub;
2.Connect USB WiFi adapter 1 to Tello drone 1, and assign the interface IP to 192.168.10.2;
3.Connect USB WiFi adapter 2 to Tello drone 2, and assign the interface IP to 192.168.10.3;
4.execute the code:
`
go run examples/tello_multipledrones.go
`