### PR TITLE
Added ability to make a relay driver inverted

### DIFF
--- a/drivers/gpio/relay_driver.go
+++ b/drivers/gpio/relay_driver.go
@@ -8,7 +8,7 @@ type RelayDriver struct {
 	name       string
 	connection DigitalWriter
 	high       bool
-	inverted   bool
+	Inverted   bool
 	gobot.Commander
 }
 
@@ -24,7 +24,7 @@ func NewRelayDriver(a DigitalWriter, pin string) *RelayDriver {
 		pin:        pin,
 		connection: a,
 		high:       false,
-		inverted:   false,
+		Inverted:   false,
 		Commander:  gobot.NewCommander(),
 	}
 
@@ -55,12 +55,6 @@ func (l *RelayDriver) Name() string { return l.name }
 // SetName sets the RelayDrivers name
 func (l *RelayDriver) SetName(n string) { l.name = n }
 
-// Inverted returns the RelayDrivers inverted state
-func (l *RelayDriver) Inverted() bool { return l.inverted }
-
-// SetInverted sets the RelayDrivers inverted state
-func (l *RelayDriver) SetInverted(inverted bool) { l.inverted = inverted }
-
 // Pin returns the RelayDrivers name
 func (l *RelayDriver) Pin() string { return l.pin }
 
