### PR TITLE
[Hot-fix] Unexpected behavior in Hover()

### DIFF
--- a/platforms/dji/tello/driver.go
+++ b/platforms/dji/tello/driver.go
@@ -500,6 +500,7 @@ func (d *Driver) Hover() {
 
 	d.rx = float32(0)
 	d.ry = float32(0)
+	d.lx = float32(0)
 	d.ly = float32(0)
 }
 


### PR DESCRIPTION
Triggering the drone.Hover() action was not interrupting the drone's action and it was in an ongoing 360 turn.

It is not showing expected behavior (stopping the movement) due to a missing d.lx type:

```
// Hover tells the drone to stop moving on the X, Y, and Z axes and stay in place
func (d *Driver) Hover() {
	d.cmdMutex.Lock()
	defer d.cmdMutex.Unlock()
	d.rx = float32(0)
	d.ry = float32(0)
	d.lx = float32(0)
	d.ly = float32(0)
}
```

This change fixes the bug.