### PR TITLE
689 update codegangsta to urfave

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Descriptions for each of these will eventually be provided below.
 
 * All active development is in the `dev` branch. New or updated features must be added to the `dev` branch. Hotfixes will be considered on the `master` branch in situations where it does not alter behaviour or features, only fixes a bug.
 * All patches must be provided under the Apache 2.0 License
-* Please use the -s option in git to "sign off" that the commit is your work and you are providing it under the Apache 2.0 License
+* Please use the -S option in git to "sign off" that the commit is your work and you are providing it under the Apache 2.0 License
 * Submit a Github Pull Request to the appropriate branch and ideally discuss the changes with us in IRC.
 * We will look at the patch, test it out, and give you feedback.
 * Avoid doing minor whitespace changes, renamings, etc. along with merged content. These will be done by the maintainers from time to time but they can complicate merges and should be done seperately.

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,45 +3,50 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:da54e55f2f63347514121c0d7b53631970367b26281d057ec66925c57324b8f1"
   name = "github.com/bmizerany/pat"
   packages = ["."]
+  pruneopts = ""
   revision = "6226ea591a40176dd3ff9cd8eff81ed6ca721a00"
 
 [[projects]]
-  name = "github.com/codegangsta/cli"
-  packages = ["."]
-  revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
-  version = "v1.20.0"
+  digest = "1:141635a36d65611d06a05ec1d17be950e386426b6540169fe7c9476df41f6493"
+  name = "github.com/cpuguy83/go-md2man"
+  packages = ["md2man"]
+  pruneopts = ""
+  revision = "7762f7e404f8416dfa1d9bb6a8c192aa9acb4d19"
+  version = "v1.0.10"
 
 [[projects]]
+  digest = "1:2a3e7762c7601d229c2e3e24122391d2640d2036c63b95e712576641129cfbc1"
   name = "github.com/creack/goselect"
   packages = ["."]
+  pruneopts = ""
   revision = "c98c4e62c41618cf78d3ff759af0d4dbaa677748"
   version = "v0.1.0"
 
 [[projects]]
-  name = "github.com/davecgh/go-spew"
-  packages = ["spew"]
-  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
-  version = "v1.1.1"
-
-[[projects]]
   branch = "master"
+  digest = "1:917123ed8122468eb815cc418af3bbf298c91f9cb1c36164e063f50e1a726e97"
   name = "github.com/donovanhide/eventsource"
   packages = ["."]
+  pruneopts = ""
   revision = "3ed64d21fb0b6bd8b49bcfec08f3004daee8723d"
 
 [[projects]]
+  digest = "1:392ebbe504a822b15b41dd09cecc5baa98e9e0942502950dc14ba1f23c149e32"
   name = "github.com/eclipse/paho.mqtt.golang"
   packages = [
     ".",
-    "packets"
+    "packets",
   ]
+  pruneopts = ""
   revision = "adca289fdcf8c883800aafa545bc263452290bae"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:096920b06385101f5eee18c51987e481f2c0093f9dcc0661d38327f4d2acaafb"
   name = "github.com/go-ble/ble"
   packages = [
     ".",
@@ -53,188 +58,305 @@
     "linux/hci",
     "linux/hci/cmd",
     "linux/hci/evt",
-    "linux/hci/socket"
+    "linux/hci/socket",
   ]
+  pruneopts = ""
   revision = "e4c77014ff5a22003a43b91ce1c53381ac9de901"
 
 [[projects]]
+  digest = "1:4b6a43ba3296f26ea01ae125e50951f141c215dd18b5b91e9f397117b2951eb1"
   name = "github.com/gobuffalo/uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "3f701655805f1ef76e9963d1b377497a0c66d7cd"
   version = "v2.0.5"
 
 [[projects]]
+  digest = "1:141cc9fc6279592458b304038bd16a05ef477d125c6dad281216345a11746fd7"
   name = "github.com/gofrs/uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "6b08a5c5172ba18946672b49749cde22873dd7c2"
   version = "v3.2.0"
 
 [[projects]]
