### PR TITLE
#700 - Avoid to close the connection.

### DIFF
--- a/drivers/spi/apa102.go
+++ b/drivers/spi/apa102.go
@@ -73,7 +73,6 @@ func (d *APA102Driver) Start() (err error) {
 
 // Halt stops the driver.
 func (d *APA102Driver) Halt() (err error) {
-	d.connection.Close()
 	return
 }
 

--- a/drivers/spi/mcp3002.go
+++ b/drivers/spi/mcp3002.go
@@ -69,7 +69,6 @@ func (d *MCP3002Driver) Start() (err error) {
 
 // Halt stops the driver.
 func (d *MCP3002Driver) Halt() (err error) {
-	d.connection.Close()
 	return
 }
 

--- a/drivers/spi/mcp3004.go
+++ b/drivers/spi/mcp3004.go
@@ -69,7 +69,6 @@ func (d *MCP3004Driver) Start() (err error) {
 
 // Halt stops the driver.
 func (d *MCP3004Driver) Halt() (err error) {
-	d.connection.Close()
 	return
 }
 

--- a/drivers/spi/mcp3008.go
+++ b/drivers/spi/mcp3008.go
@@ -69,7 +69,6 @@ func (d *MCP3008Driver) Start() (err error) {
 
 // Halt stops the driver.
 func (d *MCP3008Driver) Halt() (err error) {
-	d.connection.Close()
 	return
 }
 

--- a/drivers/spi/mcp3202.go
+++ b/drivers/spi/mcp3202.go
@@ -69,7 +69,6 @@ func (d *MCP3202Driver) Start() (err error) {
 
 // Halt stops the driver.
 func (d *MCP3202Driver) Halt() (err error) {
-	d.connection.Close()
 	return
 }
 

--- a/drivers/spi/mcp3204.go
+++ b/drivers/spi/mcp3204.go
@@ -69,7 +69,6 @@ func (d *MCP3204Driver) Start() (err error) {
 
 // Halt stops the driver.
 func (d *MCP3204Driver) Halt() (err error) {
-	d.connection.Close()
 	return
 }
 

--- a/drivers/spi/mcp3208.go
+++ b/drivers/spi/mcp3208.go
@@ -69,7 +69,6 @@ func (d *MCP3208Driver) Start() (err error) {
 
 // Halt stops the driver.
 func (d *MCP3208Driver) Halt() (err error) {
-	d.connection.Close()
 	return
 }
 

--- a/drivers/spi/mcp3304.go
+++ b/drivers/spi/mcp3304.go
@@ -69,7 +69,6 @@ func (d *MCP3304Driver) Start() (err error) {
 
 // Halt stops the driver.
 func (d *MCP3304Driver) Halt() (err error) {
-	d.connection.Close()
 	return
 }
 


### PR DESCRIPTION
Each spi drivers must not close the connection: it's not its responsibility.
Robots should close the connection.

Signed-off-by: Eithel <tux.eithel@gmail.com>