@@ -71,7 +65,7 @@ func (l *RelayDriver) Connection() gobot.Connection {
 
 // State return true if the relay is On and false if the relay is Off
 func (l *RelayDriver) State() bool {
-	if l.inverted {
+	if l.Inverted {
 		return !l.high
 	}
 	return l.high
@@ -83,7 +77,7 @@ func (l *RelayDriver) On() (err error) {
 		return
 	}
 
-	if l.inverted {
+	if l.Inverted {
 		l.high = false
 	} else {
 		l.high = true
@@ -98,7 +92,7 @@ func (l *RelayDriver) Off() (err error) {
 		return
 	}
 
-	if l.inverted {
+	if l.Inverted {
 		l.high = true
 	} else {
 		l.high = false

--- a/drivers/gpio/relay_driver.go
+++ b/drivers/gpio/relay_driver.go
@@ -8,6 +8,7 @@ type RelayDriver struct {
 	name       string
 	connection DigitalWriter
 	high       bool
+	inverted   bool
 	gobot.Commander
 }
 
@@ -23,6 +24,7 @@ func NewRelayDriver(a DigitalWriter, pin string) *RelayDriver {
 		pin:        pin,
 		connection: a,
 		high:       false,
+		inverted:   false,
 		Commander:  gobot.NewCommander(),
 	}
 
@@ -53,6 +55,12 @@ func (l *RelayDriver) Name() string { return l.name }
 // SetName sets the RelayDrivers name
 func (l *RelayDriver) SetName(n string) { l.name = n }
 
+// Inverted returns the RelayDrivers inverted state
+func (l *RelayDriver) Inverted() bool { return l.inverted }
+
+// SetInverted sets the RelayDrivers inverted state
+func (l *RelayDriver) SetInverted(inverted bool) { l.inverted = inverted }
+
 // Pin returns the RelayDrivers name
 func (l *RelayDriver) Pin() string { return l.pin }
 
@@ -63,6 +71,9 @@ func (l *RelayDriver) Connection() gobot.Connection {
 
 // State return true if the relay is On and false if the relay is Off
 func (l *RelayDriver) State() bool {
+	if l.inverted {
+		return !l.high
+	}
 	return l.high
 }
 
@@ -71,7 +82,13 @@ func (l *RelayDriver) On() (err error) {
 	if err = l.connection.DigitalWrite(l.Pin(), 1); err != nil {
 		return
 	}
-	l.high = true
+
+	if l.inverted {
+		l.high = false
+	} else {
+		l.high = true
+	}
+
 	return
 }
 
@@ -80,7 +97,13 @@ func (l *RelayDriver) Off() (err error) {
 	if err = l.connection.DigitalWrite(l.Pin(), 0); err != nil {
 		return
 	}
-	l.high = false
+
+	if l.inverted {
+		l.high = true
+	} else {
+		l.high = false
+	}
+
 	return
 }
 

--- a/drivers/gpio/relay_driver_test.go
+++ b/drivers/gpio/relay_driver_test.go
@@ -10,6 +10,9 @@ import (
 
 var _ gobot.Driver = (*RelayDriver)(nil)
 
+// Helper to return low/high value for testing
+func (l *RelayDriver) High() bool { return l.high }
+
 func initTestRelayDriver() *RelayDriver {
 	a := newGpioTestAdaptor()
 	a.testAdaptorDigitalWrite = func() (err error) {
@@ -33,6 +36,13 @@ func TestRelayDriverSetName(t *testing.T) {
 	gobottest.Assert(t, g.Name(), "mybot")
 }
 
+func TestRelayDriverSetInverted(t *testing.T) {
+	d := initTestRelayDriver()
+	gobottest.Assert(t, d.Inverted(), false)
+	d.SetInverted(true)
+	gobottest.Assert(t, d.Inverted(), true)
+}
+
 func TestRelayDriverStart(t *testing.T) {
 	d := initTestRelayDriver()
 	gobottest.Assert(t, d.Start(), nil)
@@ -52,6 +62,17 @@ func TestRelayDriverToggle(t *testing.T) {
 	gobottest.Assert(t, d.State(), false)
 }
 
+func TestRelayDriverToggleInverted(t *testing.T) {
+	d := initTestRelayDriver()
+	d.SetInverted(true)
+	d.Off()
+	gobottest.Assert(t, d.State(), false)
+	d.Toggle()
+	gobottest.Assert(t, d.State(), true)
+	d.Toggle()
+	gobottest.Assert(t, d.State(), false)
+}
+
 func TestRelayDriverCommands(t *testing.T) {
 	d := initTestRelayDriver()
 	gobottest.Assert(t, d.Command("Off")(nil), nil)
@@ -61,5 +82,22 @@ func TestRelayDriverCommands(t *testing.T) {
 	gobottest.Assert(t, d.State(), true)
 
 	gobottest.Assert(t, d.Command("Toggle")(nil), nil)
+	gobottest.Assert(t, d.State(), false)
+}
+
+func TestRelayDriverCommandsInverted(t *testing.T) {
+	d := initTestRelayDriver()
+	d.SetInverted(true)
+
+	gobottest.Assert(t, d.Command("Off")(nil), nil)
+	gobottest.Assert(t, d.High(), true)
+	gobottest.Assert(t, d.State(), false)
+
+	gobottest.Assert(t, d.Command("On")(nil), nil)
+	gobottest.Assert(t, d.High(), false)
+	gobottest.Assert(t, d.State(), true)
+
+	gobottest.Assert(t, d.Command("Toggle")(nil), nil)
+	gobottest.Assert(t, d.High(), true)
 	gobottest.Assert(t, d.State(), false)
 }

--- a/drivers/gpio/relay_driver_test.go
+++ b/drivers/gpio/relay_driver_test.go
@@ -36,13 +36,6 @@ func TestRelayDriverSetName(t *testing.T) {
 	gobottest.Assert(t, g.Name(), "mybot")
 }
 
-func TestRelayDriverSetInverted(t *testing.T) {
-	d := initTestRelayDriver()
-	gobottest.Assert(t, d.Inverted(), false)
-	d.SetInverted(true)
-	gobottest.Assert(t, d.Inverted(), true)
-}
-
 func TestRelayDriverStart(t *testing.T) {
 	d := initTestRelayDriver()
 	gobottest.Assert(t, d.Start(), nil)
@@ -64,7 +57,7 @@ func TestRelayDriverToggle(t *testing.T) {
 
 func TestRelayDriverToggleInverted(t *testing.T) {
 	d := initTestRelayDriver()
-	d.SetInverted(true)
+	d.Inverted = true
 	d.Off()
 	gobottest.Assert(t, d.State(), false)
 	d.Toggle()
@@ -87,7 +80,7 @@ func TestRelayDriverCommands(t *testing.T) {
 
 func TestRelayDriverCommandsInverted(t *testing.T) {
 	d := initTestRelayDriver()
-	d.SetInverted(true)
+	d.Inverted = true
 
 	gobottest.Assert(t, d.Command("Off")(nil), nil)
 	gobottest.Assert(t, d.High(), true)


### PR DESCRIPTION
I did not want to break any existing projects that already use the RelayDriver, but at the same time didn't want to create a completely new RelayDriver that has all the same functionality as the standard one, execpt that it's inverted.

For this reason I didn't updated the signature for `NewRelayDriver` and rather opted to add `SetInverted` which can then set this value after the initial instance was created.

[#648]