### PR TITLE
Bump periph.io/x/periph to v3.0.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,14 +27,28 @@
 
 [[projects]]
   name = "github.com/eclipse/paho.mqtt.golang"
-  packages = [".","packets"]
+  packages = [
+    ".",
+    "packets"
+  ]
   revision = "36d01c2b4cbeb3d2a12063e4880ce30800af9560"
   version = "v1.1.1"
 
 [[projects]]
   branch = "master"
   name = "github.com/go-ble/ble"
-  packages = [".","darwin","linux","linux/adv","linux/att","linux/gatt","linux/hci","linux/hci/cmd","linux/hci/evt","linux/hci/socket"]
+  packages = [
+    ".",
+    "darwin",
+    "linux",
+    "linux/adv",
+    "linux/att",
+    "linux/gatt",
+    "linux/hci",
+    "linux/hci/cmd",
+    "linux/hci/evt",
+    "linux/hci/socket"
+  ]
   revision = "788214691384e85e345bff9fd5eeb046f5983594"
 
 [[projects]]
@@ -52,7 +66,11 @@
 [[projects]]
   branch = "master"
   name = "github.com/hybridgroup/go-ardrone"
-  packages = ["client","client/commands","client/navdata"]
+  packages = [
+    "client",
+    "client/commands",
+    "client/navdata"
+  ]
   revision = "b9750d8d7b78f9638e5fdd899835e99d46b5a56c"
 
 [[projects]]
@@ -81,7 +99,10 @@
 
 [[projects]]
   name = "github.com/nats-io/go-nats"
-  packages = ["encoders/builtin","util"]
+  packages = [
+    "encoders/builtin",
+    "util"
+  ]
   revision = "29f9728a183bf3fa7e809e14edac00b33be72088"
   version = "v1.3.0"
 
@@ -136,7 +157,10 @@
 [[projects]]
   branch = "master"
   name = "go.bug.st/serial.v1"
-  packages = [".","unixutils"]
+  packages = [
+    ".",
+    "unixutils"
+  ]
   revision = "eae1344f9f90101f887b08d13391c34399f97873"
 
 [[projects]]
@@ -148,24 +172,43 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["proxy","websocket"]
+  packages = [
+    "proxy",
+    "websocket"
+  ]
   revision = "01c190206fbdffa42f334f4b2bf2220f50e64920"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "8eb05f94d449fdf134ec24630ce69ada5b469c1c"
 
 [[projects]]
   name = "periph.io/x/periph"
-  packages = [".", "conn", "conn/gpio","conn/gpio/gpioreg","conn/i2c","conn/i2c/i2creg","conn/pin","conn/spi","conn/spi/spireg","devices","host/fs","host/sysfs"]
-  revision = "c0de80b1b075a2019fced09524f2318cf690a685"
-  version = "v2.3.0"
+  packages = [
+    ".",
+    "conn",
+    "conn/gpio",
+    "conn/gpio/gpioreg",
+    "conn/i2c",
+    "conn/i2c/i2creg",
+    "conn/physic",
+    "conn/pin",
+    "conn/spi",
+    "conn/spi/spireg",
+    "host/fs",
+    "host/sysfs"
+  ]
+  revision = "000523f7fa26b78f012b93221c94434ac5b18e37"
+  version = "v3.0.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "da1b45abbc42d33c260a2faeeae33da906f384b360b96ceb0c5eb8ca236efec4"
+  inputs-digest = "c01c2f668e2331bb00208a9a8b74f55b9ff36cf524b95ef498eb2dbcac339214"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -79,7 +79,7 @@
 
 [[constraint]]
   name = "periph.io/x/periph"
-  version = "2.3.0"
+  version = "3.0.0"
 
 [[constraint]]
   branch = "master"

--- a/drivers/spi/spi.go
+++ b/drivers/spi/spi.go
@@ -1,6 +1,7 @@
 package spi
 
 import (
+	"periph.io/x/periph/conn/physic"
 	xspi "periph.io/x/periph/conn/spi"
 	xsysfs "periph.io/x/periph/host/sysfs"
 )
@@ -79,7 +80,7 @@ func GetSpiConnection(busNum, chipNum, mode, bits int, maxSpeed int64) (Connecti
 	if err != nil {
 		return nil, err
 	}
-	c, err := p.Connect(maxSpeed, xspi.Mode(mode), bits)
+	c, err := p.Connect(physic.Frequency(maxSpeed)*physic.Hertz, xspi.Mode(mode), bits)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/spi/spi_test.go
+++ b/drivers/spi/spi_test.go
@@ -2,6 +2,7 @@ package spi
 
 import (
 	"periph.io/x/periph/conn"
+	"periph.io/x/periph/conn/physic"
 	xspi "periph.io/x/periph/conn/spi"
 )
 
@@ -35,6 +36,10 @@ type TestSpiDevice struct {
 	dev Connection
 }
 
+func (c *TestSpiDevice) String() string {
+	return "TestSpiDevice"
+}
+
 func (c *TestSpiDevice) Duplex() conn.Duplex {
 	return conn.Half
 }
@@ -51,14 +56,18 @@ type TestSpiConnection struct {
 	conn Operations
 }
 
+func (c *TestSpiConnection) String() string {
+	return "TestSpiConnection"
+}
+
 func (c *TestSpiConnection) Close() error {
 	return nil
 }
 
-func (c *TestSpiConnection) Connect(maxHz int64, mode xspi.Mode, bits int) (xspi.Conn, error) {
+func (c *TestSpiConnection) Connect(maxHz physic.Frequency, mode xspi.Mode, bits int) (xspi.Conn, error) {
 	return nil, nil
 }
 
-func (c *TestSpiConnection) LimitSpeed(maxHz int64) error {
+func (c *TestSpiConnection) LimitSpeed(maxHz physic.Frequency) error {
 	return nil
 }


### PR DESCRIPTION
There was one breaking change in the spi.Port and spi.Conn interfaces.

As I ran "dep ensure" with dep v0.4.1, it decided to reformat the Gopkg.lock
file. :/