+  digest = "1:8e3bd93036b4a925fe2250d3e4f38f21cadb8ef623561cd80c3c50c114b13201"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
+  pruneopts = ""
   revision = "8a6fb523712970c966eefc6b39ed2c5e74880354"
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:27c5db168bd1132f99ef53ce03f598014c9f24bf087edf473299beffcd00aff0"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
-  revision = "886a7fbe3eb1c874d46f623bfa70af45f425b3d1"
-  version = "v1.0.0"
+  pruneopts = ""
+  revision = "bdca7bb83f603b80ef756bb953fe1dafa9cd00a2"
 
 [[projects]]
   branch = "master"
+  digest = "1:aba830e5898f09dd06027a27a10f4d44e8b0762a3ba0c83a771a01f4e72b81c3"
   name = "github.com/hybridgroup/go-ardrone"
   packages = [
     "client",
     "client/commands",
-    "client/navdata"
+    "client/navdata",
   ]
+  pruneopts = ""
   revision = "b9750d8d7b78f9638e5fdd899835e99d46b5a56c"
 
 [[projects]]
   branch = "master"
+  digest = "1:9956f4f58b2ccea25656086bcd7be0273915961a8231965a1a6c886874172054"
   name = "github.com/hybridgroup/mjpeg"
   packages = ["."]
+  pruneopts = ""
   revision = "4680f319790ebffe28bbee775ecd1725693731ca"
 
 [[projects]]
+  digest = "1:85fdd2ce48a3fd1ddc4671b972f50a47dcf2eebb24813e90b28a8a1fcf65ee5a"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
+  pruneopts = ""
   revision = "3a70a971f94a22f2fa562ffcc7a0eb45f5daf045"
   version = "v0.1.1"
 
 [[projects]]
+  digest = "1:d0600e4cf07697303f37130791b2ce4577367931416bea8ec4f601bde3f7c5bf"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
+  pruneopts = ""
   revision = "c2a7a6ca930a4cd0bc33a3f298eb71960732a3a7"
   version = "v0.0.7"
 
 [[projects]]
   branch = "master"
+  digest = "1:50416da10e189bc201e122e20078fb8e680a439cbdd24aaece06c434b4415b60"
   name = "github.com/mgutz/ansi"
   packages = ["."]
+  pruneopts = ""
   revision = "9520e82c474b0a04dd04f8a40959027271bab992"
 
 [[projects]]
+  digest = "1:47af139ef25cee26d54b8422b73a043ab5d8f5ec26a1ae49d3ca9212f1dbfdac"
   name = "github.com/mgutz/logxi"
   packages = ["v1"]
+  pruneopts = ""
   revision = "aebf8a7d67ab4625e0fd4a665766fef9a709161b"
   version = "v1"
 
 [[projects]]
+  digest = "1:2b5ed2cf6e8623bddd5653cffb8c6e462c2390b70186eb01546539aa177bb194"
   name = "github.com/nats-io/go-nats"
   packages = [
     ".",
     "encoders/builtin",
-    "util"
+    "util",
   ]
+  pruneopts = ""
   revision = "70fe06cee50d4b6f98248d9675fb55f2a3aa7228"
   version = "v1.7.2"
 
 [[projects]]
+  digest = "1:0006112541eed60bdfa279c8965c038865f05a677d980305dae7a0eec5bd133c"
   name = "github.com/nats-io/nkeys"
   packages = ["."]
+  pruneopts = ""
   revision = "1546a3320a8f195a5b5c84aef8309377c2e411d5"
   version = "v0.0.2"
 
 [[projects]]
+  digest = "1:9abd194bb617fe4df66607ca59812ca91caeb2053c8c9869d3507939bb63cc0b"
   name = "github.com/nats-io/nuid"
   packages = ["."]
+  pruneopts = ""
   revision = "4b96681fa6d28dd0ab5fe79bac63b3a493d9ee94"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:1d7e1867c49a6dd9856598ef7c3123604ea3daabf5b83f303ff457bcbc410b1d"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = ""
   revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
   version = "v0.8.1"
 
 [[projects]]
