### PR TITLE
[#574] added error handling for config loading in joystick driver

### DIFF
--- a/platforms/joystick/joystick_driver.go
+++ b/platforms/joystick/joystick_driver.go
@@ -107,7 +107,10 @@ func (j *Driver) Start() (err error) {
 	case "xbox360RockBandDrums":
 		j.config = xbox360RockBandDrumsConfig
 	default:
-		j.loadFile()
+		err := j.loadFile()
+		if err != nil {
+			return err
+		}
 	}
 
 	for _, value := range j.config.Buttons {


### PR DESCRIPTION
This hotfix fixes [#574](https://github.com/hybridgroup/gobot/issues/574), i.e improve error handling in joystick driver