### PR TITLE
Fix slice bounds out of range panic when stopping Tello drone

### DIFF
--- a/platforms/dji/tello/driver.go
+++ b/platforms/dji/tello/driver.go
@@ -816,11 +816,12 @@ func (d *Driver) processVideo() error {
 		for {
 			buf := make([]byte, 2048)
 			n, _, err := d.videoConn.ReadFromUDP(buf)
-			d.Publish(d.Event(VideoFrameEvent), buf[2:n])
-
 			if err != nil {
 				fmt.Println("Error: ", err)
+				continue
 			}
+
+			d.Publish(d.Event(VideoFrameEvent), buf[2:n])
 		}
 	}()
 


### PR DESCRIPTION
Most of the time when stopping my DJI Tello drone, I was getting this panic:
```
panic: runtime error: slice bounds out of range

goroutine 50 [running]:
gobot.io/x/gobot/platforms/dji/tello.(*Driver).processVideo.func1(0xc4200d2000)
	/Users/snelson/go/src/gobot.io/x/gobot/platforms/dji/tello/driver.go:819 +0x24e
created by gobot.io/x/gobot/platforms/dji/tello.(*Driver).processVideo
	/Users/snelson/go/src/gobot.io/x/gobot/platforms/dji/tello/driver.go:815 +0xe3
exit status 2
```
I noticed the driver was trying to publish a VideoFrameEvent before checking for an error from the read UDP operation. This commit moves the error check to immediately after the read operation and continues if an error occurred. This avoids trying to slice an empty buffer and dodges a panic.