-  name = "github.com/pmezard/go-difflib"
-  packages = ["difflib"]
-  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  branch = "master"
+  digest = "1:41063c4ea00780183e5fb9452c30b4cb1b6fa998d56c10fec102e76cb67e8f91"
+  name = "github.com/raff/goble"
+  packages = ["xpc"]
+  pruneopts = ""
+  revision = "5a206277e7359d09af80eb4519b8fa331f5ac7da"
+
+[[projects]]
+  digest = "1:87dffed114a34c714199c74e15c04ecb1c332c669f63f722220a5e4e6eb2ef52"
+  name = "github.com/russross/blackfriday"
+  packages = ["."]
+  pruneopts = ""
+  revision = "d3b5b032dc8e8927d31a5071b56e14c89f045135"
+  version = "v2.0.1"
+
+[[projects]]
+  digest = "1:42a59e0ee70c485f96de4a30f86f88266d50b50f918053dec798f0cb2b4b7a88"
+  name = "github.com/shurcooL/sanitized_anchor_name"
+  packages = ["."]
+  pruneopts = ""
+  revision = "7bfe4c7ecddb3666a94b053b422cdd8f5aaa3615"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  name = "github.com/raff/goble"
-  packages = ["xpc"]
-  revision = "5a206277e7359d09af80eb4519b8fa331f5ac7da"
-
-[[projects]]
-  branch = "master"
+  digest = "1:eb22cc3727f58f5939373c397b0b9a8076f63e5b19584dcc00901dc5d407a77b"
   name = "github.com/sigurn/crc8"
   packages = ["."]
+  pruneopts = ""
   revision = "e55481d6f45c5a8f040343bace9013571dae103e"
 
 [[projects]]
   branch = "master"
+  digest = "1:52ed74cbf4d1bb1975642c817ec91b221c8963fa599885319407bf468431851d"
   name = "github.com/sigurn/utils"
   packages = ["."]
+  pruneopts = ""
   revision = "f19e41f79f8f006116f682c1af454591bc278ad4"
 
 [[projects]]
-  name = "github.com/stretchr/testify"
-  packages = ["assert"]
-  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
-  version = "v1.3.0"
-
-[[projects]]
   branch = "master"
+  digest = "1:5a80808c3292ff8a8a7c340b8e4b4b4253eae8a6831fa3d506b232c8f5564ccf"
   name = "github.com/tarm/serial"
   packages = ["."]
+  pruneopts = ""
   revision = "98f6abe2eb07edd42f6dfa2a934aea469acc29b7"
 
 [[projects]]
+  digest = "1:c6b7dd6b1f602f71a9522d03a65150ace6550839b71c543efa5686d56686c913"
+  name = "github.com/urfave/cli"
+  packages = ["."]
+  pruneopts = ""
+  revision = "bfe2e925cfb6d44b40ad3a779165ea7e8aff9212"
+  version = "v1.22.0"
+
+[[projects]]
+  digest = "1:4aa77644fa15ef170580070adcb70bd0adb02b0980bcc632eeaa528fd0e8137e"
   name = "github.com/veandco/go-sdl2"
   packages = ["sdl"]
+  pruneopts = ""
   revision = "271d2ec43388932fd2a80f4c2e81021734685a62"
   version = "v0.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:488c97dd29d2f0ddb48e8a04aed2da02f43efbd6e6c9a7bf9653819f55c8e90c"
   name = "go.bug.st/serial.v1"
   packages = [
     ".",
-    "unixutils"
+    "unixutils",
   ]
+  pruneopts = ""
   revision = "5f7892a7bb453066bdc6683b9b5d24d9dee03ec1"
 
 [[projects]]
