### PR TITLE
Added rudiementary support for TH02  Grove Sensor

### DIFF
--- a/drivers/i2c/th02_driver.go
+++ b/drivers/i2c/th02_driver.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Weston Schmidt <weston_schmidt@alumni.purdue.edu>
+ * Copyright (c) 2018 Nick Potts <nick@the-potts.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@ package i2c
 
 // TH02Driver is a driver for the TH02-D based devices.
 //
-// This module was tested with AdaFruit Sensiron SHT32-D Breakout.
-// https://www.adafruit.com/products/2857
+// This module was tested with a Grove "Temperature&Humidity Sensor (High-Accuracy & Mini ) v1.0"
+// from https://www.seeedstudio.com/Grove-Temperature-Humidity-Sensor-High-Accuracy-Min-p-1921.htm
+// Datasheet is at http://www.hoperf.com/upload/sensor/TH02_V1.1.pdf
 
 import (
 	"fmt"
@@ -30,28 +31,17 @@ import (
 
 const (
 
-	// TH02AddressA is the default address of device
+	// TH02Address is the default address of device
 	TH02Address = 0x40
 
 	//TH02ConfigReg is the configuration register
 	TH02ConfigReg = 0x03
-
-	// TH02RegConfigHighAccuracyTemp is the CONFIG register to read temperature
-	// TH02HighAccuracyTemp = 0x11
-
-	//TH02RegConfigHighAccuracyRH is the CONFIG register to read high accuracy RH
-//	TH02HighAccuracyRH = 0x01
 )
 
+//Accuracy constants for the TH02 devices
 const (
 	TH02HighAccuracy = 0 //High Accuracy
 	TH02LowAccuracy  = 1 //Lower Accuracy
-)
-
-var (
-//ErrInvalidAccuracy = errors.New("Invalid accuracy")
-//ErrInvalidCrc      = errors.New("Invalid crc")
-//ErrInvalidTemp     = errors.New("Invalid temperature units")
 )
 
 // TH02Driver is a Driver for a TH02 humidity and temperature sensor

--- a/drivers/i2c/th02_driver.go
+++ b/drivers/i2c/th02_driver.go
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2018 Nicholas Potts <nick@the-potts.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package i2c
+
+// TH02Driver is a driver for the TH02-D based devices.
+//
+// This module was tested with a Grove Temperature and Humidty Sensor (High Accuracy)
+// https://www.seeedstudio.com/Grove-Temperature-Humidity-Sensor-High-Accuracy-Min-p-1921.html
+
+import (
+	"fmt"
+	"time"
+
+	"gobot.io/x/gobot"
+)
+
+// TH02Address is the default address of device
+const TH02Address = 0x40
+
+//TH02ConfigReg is the configuration register
+const TH02ConfigReg = 0x03
+
+// TH02HighAccuracyTemp is the CONFIG write value to start reading temperature
+const TH02HighAccuracyTemp = 0x11
+
+//TH02HighAccuracyRH is the CONFIG write value to start reading high accuracy RH
+const TH02HighAccuracyRH = 0x01
+
+// TH02Driver is a Driver for a TH02 humidity and temperature sensor
+type TH02Driver struct {
+	Units      string
+	name       string
+	connector  Connector
+	connection Connection
+	Config
+	addr     byte
+	accuracy byte
+	delay    time.Duration
+}
+
+// NewTH02Driver creates a new driver with specified i2c interface
+// Params:
+//		conn Connector - the Adaptor to use with this Driver
+//
+// Optional params:
+//		i2c.WithBus(int):	bus to use with this driver
+//		i2c.WithAddress(int):	address to use with this driver
+//
+func NewTH02Driver(a Connector, options ...func(Config)) *TH02Driver {
+	s := &TH02Driver{
+		Units:     "C",
+		name:      gobot.DefaultName("TH02"),
+		connector: a,
+		addr:      TH02Address,
+		Config:    NewConfig(),
+	}
+	//	s.SetAccuracy(TH02AccuracyHigh)
+
+	for _, option := range options {
+		option(s)
+	}
+
+	return s
+}
+
+// Name returns the name for this Driver
+func (s *TH02Driver) Name() string { return s.name }
+
+// SetName sets the name for this Driver
+func (s *TH02Driver) SetName(n string) { s.name = n }
+
+// Connection returns the connection for this Driver
+func (s *TH02Driver) Connection() gobot.Connection { return s.connector.(gobot.Connection) }
+
+// Start initializes the TH02
+func (s *TH02Driver) Start() (err error) {
+	bus := s.GetBusOrDefault(s.connector.GetDefaultBus())
+	address := s.GetAddressOrDefault(int(s.addr))
+
+	s.connection, err = s.connector.GetConnection(address, bus)
+	return err
+}
+
+// Halt returns true if devices is halted successfully
+func (s *TH02Driver) Halt() (err error) { return }
+
+// SetAddress sets the address of the device
+func (s *TH02Driver) SetAddress(address int) { s.addr = byte(address) }
+
+// SerialNumber returns the serial number of the chip
+func (s *TH02Driver) SerialNumber() (sn uint32, err error) {
+	ret, err := s.readRegister(0x11)
+	return uint32(ret) >> 4, err
+}
+
+// Sample returns the temperature in celsius and relative humidity for one sample
+func (s *TH02Driver) Sample() (temp float32, rh float32, err error) {
+	if err := s.writeRegister(TH02ConfigReg, TH02HighAccuracyRH); err != nil {
+		return 0, 0, err
+	}
+
+	rrh, err := s.readData()
+	if err != nil {
+		return 0, 0, err
+	}
+	rrh = rrh >> 4
+	rh = float32(rrh)/16.0 - 24.0
+
+	if err := s.writeRegister(TH02ConfigReg, TH02HighAccuracyTemp); err != nil {
+		return 0, 0, err
+	}
+
+	rt, err := s.readData()
+	if err != nil {
+		return 0, rh, err
+	}
+	rt = rt / 4
+	temp = float32(rt)/32.0 - 50.0
+
+	switch s.Units {
+	case "F":
+		temp = 9.0/5.0 + 32.0
+	}
+
+	return temp, rh, nil
+
+}
+
+// getStatusRegister returns the device status register
+func (s *TH02Driver) getStatusRegister() (status byte, err error) {
+	return s.readRegister(TH02ConfigReg)
+}
+
+//writeRegister writes the value to the register.
+func (s *TH02Driver) writeRegister(reg, value byte) error {
+	_, err := s.connection.Write([]byte{reg, value})
+	return err
+}
+
+//readRegister returns the value of a single regusterm and a non-nil error on problem
+func (s *TH02Driver) readRegister(reg byte) (byte, error) {
+	if _, err := s.connection.Write([]byte{reg}); err != nil {
+		return 0, err
+	}
+	rcvd := make([]byte, 1)
+	_, err := s.connection.Read(rcvd)
+	return rcvd[0], err
+}
+
+func (s *TH02Driver) waitForReady() error {
+	start := time.Now()
+	for {
+		if time.Since(start) > 100*time.Millisecond {
+			return fmt.Errorf("timeout on \\RDY")
+		}
+		reg, _ := s.readRegister(0x00)
+		if reg == 0 {
+			return nil
+		}
+	}
+}
+
+func (s *TH02Driver) readData() (uint16, error) {
+	if err := s.waitForReady(); err != nil {
+		return 1, err
+	}
+
+	if n, err := s.connection.Write([]byte{0x01}); err != nil || n != 1 {
+		return 0, fmt.Errorf("n=%d not 1, or err = %v", n, err)
+	}
+	rcvd := make([]byte, 3)
+	n, err := s.connection.Read(rcvd)
+	if err != nil || n != 3 {
+		return 0, fmt.Errorf("n=%d not 3, or err = %v", n, err)
+	}
+	return uint16(rcvd[1])<<8 + uint16(rcvd[2]), nil
+
+}

--- a/drivers/i2c/th02_driver_test.go
+++ b/drivers/i2c/th02_driver_test.go
@@ -1,0 +1,282 @@
+package i2c
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/gobottest"
+)
+
+var _ gobot.Driver = (*TH02Driver)(nil)
+
+// // --------- HELPERS
+func initTestTH02Driver() *SHT3xDriver {
+	driver, _ := initTestSHT3xDriverWithStubbedAdaptor()
+	return driver
+}
+
+func initTestTH02DriverWithStubbedAdaptor() (*TH02Driver, *i2cTestAdaptor) {
+	adaptor := newI2cTestAdaptor()
+	return NewTH02Driver(adaptor), adaptor
+}
+
+// --------- TESTS
+
+func TestNewTH02Driver(t *testing.T) {
+	i2cd := newI2cTestAdaptor()
+	defer i2cd.Close()
+	// Does it return a pointer to an instance of SHT3xDriver?
+	var iface interface{} = NewTH02Driver(i2cd)
+	_, ok := iface.(*TH02Driver)
+	if !ok {
+		t.Errorf("NewTH02Driver() should have returned a *NewTH02Driver")
+	}
+	b := NewTH02Driver(i2cd, func(Config) {})
+	gobottest.Refute(t, b.Connection(), nil)
+
+	//cover some basically useless protions the Interface demands
+	if name := b.Name(); name != b.name {
+		t.Errorf("Didnt return the proper name.  Got %q wanted %q", name, b.name)
+	}
+
+	if b.SetName("42"); b.name != "42" {
+		t.Errorf("yikes - didnt set name.")
+	}
+}
+
+func TestTH02Driver_Accuracy(t *testing.T) {
+	i2cd := newI2cTestAdaptor()
+	defer i2cd.Close()
+	b := NewTH02Driver(i2cd)
+
+	if b.SetAddress(0x42); b.addr != 0x42 {
+		t.Error("Didnt set address as expected")
+	}
+
+	if b.SetAccuracy(0x42); b.accuracy != TH02HighAccuracy {
+		t.Error("Setting an invalid accuracy should resolve to TH02HighAccuracy")
+	}
+
+	if b.SetAccuracy(TH02LowAccuracy); b.accuracy != TH02LowAccuracy {
+		t.Error("Expected setting low accuracy to actually set to low accuracy")
+	}
+
+	if acc := b.Accuracy(); acc != TH02LowAccuracy {
+		t.Errorf("Accuract() didnt return what was expected")
+	}
+}
+
+func TestTH022DriverStart(t *testing.T) {
+	b, _ := initTestTH02DriverWithStubbedAdaptor()
+	gobottest.Assert(t, b.Start(), nil)
+}
+
+func TestTH02StartConnectError(t *testing.T) {
+	d, adaptor := initTestTH02DriverWithStubbedAdaptor()
+	adaptor.Testi2cConnectErr(true)
+	gobottest.Assert(t, d.Start(), errors.New("Invalid i2c connection"))
+}
+
+func TestTH02DriverHalt(t *testing.T) {
+	sht3x := initTestTH02Driver()
+	gobottest.Assert(t, sht3x.Halt(), nil)
+}
+
+func TestTH02DriverOptions(t *testing.T) {
+	d := NewTH02Driver(newI2cTestAdaptor(), WithBus(2))
+	gobottest.Assert(t, d.GetBusOrDefault(1), 2)
+	d.Halt()
+}
+
+func TestTH02Driver_ReadData(t *testing.T) {
+	d, i2cd := initTestTH02DriverWithStubbedAdaptor()
+	gobottest.Assert(t, d.Start(), nil)
+
+	type x struct {
+		rd, wr func([]byte) (int, error)
+		rtn    uint16
+		errNil bool
+	}
+
+	tests := map[string]x{
+		"example RH": x{
+			rd: func(b []byte) (int, error) {
+				copy(b, []byte{0x00, 0x07, 0xC0})
+				return 3, nil
+			},
+			wr: func([]byte) (int, error) {
+				return 1, nil
+			},
+			errNil: true,
+			rtn:    1984,
+		},
+		"example T": x{
+			rd: func(b []byte) (int, error) {
+				copy(b, []byte{0x00, 0x12, 0xC0})
+				return 3, nil
+			},
+			wr: func([]byte) (int, error) {
+				return 1, nil
+			},
+			errNil: true,
+			rtn:    4800,
+		},
+		"timeout - no wait for ready": x{
+			rd: func(b []byte) (int, error) {
+				time.Sleep(200 * time.Millisecond)
+				copy(b, []byte{0x01})
+				return 1, fmt.Errorf("nope")
+			},
+			wr: func([]byte) (int, error) {
+				return 1, nil
+			},
+			errNil: false,
+			rtn:    0,
+		},
+		"unable to write status register": x{
+			rd: func(b []byte) (int, error) {
+				copy(b, []byte{0x00})
+				return 0, nil
+			},
+			wr: func([]byte) (int, error) {
+				return 0, fmt.Errorf("Nope")
+			},
+			errNil: false,
+			rtn:    0,
+		},
+		"unable to read doesnt provide enought data": x{
+			rd: func(b []byte) (int, error) {
+				copy(b, []byte{0x00, 0x01})
+				return 2, nil
+			},
+			wr: func([]byte) (int, error) {
+				return 1, nil
+			},
+			errNil: false,
+			rtn:    0,
+		},
+	}
+
+	for name, x := range tests {
+		t.Log("Running", name)
+		i2cd.i2cReadImpl = x.rd
+		i2cd.i2cWriteImpl = x.wr
+		got, err := d.readData()
+		gobottest.Assert(t, err == nil, x.errNil)
+		gobottest.Assert(t, got, x.rtn)
+	}
+}
+
+func TestTH02Driver_waitForReady(t *testing.T) {
+	d, i2cd := initTestTH02DriverWithStubbedAdaptor()
+	gobottest.Assert(t, d.Start(), nil)
+
+	i2cd.i2cReadImpl = func(b []byte) (int, error) {
+		time.Sleep(50 * time.Millisecond)
+		copy(b, []byte{0x01, 0x00})
+		return 3, nil
+	}
+
+	i2cd.i2cWriteImpl = func([]byte) (int, error) {
+		return 1, nil
+	}
+
+	timeout := 10 * time.Microsecond
+	if err := d.waitForReady(&timeout); err == nil {
+		t.Error("Expected a timeout error")
+	}
+}
+
+func TestTH02Driver_WriteRegister(t *testing.T) {
+	d, i2cd := initTestTH02DriverWithStubbedAdaptor()
+	gobottest.Assert(t, d.Start(), nil)
+
+	i2cd.i2cWriteImpl = func([]byte) (int, error) {
+		return 1, nil
+	}
+
+	if err := d.writeRegister(0x00, 0x00); err != nil {
+		t.Errorf("expected a nil error write")
+	}
+}
+
+func TestTH02Driver_Heater(t *testing.T) {
+	d, i2cd := initTestTH02DriverWithStubbedAdaptor()
+	gobottest.Assert(t, d.Start(), nil)
+
+	i2cd.i2cReadImpl = func(b []byte) (int, error) {
+		copy(b, []byte{0xff})
+		return 1, nil
+	}
+
+	i2cd.i2cWriteImpl = func([]byte) (int, error) {
+		return 1, nil
+	}
+
+	on, err := d.Heater()
+	gobottest.Assert(t, on, true)
+	gobottest.Assert(t, err, nil)
+}
+func TestTH02Driver_SerialNumber(t *testing.T) {
+	d, i2cd := initTestTH02DriverWithStubbedAdaptor()
+	gobottest.Assert(t, d.Start(), nil)
+
+	i2cd.i2cReadImpl = func(b []byte) (int, error) {
+		copy(b, []byte{0x42})
+		return 1, nil
+	}
+
+	i2cd.i2cWriteImpl = func([]byte) (int, error) {
+		return 1, nil
+	}
+
+	sn, err := d.SerialNumber()
+
+	gobottest.Assert(t, sn, uint32((0x42)>>4))
+	gobottest.Assert(t, err, nil)
+}
+
+func TestTH02Driver_ApplySettings(t *testing.T) {
+	d := &TH02Driver{}
+
+	type x struct {
+		acc, base, out byte
+		heating        bool
+	}
+
+	tests := map[string]x{
+		"low acc, heating":     x{acc: TH02LowAccuracy, base: 0x00, heating: true, out: 0x01},
+		"high acc, no heating": x{acc: TH02HighAccuracy, base: 0x00, heating: false, out: 0x23},
+	}
+
+	for name, x := range tests {
+		t.Log(name)
+		d.accuracy = x.acc
+		d.heating = x.heating
+		got := d.applysettings(x.base)
+		gobottest.Assert(t, x.out, got)
+	}
+}
+
+func TestTH02Driver_Sample(t *testing.T) {
+	d, i2cd := initTestTH02DriverWithStubbedAdaptor()
+	gobottest.Assert(t, d.Start(), nil)
+
+	i2cd.i2cReadImpl = func(b []byte) (int, error) {
+		copy(b, []byte{0x00, 0x00, 0x07, 0xC0})
+		return 4, nil
+	}
+
+	i2cd.i2cWriteImpl = func([]byte) (int, error) {
+		return 1, nil
+	}
+
+	temp, rh, _ := d.Sample()
+
+	gobottest.Assert(t, temp, float32(0))
+	gobottest.Assert(t, rh, float32(0))
+
+}


### PR DESCRIPTION
This commit adds basic support for a TH02 based Grove Sensor which is
silkscreened as

  Temperature&Humidity Sensor (High-Accuracy & Mini ) v1.0

https://www.seeedstudio.com/Grove-Temperature-Humidity-Sensor-High-Accuracy-Min-p-1921.html

This is a modified variant of a SHT2* driver, and still needs some
changes to be more useable.  It is written to assume you want to use the
High Precisions (slow sample rate)

Signed-off-by: npotts <npotts@users.noreply.github.com>