### PR TITLE
Apa102 use default brightness

### DIFF
--- a/drivers/spi/apa102.go
+++ b/drivers/spi/apa102.go
@@ -7,7 +7,7 @@ import (
 	"gobot.io/x/gobot"
 )
 
-// APA102Driver is a driver for the APA102 programmable RGB LEDs
+// APA102Driver is a driver for the APA102 programmable RGB LEDs.
 type APA102Driver struct {
 	name       string
 	connector  Connector
@@ -21,15 +21,16 @@ type APA102Driver struct {
 // NewAPA102Driver creates a new Gobot Driver for APA102 RGB LEDs.
 //
 // Params:
-//      a *Adaptor - the Adaptor to use with this Driver
-//		count int - how many LEDs are in the array controlled by this driver
+//      a *Adaptor - the Adaptor to use with this Driver.
+//      count int - how many LEDs are in the array controlled by this driver.
+//      bright - the default brightness to apply for all LEDs (must be between 0 and 31).
 //
 // Optional params:
-//      spi.WithBus(int):    	bus to use with this driver
-//     	spi.WithChip(int):    	chip to use with this driver
-//      spi.WithMode(int):    	mode to use with this driver
-//      spi.WithBits(int):    	number of bits to use with this driver
-//      spi.WithSpeed(int64):   speed in Hz to use with this driver
+//      spi.WithBus(int):    	  bus to use with this driver.
+//      spi.WithChip(int):    	chip to use with this driver.
+//      spi.WithMode(int):    	mode to use with this driver.
+//      spi.WithBits(int):    	number of bits to use with this driver.
+//      spi.WithSpeed(int64):   speed in Hz to use with this driver.
 //
 func NewAPA102Driver(a Connector, count int, options ...func(Config)) *APA102Driver {
 	d := &APA102Driver{

--- a/drivers/spi/apa102_test.go
+++ b/drivers/spi/apa102_test.go
@@ -11,7 +11,7 @@ import (
 var _ gobot.Driver = (*APA102Driver)(nil)
 
 func initTestDriver() *APA102Driver {
-	d := NewAPA102Driver(&TestConnector{}, 10)
+	d := NewAPA102Driver(&TestConnector{}, 10, 31)
 	return d
 }
 
@@ -30,10 +30,10 @@ func TestDriverLEDs(t *testing.T) {
 	d := initTestDriver()
 	d.Start()
 
-	d.SetRGBA(0, color.RGBA{255, 255, 255, 0})
-	d.SetRGBA(1, color.RGBA{255, 255, 255, 0})
-	d.SetRGBA(2, color.RGBA{255, 255, 255, 0})
-	d.SetRGBA(3, color.RGBA{255, 255, 255, 0})
+	d.SetRGBA(0, color.RGBA{255, 255, 255, 15})
+	d.SetRGBA(1, color.RGBA{255, 255, 255, 15})
+	d.SetRGBA(2, color.RGBA{255, 255, 255, 15})
+	d.SetRGBA(3, color.RGBA{255, 255, 255, 15})
 
 	gobottest.Assert(t, d.Draw(), nil)
 }


### PR DESCRIPTION
@deadprogram I've update my pull request to last dev branch, it allows a default setting for brightness on APA102 driver. https://github.com/hybridgroup/gobot/pull/666#issuecomment-494378861