### PR TITLE
added support for EDU drones

### DIFF
--- a/platforms/dji/tello/driver.go
+++ b/platforms/dji/tello/driver.go
@@ -221,6 +221,33 @@ func NewDriver(port string) *Driver {
 	return d
 }
 
+// NewEDUDriver creates a driver for the Tello drone in AP mode. Pass in the UDP port to use for the responses from the drone.
+func NewEDUDriver(address string, port string) *Driver {
+	d := &Driver{name: gobot.DefaultName("Tello"),
+		reqAddr:   address,
+		respPort:  port,
+		videoPort: "11111",
+		Eventer:   gobot.NewEventer(),
+	}
+
+	d.AddEvent(ConnectedEvent)
+	d.AddEvent(FlightDataEvent)
+	d.AddEvent(TakeoffEvent)
+	d.AddEvent(LandingEvent)
+	d.AddEvent(PalmLandingEvent)
+	d.AddEvent(BounceEvent)
+	d.AddEvent(FlipEvent)
+	d.AddEvent(TimeEvent)
+	d.AddEvent(LogEvent)
+	d.AddEvent(WifiDataEvent)
+	d.AddEvent(LightStrengthEvent)
+	d.AddEvent(SetExposureEvent)
+	d.AddEvent(VideoFrameEvent)
+	d.AddEvent(SetVideoEncoderRateEvent)
+
+	return d
+}
+
 // Name returns the name of the device.
 func (d *Driver) Name() string { return d.name }
 


### PR DESCRIPTION
Tello EDU drones have AP mode which allows a tello to connect to non standard IP address. The default driver function currently has the IP addresses hard coded, not allowing for the AP mode functionality. 

I added a new function, NewEDUDriver which takes in the address to set for the driver.