### PR TITLE
add ultrasonic support for i2c driver

### DIFF
--- a/drivers/i2c/grovepi_driver_test.go
+++ b/drivers/i2c/grovepi_driver_test.go
@@ -1,13 +1,12 @@
 package i2c
 
 import (
-	"strings"
-	"testing"
-
 	"gobot.io/x/gobot"
 	"gobot.io/x/gobot/drivers/aio"
 	"gobot.io/x/gobot/drivers/gpio"
 	"gobot.io/x/gobot/gobottest"
+	"strings"
+	"testing"
 )
 
 var _ gobot.Driver = (*GrovePiDriver)(nil)
@@ -24,9 +23,8 @@ var _ aio.AnalogReader = (*GrovePiDriver)(nil)
 // must implement the Adaptor interface
 var _ gobot.Adaptor = (*GrovePiDriver)(nil)
 
-func initTestGrovePiDriver() (driver *GrovePiDriver) {
-	driver, _ = initGrovePiDriverWithStubbedAdaptor()
-	return
+func initTestGrovePiDriver() (driver *GrovePiDriver, adaptor *i2cTestAdaptor) {
+	return initGrovePiDriverWithStubbedAdaptor()
 }
 
 func initGrovePiDriverWithStubbedAdaptor() (*GrovePiDriver, *i2cTestAdaptor) {
@@ -35,7 +33,7 @@ func initGrovePiDriverWithStubbedAdaptor() (*GrovePiDriver, *i2cTestAdaptor) {
 }
 
 func TestGrovePiDriverName(t *testing.T) {
-	g := initTestGrovePiDriver()
+	g, _ := initTestGrovePiDriver()
 	gobottest.Refute(t, g.Connection(), nil)
 	gobottest.Assert(t, strings.HasPrefix(g.Name(), "GrovePi"), true)
 }
@@ -45,9 +43,41 @@ func TestGrovePiDriverOptions(t *testing.T) {
 	gobottest.Assert(t, g.GetBusOrDefault(1), 2)
 }
 
+func TestGrovePiDriver_UltrasonicRead(t *testing.T) {
+	g, a := initTestGrovePiDriver()
+	g.Start()
+
+	fakePin := byte(1)
+    fakeI2cResponse := []byte{CommandReadUltrasonic, 1, 2}
+
+	expectedCommand := []byte{CommandReadUltrasonic, fakePin, 0, 0}
+    expectedResult := 257
+
+	resultCommand := make([]byte, 3)
+
+    // capture i2c command
+	a.i2cWriteImpl = func(bytes []byte) (i int, e error) {
+		resultCommand = bytes
+		return len(bytes), nil
+	}
+
+	// fake i2c response
+	a.i2cReadImpl = func(bytes []byte) (i int, e error) {
+		bytes[0] = fakeI2cResponse[0]
+		bytes[1] = fakeI2cResponse[1]
+		bytes[2] = fakeI2cResponse[2]
+		return len(bytes), nil
+	}
+
+	result, _ := g.readUltrasonic(fakePin, 10)
+
+	gobottest.Assert(t, resultCommand, expectedCommand)
+	gobottest.Assert(t, result, expectedResult)
+}
+
 // Methods
 func TestGrovePiDriverStart(t *testing.T) {
-	g := initTestGrovePiDriver()
+	g, _ := initTestGrovePiDriver()
 
 	gobottest.Assert(t, g.Start(), nil)
 }


### PR DESCRIPTION
Add new i2c feature for grovepi.

I use this code with the grove ultra sonic ranger : https://www.seeedstudio.com/Grove-Ultrasonic-Distance-Sensor.html

Mainly based on : https://github.com/DexterInd/GrovePi/blob/3b43647a4c87a892578a6818d8d55d16d932edba/Script/multi_grovepi_installer/grovepi3.py#L191

Feel free to comment, accept or refused it ^^

btw : nice project ;)