### PR TITLE
tello: make sure videoConn has been opened before closing it

### DIFF
--- a/platforms/dji/tello/driver.go
+++ b/platforms/dji/tello/driver.go
@@ -289,7 +289,9 @@ func (d *Driver) Halt() (err error) {
 
 	// TODO: cleanly shutdown the goroutines that are handling the UDP connections before closing
 	d.cmdConn.Close()
-	d.videoConn.Close()
+	if d.videoConn != nil {
+		d.videoConn.Close()
+	}
 	return
 }
 


### PR DESCRIPTION
If the `ConnectedEvent` has not been received before calling `Halt()`, `d.videoConn` is `nil` and therefore `d.videoConn.Close()` panics. This PR fixes the panic.