### PR TITLE
Add diagonal hat directions to Xbox 360 joystick config

### DIFF
--- a/platforms/joystick/configs/xbox360_power_a_mini_proex.json
+++ b/platforms/joystick/configs/xbox360_power_a_mini_proex.json
@@ -19,8 +19,28 @@
         },
         {
             "hat": 0,
+            "name": "upLeft",
+            "id": 9
+        },
+        {
+            "hat": 0,
+            "name": "downLeft",
+            "id": 12
+        },
+        {
+            "hat": 0,
             "name": "right",
             "id": 2
+        },
+        {
+            "hat": 0,
+            "name": "upRight",
+            "id": 3
+        },
+        {
+            "hat": 0,
+            "name": "downRight",
+            "id": 6
         },
         {
             "hat": 0,

--- a/platforms/joystick/joystick_xbox360.go
+++ b/platforms/joystick/joystick_xbox360.go
@@ -93,8 +93,28 @@ var xbox360Config = joystickConfig{
 		},
 		hat{
 			Hat:  0,
+			Name: "upLeft",
+			ID:   9,
+		},
+		hat{
+			Hat:  0,
+			Name: "downLeft",
+			ID:   12,
+		},
+		hat{
+			Hat:  0,
 			Name: "right",
 			ID:   2,
+		},
+		hat{
+			Hat:  0,
+			Name: "upRight",
+			ID:   3,
+		},
+		hat{
+			Hat:  0,
+			Name: "downRight",
+			ID:   6,
 		},
 		hat{
 			Hat:  0,


### PR DESCRIPTION
Diagonal directions are simply the 2 buttons hit added. 
Tested on a PowerA Xbox controller