### PR TITLE
Staticcheck lint fixes

### DIFF
--- a/drivers/i2c/adafruit_driver.go
+++ b/drivers/i2c/adafruit_driver.go
@@ -327,7 +327,7 @@ func (a *AdafruitMotorHatDriver) setPin(conn Connection, pin byte, value int32) 
 	if value == 1 {
 		return a.setPWM(conn, pin, 4096, 0)
 	}
-	return errors.New("Invalid pin")
+	return errors.New("invalid pin")
 }
 
 // SetDCMotorSpeed will set the appropriate pins to run the specified DC motor

--- a/drivers/i2c/ads1x15_driver.go
+++ b/drivers/i2c/ads1x15_driver.go
@@ -212,7 +212,7 @@ func (d *ADS1x15Driver) BestGainForVoltage(voltage float64) (bestGain int, err e
 	}
 
 	if currentBestGain < 0 {
-		err = fmt.Errorf("The maximum voltage which can be read is %f", max)
+		err = fmt.Errorf("the maximum voltage which can be read is %f", max)
 		return
 	}
 
@@ -271,19 +271,15 @@ func (d *ADS1x15Driver) AnalogRead(pin string) (value int, err error) {
 	case "0-1":
 		useDifference = true
 		channel = 0
-		break
 	case "0-3":
 		useDifference = true
 		channel = 1
-		break
 	case "1-3":
 		useDifference = true
 		channel = 2
-		break
 	case "2-3":
 		useDifference = true
 		channel = 3
-		break
 	}
 
 	if useDifference {
@@ -315,7 +311,7 @@ func (d *ADS1x15Driver) rawRead(mux int, gain int, dataRate int) (value float64,
 	gainConf, ok := d.gainConfig[gain]
 
 	if !ok {
-		err = errors.New("Gain must be one of: 2/3, 1, 2, 4, 8, 16")
+		err = errors.New("gain must be one of: 2/3, 1, 2, 4, 8, 16")
 		return
 	}
 	config |= gainConf
@@ -331,7 +327,7 @@ func (d *ADS1x15Driver) rawRead(mux int, gain int, dataRate int) (value float64,
 			keys = append(keys, k)
 		}
 
-		err = fmt.Errorf("Invalid data rate. Accepted values: %d", keys)
+		err = fmt.Errorf("invalid data rate. Accepted values: %d", keys)
 		return
 	}
 	// Set the data rate (this is controlled by the subclass as it differs
@@ -363,7 +359,7 @@ func (d *ADS1x15Driver) rawRead(mux int, gain int, dataRate int) (value float64,
 	voltageMultiplier, ok := d.gainVoltage[gain]
 
 	if !ok {
-		err = errors.New("Gain must be one of: 2/3, 1, 2, 4, 8, 16")
+		err = errors.New("gain must be one of: 2/3, 1, 2, 4, 8, 16")
 		return
 	}
 
@@ -374,7 +370,7 @@ func (d *ADS1x15Driver) rawRead(mux int, gain int, dataRate int) (value float64,
 
 func (d *ADS1x15Driver) checkChannel(channel int) (err error) {
 	if channel < 0 || channel > 3 {
-		err = errors.New("Invalid channel, must be between 0 and 3")
+		err = errors.New("invalid channel, must be between 0 and 3")
 	}
 	return
 }

--- a/drivers/i2c/ads1x15_driver_test.go
+++ b/drivers/i2c/ads1x15_driver_test.go
@@ -22,11 +22,6 @@ func initTestADS1015Driver() (driver *ADS1x15Driver) {
 	return
 }
 
-func initTestADS1115Driver() (driver *ADS1x15Driver) {
-	driver, _ = initTestADS1115DriverWithStubbedAdaptor()
-	return
-}
-
 func initTestADS1015DriverWithStubbedAdaptor() (*ADS1x15Driver, *i2cTestAdaptor) {
 	adaptor := newI2cTestAdaptor()
 	return NewADS1015Driver(adaptor), adaptor
@@ -125,7 +120,7 @@ func TestADS1015DriverAnalogRead(t *testing.T) {
 	gobottest.Assert(t, val, 1022)
 	gobottest.Assert(t, err, nil)
 
-	val, err = d.AnalogRead("3-2")
+	_, err = d.AnalogRead("3-2")
 	gobottest.Refute(t, err.Error(), nil)
 }
 
@@ -170,7 +165,7 @@ func TestADS1115DriverAnalogRead(t *testing.T) {
 	gobottest.Assert(t, val, 1022)
 	gobottest.Assert(t, err, nil)
 
-	val, err = d.AnalogRead("3-2")
+	_, err = d.AnalogRead("3-2")
 	gobottest.Refute(t, err.Error(), nil)
 }
 
@@ -216,8 +211,9 @@ func TestADS1x15DriverBestGainForVoltage(t *testing.T) {
 
 	g, err := d.BestGainForVoltage(1.5)
 	gobottest.Assert(t, g, 2)
+	gobottest.Assert(t, err, nil)
 
-	g, err = d.BestGainForVoltage(20.0)
+	_, err = d.BestGainForVoltage(20.0)
 	gobottest.Assert(t, err, errors.New("The maximum voltage which can be read is 6.144000"))
 }
 

--- a/drivers/i2c/blinkm_driver_test.go
+++ b/drivers/i2c/blinkm_driver_test.go
@@ -150,7 +150,7 @@ func TestBlinkMDriverFirmwareVersion(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 
-	version, err := blinkM.FirmwareVersion()
+	_, err := blinkM.FirmwareVersion()
 	gobottest.Assert(t, err, errors.New("write error"))
 }
 
@@ -181,9 +181,8 @@ func TestBlinkMDriverColor(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 
-	color, err := blinkM.Color()
+	_, err := blinkM.Color()
 	gobottest.Assert(t, err, errors.New("write error"))
-
 }
 
 func TestBlinkMDriverFade(t *testing.T) {

--- a/drivers/i2c/ccs811_driver.go
+++ b/drivers/i2c/ccs811_driver.go
@@ -13,11 +13,11 @@ type CCS811DriveMode uint8
 
 // Operating modes which dictate how often measurements are being made. If 0x00 is used as an operating mode, measurements will be disabled
 const (
-	CCS811DriveModeIdle  CCS811DriveMode = 0x00
-	CCS811DriveMode1Sec                  = 0x01
-	CCS811DriveMode10Sec                 = 0x02
-	CCS811DriveMode60Sec                 = 0x03
-	CCS811DriveMode250MS                 = 0x04
+	CCS811DriveModeIdle CCS811DriveMode = iota
+	CCS811DriveMode1Sec
+	CCS811DriveMode10Sec
+	CCS811DriveMode60Sec
+	CCS811DriveMode250MS
 )
 
 const (
@@ -33,9 +33,9 @@ const (
 	//This multi-byte read only register contains the calculated eCO2 (ppm) and eTVOC (ppb) values followed by the STATUS register, ERROR_ID register and the RAW_DATA register.
 	ccs811RegAlgResultData = 0x02
 	//Two byte read only register which contains the latest readings from the sensor.
-	ccs811RegRawData = 0x03
+	// ccs811RegRawData = 0x03
 	//A multi-byte register that can be written with the current Humidity and Temperature values if known.
-	ccs811RegEnvData = 0x05
+	// ccs811RegEnvData = 0x05
 	//Register that holds the NTC value used for temperature calcualtions
 	ccs811RegNtc = 0x06
 	//Asserting the SW_RESET will restart the CCS811 in Boot mode to enable new application firmware to be downloaded.
@@ -309,27 +309,27 @@ func (d *CCS811Driver) startApp() error {
 func (d *CCS811Driver) initialize() error {
 	deviceID, err := d.connection.ReadByteData(ccs811RegHwID)
 	if err != nil {
-		return fmt.Errorf("Failed to get the device id from ccs811RegHwID with error: %s", err.Error())
+		return fmt.Errorf("failed to get the device id from ccs811RegHwID with error: %s", err.Error())
 	}
 
 	// Verify that the connected device is the CCS811 sensor
 	if deviceID != ccs811HwIDCode {
-		return fmt.Errorf("The fetched device id %d is not the known id %d with error", deviceID, ccs811HwIDCode)
+		return fmt.Errorf("the fetched device id %d is not the known id %d with error", deviceID, ccs811HwIDCode)
 	}
 
 	if err := d.resetDevice(); err != nil {
-		return fmt.Errorf("Was not able to reset the device with error: %s", err.Error())
+		return fmt.Errorf("was not able to reset the device with error: %s", err.Error())
 	}
 
 	// Required sleep to allow device to switch states
 	time.Sleep(100 * time.Millisecond)
 
 	if err := d.startApp(); err != nil {
-		return fmt.Errorf("Failed to start app code with error: %s", err.Error())
+		return fmt.Errorf("failed to start app code with error: %s", err.Error())
 	}
 
 	if err := d.updateMeasMode(); err != nil {
-		return fmt.Errorf("Failed to update the measMode register with error: %s", err.Error())
+		return fmt.Errorf("failed to update the measMode register with error: %s", err.Error())
 	}
 
 	return nil

--- a/drivers/i2c/drv2605l_driver.go
+++ b/drivers/i2c/drv2605l_driver.go
@@ -9,14 +9,14 @@ type DRV2605Mode uint8
 
 // Operating modes, for use in SetMode()
 const (
-	DRV2605ModeIntTrig     DRV2605Mode = 0x00
-	DRV2605ModeExtTrigEdge             = 0x01
-	DRV2605ModeExtTrigLvl              = 0x02
-	DRV2605ModePWMAnalog               = 0x03
-	DRV2605ModeAudioVibe               = 0x04
-	DRV2605ModeRealtime                = 0x05
-	DRV2605ModeDiagnose                = 0x06
-	DRV2605ModeAutocal                 = 0x07
+	DRV2605ModeIntTrig DRV2605Mode = iota
+	DRV2605ModeExtTrigEdge
+	DRV2605ModeExtTrigLvl
+	DRV2605ModePWMAnalog
+	DRV2605ModeAudioVibe
+	DRV2605ModeRealtime
+	DRV2605ModeDiagnose
+	DRV2605ModeAutocal
 )
 
 const (

--- a/drivers/i2c/grovepi_driver.go
+++ b/drivers/i2c/grovepi_driver.go
@@ -156,12 +156,14 @@ func (d *GrovePiDriver) DigitalWrite(pin string, val byte) (err error) {
 // WriteAnalog writes PWM aka analog to the GrovePi. Not yet working.
 func (d *GrovePiDriver) WriteAnalog(pin byte, val byte) error {
 	buf := []byte{CommandWriteAnalog, pin, val, 0}
-	_, err := d.connection.Write(buf)
+	if _, err := d.connection.Write(buf); err != nil {
+		return err
+	}
 
 	time.Sleep(2 * time.Millisecond)
 
 	data := make([]byte, 1)
-	_, err = d.connection.Read(data)
+	_, err := d.connection.Read(data)
 
 	return err
 }
@@ -174,11 +176,13 @@ func (d *GrovePiDriver) PinMode(pin byte, mode string) error {
 	} else {
 		b = []byte{CommandPinMode, pin, 0, 0}
 	}
-	_, err := d.connection.Write(b)
+	if _, err := d.connection.Write(b); err != nil {
+		return err
+	}
 
 	time.Sleep(2 * time.Millisecond)
 
-	_, err = d.connection.ReadByte()
+	_, err := d.connection.ReadByte()
 
 	return err
 }
@@ -186,7 +190,7 @@ func (d *GrovePiDriver) PinMode(pin byte, mode string) error {
 func getPin(pin string) string {
 	if len(pin) > 1 {
 		if strings.ToUpper(pin[0:1]) == "A" || strings.ToUpper(pin[0:1]) == "D" {
-			return pin[1:len(pin)]
+			return pin[1:]
 		}
 	}
 
@@ -245,11 +249,13 @@ func (d *GrovePiDriver) writeDigital(pin byte, val byte) error {
 	defer d.mutex.Unlock()
 
 	buf := []byte{CommandWriteDigital, pin, val, 0}
-	_, err := d.connection.Write(buf)
+	if _, err := d.connection.Write(buf); err != nil {
+		return err
+	}
 
 	time.Sleep(2 * time.Millisecond)
 
-	_, err = d.connection.ReadByte()
+	_, err := d.connection.ReadByte()
 
 	return err
 }

--- a/drivers/i2c/helpers_test.go
+++ b/drivers/i2c/helpers_test.go
@@ -12,14 +12,6 @@ var rgb = map[string]interface{}{
 	"blue":  1.0,
 }
 
-func castColor(color string) byte {
-	return byte(rgb[color].(float64))
-}
-
-var red = castColor("red")
-var green = castColor("green")
-var blue = castColor("blue")
-
 type i2cTestAdaptor struct {
 	name          string
 	written       []byte

--- a/drivers/i2c/i2c.go
+++ b/drivers/i2c/i2c.go
@@ -20,10 +20,10 @@ const (
 )
 
 var (
-	ErrEncryptedBytes  = errors.New("Encrypted bytes")
-	ErrNotEnoughBytes  = errors.New("Not enough bytes read")
-	ErrNotReady        = errors.New("Device is not ready")
-	ErrInvalidPosition = errors.New("Invalid position value")
+	ErrEncryptedBytes  = errors.New("encrypted bytes")
+	ErrNotEnoughBytes  = errors.New("not enough bytes read")
+	ErrNotReady        = errors.New("device is not ready")
+	ErrInvalidPosition = errors.New("invalid position value")
 )
 
 type I2cOperations interface {

--- a/drivers/i2c/ina3221_driver.go
+++ b/drivers/i2c/ina3221_driver.go
@@ -49,7 +49,6 @@ type INA3221Driver struct {
 	connector  Connector
 	connection Connection
 	Config
-	halt chan bool
 }
 
 // NewINA3221Driver creates a new driver with the specified i2c interface.

--- a/drivers/i2c/mpu6050_driver.go
+++ b/drivers/i2c/mpu6050_driver.go
@@ -3,7 +3,6 @@ package i2c
 import (
 	"bytes"
 	"encoding/binary"
-	"time"
 
 	"gobot.io/x/gobot"
 )
@@ -38,7 +37,6 @@ type MPU6050Driver struct {
 	connector  Connector
 	connection Connection
 	Config
-	interval      time.Duration
 	Accelerometer ThreeDData
 	Gyroscope     ThreeDData
 	Temperature   int16

--- a/drivers/i2c/sht3x_driver.go
+++ b/drivers/i2c/sht3x_driver.go
@@ -45,10 +45,18 @@ const SHT3xAccuracyMedium = 0x0b
 const SHT3xAccuracyHigh = 0x00
 
 var (
-	crc8Params         = crc8.Params{0x31, 0xff, false, false, 0x00, 0xf7, "CRC-8/SENSIRON"}
-	ErrInvalidAccuracy = errors.New("Invalid accuracy")
-	ErrInvalidCrc      = errors.New("Invalid crc")
-	ErrInvalidTemp     = errors.New("Invalid temperature units")
+	crc8Params = crc8.Params{
+		Poly:   0x31,
+		Init:   0xff,
+		RefIn:  false,
+		RefOut: false,
+		XorOut: 0x00,
+		Check:  0xf7,
+		Name:   "CRC-8/SENSIRON",
+	}
+	ErrInvalidAccuracy = errors.New("invalid accuracy")
+	ErrInvalidCrc      = errors.New("invalid crc")
+	ErrInvalidTemp     = errors.New("invalid temperature units")
 )
 
 // SHT3xDriver is a Driver for a SHT3x humidity and temperature sensor
@@ -161,7 +169,7 @@ func (s *SHT3xDriver) Heater() (status bool, err error) {
 // SetHeater enables or disables the heater on the device
 func (s *SHT3xDriver) SetHeater(enabled bool) (err error) {
 	out := []byte{0x30, 0x66}
-	if true == enabled {
+	if enabled {
 		out[1] = 0x6d
 	}
 	_, err = s.connection.Write(out)

--- a/drivers/i2c/sht3x_driver_test.go
+++ b/drivers/i2c/sht3x_driver_test.go
@@ -231,7 +231,7 @@ func TestSHT3xDriverHeater(t *testing.T) {
 		return 3, nil
 	}
 
-	status, err = sht3x.Heater()
+	_, err = sht3x.Heater()
 	gobottest.Assert(t, err, ErrInvalidCrc)
 
 	// heater read failed
@@ -240,7 +240,7 @@ func TestSHT3xDriverHeater(t *testing.T) {
 		return 2, nil
 	}
 
-	status, err = sht3x.Heater()
+	_, err = sht3x.Heater()
 	gobottest.Refute(t, err, nil)
 }
 

--- a/drivers/i2c/ssd1306_driver.go
+++ b/drivers/i2c/ssd1306_driver.go
@@ -27,12 +27,12 @@ const (
 	ssd1306SetComOutput8 = 0xC8
 	ssd1306SetContrast   = 0x81
 	// scrolling commands
-	ssd1306ContinuousHScrollRight  = 0x26
-	ssd1306ContinuousHScrollLeft   = 0x27
-	ssd1306ContinuousVHScrollRight = 0x29
-	ssd1306ContinuousVHScrollLeft  = 0x2A
-	ssd1306StopScroll              = 0x2E
-	ssd1306StartScroll             = 0x2F
+	// ssd1306ContinuousHScrollRight  = 0x26
+	// ssd1306ContinuousHScrollLeft   = 0x27
+	// ssd1306ContinuousVHScrollRight = 0x29
+	// ssd1306ContinuousVHScrollLeft  = 0x2A
+	// ssd1306StopScroll              = 0x2E
+	// ssd1306StartScroll             = 0x2F
 	// adressing settings commands
 	ssd1306SetMemoryAddressingMode = 0x20
 	ssd1306ColumnAddr              = 0x21

--- a/drivers/i2c/th02_driver.go
+++ b/drivers/i2c/th02_driver.go
@@ -54,8 +54,6 @@ type TH02Driver struct {
 	addr     byte
 	accuracy byte
 	heating  bool
-
-	delay time.Duration
 }
 
 // NewTH02Driver creates a new driver with specified i2c interface.

--- a/drivers/i2c/tsl2561_driver.go
+++ b/drivers/i2c/tsl2561_driver.go
@@ -387,7 +387,7 @@ func (d *TSL2561Driver) CalculateLux(broadband uint16, ir uint16) (lux uint32) {
 	ratio := (ratio1 + 1) / 2
 
 	b, m := d.getBM(ratio)
-	temp := (channel0 * b) - (channel1 * m)
+	temp := int64(channel0*b) - int64(channel1*m)
 
 	// Negative lux not allowed
 	if temp < 0 {
@@ -398,7 +398,7 @@ func (d *TSL2561Driver) CalculateLux(broadband uint16, ir uint16) (lux uint32) {
 	temp += (1 << (tsl2561LuxLuxScale - 1))
 
 	// Strip off fractional portion
-	lux = temp >> tsl2561LuxLuxScale
+	lux = uint32(temp) >> tsl2561LuxLuxScale
 
 	return lux
 }
@@ -469,7 +469,7 @@ func (d *TSL2561Driver) getClipScaling() (clipThreshold uint16, chScale uint32) 
 
 func (d *TSL2561Driver) getBM(ratio uint32) (b uint32, m uint32) {
 	switch {
-	case (ratio >= 0) && (ratio <= tsl2561LuxK1T):
+	case ratio <= tsl2561LuxK1T:
 		b = tsl2561LuxB1T
 		m = tsl2561LuxM1T
 	case (ratio <= tsl2561LuxK2T):
@@ -506,5 +506,4 @@ func (d *TSL2561Driver) waitForADC() {
 	case TSL2561IntegrationTime402MS:
 		time.Sleep(450 * time.Millisecond)
 	}
-	return
 }

--- a/drivers/i2c/wiichuck_driver_test.go
+++ b/drivers/i2c/wiichuck_driver_test.go
@@ -191,10 +191,8 @@ func TestWiichuckDriverUpdateJoystick(t *testing.T) {
 }
 
 func TestWiichuckDriverEncrypted(t *testing.T) {
-	wii := initTestWiichuckDriver()
-
 	// ------ When value is encrypted
-	wii = initTestWiichuckDriver()
+	wii := initTestWiichuckDriver()
 	encryptedValue := []byte{1, 1, 2, 2, 3, 3}
 
 	wii.update(encryptedValue)


### PR DESCRIPTION
When creating some new drivers noticed a host of warning from staticcheck/govet/golint.  Was able to squash all but a single unsafe pointer warning that would have to investigate further.