### PR TITLE
Stop using Red parameter for brightness value

### DIFF
--- a/drivers/spi/apa102.go
+++ b/drivers/spi/apa102.go
@@ -1,9 +1,9 @@
 package spi
 
 import (
-	"image/color"
-
 	"gobot.io/x/gobot"
+	"image/color"
+	"math"
 )
 
 // APA102Driver is a driver for the APA102 programmable RGB LEDs
@@ -93,7 +93,7 @@ func (d *APA102Driver) Draw() error {
 
 	for i, c := range d.vals {
 		j := (i + 1) * 4
-		tx[j] = 0xe0 + byte(c.R)
+		tx[j] = 0xe0 + byte(math.Min(c.A, 31))
 		tx[j+1] = byte(c.B)
 		tx[j+2] = byte(c.G)
 		tx[j+3] = byte(c.R)


### PR DESCRIPTION
This change corrects using Red parameter of RGBA for the Brightness value, to using the Alpha parameter of RGBA.

As the brightness max value for APA102 is `31` the `math.Min` stops the driver from using any value higher than 31.