### PR TITLE
added newedudriver function

### DIFF
--- a/platforms/dji/tello/driver.go
+++ b/platforms/dji/tello/driver.go
@@ -221,6 +221,33 @@ func NewDriver(port string) *Driver {
 	return d
 }
 
+// NewEDUDriver creates a driver for the Tello EDU drone in AP mode. Pass in the UDP port to use for the responses from the drone.
+func NewEDUDriver(address string, port string) *Driver {
+	d := &Driver{name: gobot.DefaultName("Tello"),
+		reqAddr:   address,
+		respPort:  port,
+		videoPort: "11111",
+		Eventer:   gobot.NewEventer(),
+	}
+
+	d.AddEvent(ConnectedEvent)
+	d.AddEvent(FlightDataEvent)
+	d.AddEvent(TakeoffEvent)
+	d.AddEvent(LandingEvent)
+	d.AddEvent(PalmLandingEvent)
+	d.AddEvent(BounceEvent)
+	d.AddEvent(FlipEvent)
+	d.AddEvent(TimeEvent)
+	d.AddEvent(LogEvent)
+	d.AddEvent(WifiDataEvent)
+	d.AddEvent(LightStrengthEvent)
+	d.AddEvent(SetExposureEvent)
+	d.AddEvent(VideoFrameEvent)
+	d.AddEvent(SetVideoEncoderRateEvent)
+
+	return d
+}
+
 // Name returns the name of the device.
 func (d *Driver) Name() string { return d.name }
 


### PR DESCRIPTION
Tello EDU drones have the ability to be put into AP mode, connecting with a router for custom IP addresses. The current Tello driver hard codes the default IP address, which disallows this functionality. The new EDU driver keeps the existing driver while also adding a second driver which can be used for EDU drones with custom IP addresses
