### PR TITLE
Fix DJI Tello video example

### DIFF
--- a/examples/tello_video.go
+++ b/examples/tello_video.go
@@ -25,7 +25,7 @@ import (
 func main() {
 	drone := tello.NewDriver("8890")
 
-	mplayer := exec.Command("mplayer", "-fps", "25", "-")
+	mplayer := exec.Command("mplayer", "-fps", "60", "-")
 	mplayerIn, _ := mplayer.StdinPipe()
 	if err := mplayer.Start(); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
This change allows mplayer to keep up with the video frame events. With the fps set to 25, the video frame events were stacking up and the video was lagging horribly behind.