### PR TITLE
pwm_pin - Fix DutyCycle() parse error, need to trim off trailing '\n'…

### DIFF
--- a/sysfs/pwm_pin.go
+++ b/sysfs/pwm_pin.go
@@ -148,7 +148,8 @@ func (p *PWMPin) DutyCycle() (duty uint32, err error) {
 		return
 	}
 
-	val, e := strconv.Atoi(string(buf))
+	v := bytes.TrimRight(buf, "\n")
+	val, e := strconv.Atoi(string(v))
 	return uint32(val), e
 }
 


### PR DESCRIPTION
… before calling strconv.Atoi(), as other functions in this package do