### PR TITLE
Add method to publish MQTT messages with retain flag

### DIFF
--- a/platforms/mqtt/mqtt_adaptor.go
+++ b/platforms/mqtt/mqtt_adaptor.go
@@ -145,6 +145,16 @@ func (a *Adaptor) Publish(topic string, message []byte) bool {
 	return true
 }
 
+// PublishAndRetain publishes a message under a specific topic with retain flag
+func (a *Adaptor) PublishAndRetain(topic string, message []byte) bool {
+	if a.client == nil {
+		return false
+	}
+
+	a.client.Publish(topic, byte(a.qos), true, message)
+	return true
+}
+
 // PublishWithQOS allows per-publish QOS values to be set and returns a poken.Token
 func (a *Adaptor) PublishWithQOS(topic string, qos int, message []byte) (paho.Token, error) {
 	if a.client == nil {


### PR DESCRIPTION
This is IMO a useful addition and is often required but somehow wasn't implemented initially