### PR TITLE
Fix Gopkg.lock is out of sync error

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -151,17 +151,10 @@
   digest = "1:f04a78a43f55f089c919beee8ec4a1495dee1bd271548da2cb44bf44699a6a61"
   name = "github.com/nats-io/go-nats"
   packages = [
+    ".",
     "encoders/builtin",
     "util",
   ]
-  pruneopts = ""
-  revision = "fb0396ee0bdb8018b0fef30d6d1de798ce99cd05"
-  version = "v1.6.0"
-
-[[projects]]
-  digest = "1:f04a78a43f55f089c919beee8ec4a1495dee1bd271548da2cb44bf44699a6a61"
-  name = "github.com/nats-io/nats"
-  packages = ["."]
   pruneopts = ""
   revision = "fb0396ee0bdb8018b0fef30d6d1de798ce99cd05"
   version = "v1.6.0"
@@ -316,7 +309,7 @@
     "github.com/hashicorp/go-multierror",
     "github.com/hybridgroup/go-ardrone/client",
     "github.com/hybridgroup/mjpeg",
-    "github.com/nats-io/nats",
+    "github.com/nats-io/go-nats",
     "github.com/pkg/errors",
     "github.com/sigurn/crc8",
     "github.com/stretchr/testify/assert",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,7 +50,7 @@
   name = "github.com/hybridgroup/go-ardrone"
 
 [[constraint]]
-  name = "github.com/nats-io/nats"
+  name = "github.com/nats-io/go-nats"
   version = "1.3.0"
 
 [[constraint]]


### PR DESCRIPTION
When running `dep ensure` on local machine - following warning message is displayed:
```
Warning: the following project(s) have [[constraint]] stanzas in Gopkg.toml:

  ✗  github.com/nats-io/nats

However, these projects are not direct dependencies of the current project:
they are not imported in any .go files, nor are they in the 'required' list in
Gopkg.toml. Dep only applies [[constraint]] rules to direct dependencies, so
these rules will have no effect.

Either import/require packages from these projects so that they become direct
dependencies, or convert each [[constraint]] to an [[override]] to enforce rules
on these projects, if they happen to be transitive dependencies.

# Gopkg.lock is out of sync with Gopkg.toml and project imports:
github.com/nats-io/go-nats: imported or required, but missing from Gopkg.lock's input-imports
github.com/nats-io/nats: in Gopkg.lock's input-imports, but neither imported nor required
```

This PR fixes this