### PR TITLE
raspi: export PiBlasterPeriod in Adaptor

### DIFF
--- a/platforms/raspi/pwm_pin_test.go
+++ b/platforms/raspi/pwm_pin_test.go
@@ -20,11 +20,14 @@ func TestPwmPin(t *testing.T) {
 	val, _ = pin.Polarity()
 	gobottest.Assert(t, val, "normal")
 
-	period, _ := pin.Period()
-	gobottest.Assert(t, period, uint32(10000000))
-	gobottest.Assert(t, pin.SetPeriod(1000), nil)
+	period, err := pin.Period()
+	gobottest.Assert(t, err, errors.New("Raspi PWM pin period not set"))
+	gobottest.Assert(t, pin.SetDutyCycle(10000), errors.New("Raspi PWM pin period not set"))
+
+	gobottest.Assert(t, pin.SetPeriod(20000000), nil)
 	period, _ = pin.Period()
-	gobottest.Assert(t, period, uint32(10000000))
+	gobottest.Assert(t, period, uint32(20000000))
+	gobottest.Assert(t, pin.SetPeriod(10000000), errors.New("Cannot set the period of individual PWM pins on Raspi"))
 
 	dc, _ := pin.DutyCycle()
 	gobottest.Assert(t, dc, uint32(0))

--- a/platforms/raspi/raspi_adaptor.go
+++ b/platforms/raspi/raspi_adaptor.go
@@ -34,15 +34,17 @@ type Adaptor struct {
 	spiDevices         [2]spi.Connection
 	spiDefaultMode     int
 	spiDefaultMaxSpeed int64
+	PiBlasterPeriod    uint32
 }
 
 // NewAdaptor creates a Raspi Adaptor
 func NewAdaptor() *Adaptor {
 	r := &Adaptor{
-		mutex:       &sync.Mutex{},
-		name:        gobot.DefaultName("RaspberryPi"),
-		digitalPins: make(map[int]*sysfs.DigitalPin),
-		pwmPins:     make(map[int]*PWMPin),
+		mutex:           &sync.Mutex{},
+		name:            gobot.DefaultName("RaspberryPi"),
+		digitalPins:     make(map[int]*sysfs.DigitalPin),
+		pwmPins:         make(map[int]*PWMPin),
+		PiBlasterPeriod: 10000000,
 	}
 	content, _ := readFile()
 	for _, v := range strings.Split(string(content), "\n") {
@@ -261,6 +263,7 @@ func (r *Adaptor) PWMPin(pin string) (raspiPWMPin sysfs.PWMPinner, err error) {
 
 	if r.pwmPins[i] == nil {
 		r.pwmPins[i] = NewPWMPin(strconv.Itoa(i))
+		r.pwmPins[i].SetPeriod(r.PiBlasterPeriod)
 	}
 
 	return r.pwmPins[i], nil
@@ -273,7 +276,7 @@ func (r *Adaptor) PwmWrite(pin string, val byte) (err error) {
 		return err
 	}
 
-	duty := uint32(gobot.FromScale(float64(val), 0, 255) * piBlasterPeriod)
+	duty := uint32(gobot.FromScale(float64(val), 0, 255) * float64(r.PiBlasterPeriod))
 	return sysfsPin.SetDutyCycle(duty)
 }
 
@@ -284,7 +287,7 @@ func (r *Adaptor) ServoWrite(pin string, angle byte) (err error) {
 		return err
 	}
 
-	duty := uint32(gobot.FromScale(float64(angle), 0, 180) * piBlasterPeriod)
+	duty := uint32(gobot.FromScale(float64(angle), 0, 180) * float64(r.PiBlasterPeriod))
 	return sysfsPin.SetDutyCycle(duty)
 }
 

--- a/platforms/raspi/raspi_adaptor_test.go
+++ b/platforms/raspi/raspi_adaptor_test.go
@@ -110,6 +110,7 @@ func TestAdaptorFinalize(t *testing.T) {
 
 func TestAdaptorDigitalPWM(t *testing.T) {
 	a := initTestAdaptor()
+	a.PiBlasterPeriod = 20000000
 
 	gobottest.Assert(t, a.PwmWrite("7", 4), nil)
 
@@ -117,6 +118,10 @@ func TestAdaptorDigitalPWM(t *testing.T) {
 		"/dev/pi-blaster",
 	})
 	sysfs.SetFilesystem(fs)
+
+	pin, _ := a.PWMPin("7")
+	period, _ := pin.Period()
+	gobottest.Assert(t, period, uint32(20000000))
 
 	gobottest.Assert(t, a.PwmWrite("7", 255), nil)
 
@@ -128,6 +133,14 @@ func TestAdaptorDigitalPWM(t *testing.T) {
 
 	gobottest.Assert(t, a.PwmWrite("notexist", 1), errors.New("Not a valid pin"))
 	gobottest.Assert(t, a.ServoWrite("notexist", 1), errors.New("Not a valid pin"))
+
+	pin, _ = a.PWMPin("12")
+	period, _ = pin.Period()
+	gobottest.Assert(t, period, uint32(20000000))
+
+	gobottest.Assert(t, pin.SetDutyCycle(1.5*1000*1000), nil)
+
+	gobottest.Assert(t, strings.Split(fs.Files["/dev/pi-blaster"].Contents, "\n")[0], "18=0.075")
 }
 
 func TestAdaptorDigitalIO(t *testing.T) {


### PR DESCRIPTION
By setting PiBlasterPeriod to a raspi.Adaptor, the PWM pin will now reflect the correct duty cycle to /dev/pi-blaster. The default value is still 10000000(ns), which is the default one in pi-blaster too.

In addition to exporting PiBlasterPeriod in raspi.Adaptor, I also have to create a pointer in PWMPin structure to point to the Adaptor's PiBlasterPeriod, in order for Period() and SetDutyCycle() in all PWMPin to reference to the same value, which should be the same throughout runtime. This hence changes the NewPWMPin() interface.

Tests updated accordingly.

Still new to golang. Let me know if something is unexpected. Thanks.