+  digest = "1:d09fcb53c57fc77049863d8ebd502f0be5f9c1038ee3d3387002bdc778902aa2"
+  name = "gobot.io/x/gobot"
+  packages = [
+    ".",
+    "api",
+    "api/robeaux",
+    "drivers/aio",
+    "drivers/gpio",
+    "drivers/i2c",
+    "drivers/spi",
+    "gobottest",
+    "platforms/audio",
+    "platforms/beaglebone",
+    "platforms/ble",
+    "platforms/chip",
+    "platforms/dexter/gopigo3",
+    "platforms/digispark",
+    "platforms/dji/tello",
+    "platforms/firmata",
+    "platforms/firmata/client",
+    "platforms/holystone/hs200",
+    "platforms/intel-iot/curie",
+    "platforms/intel-iot/edison",
+    "platforms/intel-iot/joule",
+    "platforms/joystick",
+    "platforms/keyboard",
+    "platforms/leap",
+    "platforms/mavlink",
+    "platforms/mavlink/common",
+    "platforms/megapi",
+    "platforms/microbit",
+    "platforms/mqtt",
+    "platforms/nats",
+    "platforms/neurosky",
+    "platforms/opencv",
+    "platforms/parrot/ardrone",
+    "platforms/parrot/bebop",
+    "platforms/parrot/bebop/client",
+    "platforms/parrot/minidrone",
+    "platforms/particle",
+    "platforms/pebble",
+    "platforms/raspi",
+    "platforms/sphero",
+    "platforms/sphero/bb8",
+    "platforms/sphero/ollie",
+    "platforms/sphero/sprkplus",
+    "platforms/tinkerboard",
+    "platforms/upboard/up2",
+    "sysfs",
+  ]
+  pruneopts = ""
+  revision = "7f973dfdceeb4d20fe9b778b6b6fe24ee98a22d3"
+  version = "v1.13.0"
+
+[[projects]]
+  digest = "1:bd14b92557afd9859b571c7a1469f52d2f35402eb2dfe8e54e461a30e081461c"
   name = "gocv.io/x/gocv"
   packages = ["."]
+  pruneopts = ""
   revision = "0f87fa5ef3fd497562e89a821fd87a77c28cb8ea"
   version = "v0.20.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:5b3e9450868bcf9ecbca2b01ac04f142255b5744d89ec97e1ceedf57d4522645"
   name = "golang.org/x/crypto"
   packages = [
     "ed25519",
-    "ed25519/internal/edwards25519"
+    "ed25519/internal/edwards25519",
   ]
+  pruneopts = ""
   revision = "22d7a77e9e5f409e934ed268692e56707cd169e5"
 
 [[projects]]
   branch = "master"
+  digest = "1:c7da5579c766c6c7f70fb5c0ca8062114e7fcb6bb6b2cb163152a2ec9cec1846"
   name = "golang.org/x/net"
   packages = [
     "internal/socks",
     "proxy",
-    "websocket"
+    "websocket",
   ]
+  pruneopts = ""
   revision = "018c4d40a106a7ae83689758294fcd8d23850745"
 
 [[projects]]
   branch = "master"
+  digest = "1:f8fc28f6666a22fb927b5a600299968203845989eba90b977525f3dcf37afd7e"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = ""
   revision = "c432e742b0af385916e013f6a34e9e73d139cf82"
 
 [[projects]]
+  digest = "1:fc039eb7ce53b7c46253f4c6fa15da847e2b6b0142cc7f970e611b5db64403f2"
   name = "periph.io/x/periph"
   packages = [
     ".",
@@ -248,14 +370,67 @@
     "conn/spi",
     "conn/spi/spireg",
     "host/fs",
-    "host/sysfs"
+    "host/sysfs",
   ]
+  pruneopts = ""
   revision = "df7c7a4f8f86972b1474695daf94a84c9165faed"
   version = "v3.5.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "bc6d58e39da90e8b641ebbb857b01bbecb8f7a8df8eb1ed1029f1f721d1c2139"
