### PR TITLE
Added option to specify IP for Tello edu edition

### DIFF
--- a/platforms/dji/tello/README.md
+++ b/platforms/dji/tello/README.md
@@ -50,6 +50,14 @@ func main() {
 }
 ```
 
+## Telo Edu driver
+
+If you are planning to connect to the edu version of the tello, please use the `NewDriverWithIP` driver instead
+
+```go
+drone := tello.NewDriverWithIP("192.168.10.1", "8888")
+```
+
 ## References
 
 This driver could not exist without the awesome members of the unofficial Tello forum:

--- a/platforms/dji/tello/driver.go
+++ b/platforms/dji/tello/driver.go
@@ -221,6 +221,34 @@ func NewDriver(port string) *Driver {
 	return d
 }
 
+// NewDriverWithIP creates a driver for the Tello EDU drone. Pass in the ip address and UDP port to use for the responses
+// from the drone.
+func NewDriverWithIP(ip string, port string) *Driver {
+	d := &Driver{name: gobot.DefaultName("Tello"),
+		reqAddr:   ip + ":8889",
+		respPort:  port,
+		videoPort: "11111",
+		Eventer:   gobot.NewEventer(),
+	}
+
+	d.AddEvent(ConnectedEvent)
+	d.AddEvent(FlightDataEvent)
+	d.AddEvent(TakeoffEvent)
+	d.AddEvent(LandingEvent)
+	d.AddEvent(PalmLandingEvent)
+	d.AddEvent(BounceEvent)
+	d.AddEvent(FlipEvent)
+	d.AddEvent(TimeEvent)
+	d.AddEvent(LogEvent)
+	d.AddEvent(WifiDataEvent)
+	d.AddEvent(LightStrengthEvent)
+	d.AddEvent(SetExposureEvent)
+	d.AddEvent(VideoFrameEvent)
+	d.AddEvent(SetVideoEncoderRateEvent)
+
+	return d
+}
+
 // Name returns the name of the device.
 func (d *Driver) Name() string { return d.name }
 


### PR DESCRIPTION
Since the Tello edition has the capability to join wifi networks, it gets assigned a different IP address than the default one.

Example implementation: https://github.com/danacr/drone-pod/blob/master/main.go