+  input-imports = [
+    "github.com/bmizerany/pat",
+    "github.com/hybridgroup/mjpeg",
+    "github.com/tarm/serial",
+    "github.com/urfave/cli",
+    "github.com/veandco/go-sdl2/sdl",
+    "gobot.io/x/gobot",
+    "gobot.io/x/gobot/api",
+    "gobot.io/x/gobot/api/robeaux",
+    "gobot.io/x/gobot/drivers/aio",
+    "gobot.io/x/gobot/drivers/gpio",
+    "gobot.io/x/gobot/drivers/i2c",
+    "gobot.io/x/gobot/drivers/spi",
+    "gobot.io/x/gobot/gobottest",
+    "gobot.io/x/gobot/platforms/audio",
+    "gobot.io/x/gobot/platforms/beaglebone",
+    "gobot.io/x/gobot/platforms/ble",
+    "gobot.io/x/gobot/platforms/chip",
+    "gobot.io/x/gobot/platforms/dexter/gopigo3",
+    "gobot.io/x/gobot/platforms/digispark",
+    "gobot.io/x/gobot/platforms/dji/tello",
+    "gobot.io/x/gobot/platforms/firmata",
+    "gobot.io/x/gobot/platforms/firmata/client",
+    "gobot.io/x/gobot/platforms/holystone/hs200",
+    "gobot.io/x/gobot/platforms/intel-iot/curie",
+    "gobot.io/x/gobot/platforms/intel-iot/edison",
+    "gobot.io/x/gobot/platforms/intel-iot/joule",
+    "gobot.io/x/gobot/platforms/joystick",
+    "gobot.io/x/gobot/platforms/keyboard",
+    "gobot.io/x/gobot/platforms/leap",
+    "gobot.io/x/gobot/platforms/mavlink",
+    "gobot.io/x/gobot/platforms/mavlink/common",
+    "gobot.io/x/gobot/platforms/megapi",
+    "gobot.io/x/gobot/platforms/microbit",
+    "gobot.io/x/gobot/platforms/mqtt",
+    "gobot.io/x/gobot/platforms/nats",
+    "gobot.io/x/gobot/platforms/neurosky",
+    "gobot.io/x/gobot/platforms/opencv",
+    "gobot.io/x/gobot/platforms/parrot/ardrone",
+    "gobot.io/x/gobot/platforms/parrot/bebop",
+    "gobot.io/x/gobot/platforms/parrot/bebop/client",
+    "gobot.io/x/gobot/platforms/parrot/minidrone",
+    "gobot.io/x/gobot/platforms/particle",
+    "gobot.io/x/gobot/platforms/pebble",
+    "gobot.io/x/gobot/platforms/raspi",
+    "gobot.io/x/gobot/platforms/sphero",
+    "gobot.io/x/gobot/platforms/sphero/bb8",
+    "gobot.io/x/gobot/platforms/sphero/ollie",
+    "gobot.io/x/gobot/platforms/sphero/sprkplus",
+    "gobot.io/x/gobot/platforms/tinkerboard",
+    "gobot.io/x/gobot/platforms/upboard/up2",
+    "gocv.io/x/gocv",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
   name = "github.com/bmizerany/pat"
 
 [[constraint]]
-  name = "github.com/codegangsta/cli"
+  name = "github.com/urfave/cli"
   version = "1.20.0"
 
 [[constraint]]

--- a/cli/generate.go
+++ b/cli/generate.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 type config struct {

--- a/cli/main.go
+++ b/cli/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"gobot.io/x/gobot"
 )
 


### PR DESCRIPTION
This PR seeks to address installation issues stemming from a Git repo that was renamed:
https://github.com/hybridgroup/gobot/issues/689

The only remaining reference to the old name should be in this comment:
https://github.com/jshields/gobot/blob/master/api/basic_auth.go#L11

To update `Gopkg.lock`, I ran these commands:
```
brew install dep
dep ensure
```
I have no insight into why dep made all the changes it did to the lock file, aside from removing the old dependency name and adding the new one. Here is the version I am using:
```
dep version
dep:
 version     : v0.5.4
 build date  : 2019-06-14
 git hash    : 1f7c19e
 go version  : go1.12.6
 go compiler : gc
 platform    : darwin/amd64
 features    : ImportDuringSolve=false
```