### PR TITLE
Add INPUT_PULLUP support on firmdata platform

### DIFF
--- a/drivers/gpio/aip1640_driver.go
+++ b/drivers/gpio/aip1640_driver.go
@@ -21,7 +21,7 @@ const (
 //
 // Library ported from: https://github.com/wemos/WEMOS_Matrix_LED_Shield_Arduino_Library
 type AIP1640Driver struct {
-	pinClock  *DirectPinDriver
+	pinClock   *DirectPinDriver
 	pinData    *DirectPinDriver
 	name       string
 	intensity  byte
@@ -34,7 +34,7 @@ type AIP1640Driver struct {
 func NewAIP1640Driver(a gobot.Connection, clockPin string, dataPin string) *AIP1640Driver {
 	t := &AIP1640Driver{
 		name:       gobot.DefaultName("AIP1640Driver"),
-		pinClock:  NewDirectPinDriver(a, clockPin),
+		pinClock:   NewDirectPinDriver(a, clockPin),
 		pinData:    NewDirectPinDriver(a, dataPin),
 		intensity:  7,
 		connection: a,

--- a/drivers/gpio/button_driver_test.go
+++ b/drivers/gpio/button_driver_test.go
@@ -18,6 +18,10 @@ func initTestButtonDriver() *ButtonDriver {
 	return NewButtonDriver(newGpioTestAdaptor(), "1")
 }
 
+func initTestButtonInputPullupDriver() *ButtonDriver {
+	return NewButtonDriver(newGpioInputPullupTestAdaptor(), "1")
+}
+
 func TestButtonDriverHalt(t *testing.T) {
 	d := initTestButtonDriver()
 	go func() {
@@ -156,4 +160,89 @@ func TestButtonDriverSetName(t *testing.T) {
 	g := initTestButtonDriver()
 	g.SetName("mybot")
 	gobottest.Assert(t, g.Name(), "mybot")
+}
+
+func TestButtonDriverSetInputPullup(t *testing.T) {
+	g := initTestButtonInputPullupDriver()
+	err := g.SetInputPullup()
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, g.IsInputPullup(), true)
+
+	g = initTestButtonDriver()
+	err = g.SetInputPullup()
+	gobottest.Assert(t, err, ErrDigitalReadInputPullupUnsupported)
+}
+
+func TestButtonInputPullupDriverStart(t *testing.T) {
+	sem := make(chan bool, 0)
+	a := newGpioInputPullupTestAdaptor()
+	d := NewButtonDriver(a, "1")
+	err := d.SetInputPullup()
+	gobottest.Assert(t, err, nil)
+
+	d.Once(ButtonPush, func(data interface{}) {
+		gobottest.Assert(t, d.Active, true)
+		sem <- true
+	})
+
+	a.TestAdaptorDigitalRead(func() (val int, err error) {
+		val = 1
+		return
+	})
+
+	gobottest.Assert(t, d.Start(), nil)
+
+	select {
+	case <-sem:
+	case <-time.After(buttonTestDelay * time.Millisecond):
+		t.Errorf("Button Event \"Push\" was not published")
+	}
+
+	d.Once(ButtonRelease, func(data interface{}) {
+		gobottest.Assert(t, d.Active, false)
+		sem <- true
+	})
+
+	a.TestAdaptorDigitalRead(func() (val int, err error) {
+		val = 0
+		return
+	})
+
+	select {
+	case <-sem:
+	case <-time.After(buttonTestDelay * time.Millisecond):
+		t.Errorf("Button Event \"Release\" was not published")
+	}
+
+	d.Once(Error, func(data interface{}) {
+		sem <- true
+	})
+
+	a.TestAdaptorDigitalRead(func() (val int, err error) {
+		err = errors.New("digital read error")
+		return
+	})
+
+	select {
+	case <-sem:
+	case <-time.After(buttonTestDelay * time.Millisecond):
+		t.Errorf("Button Event \"Error\" was not published")
+	}
+
+	d.Once(ButtonPush, func(data interface{}) {
+		sem <- true
+	})
+
+	d.halt <- true
+
+	a.TestAdaptorDigitalRead(func() (val int, err error) {
+		val = 1
+		return
+	})
+
+	select {
+	case <-sem:
+		t.Errorf("Button Event \"Press\" should not published")
+	case <-time.After(buttonTestDelay * time.Millisecond):
+	}
 }

--- a/drivers/gpio/direct_pin_driver_test.go
+++ b/drivers/gpio/direct_pin_driver_test.go
@@ -29,6 +29,28 @@ func initTestDirectPinDriver() *DirectPinDriver {
 	return NewDirectPinDriver(a, "1")
 }
 
+func initTestDirectPinInputPullupDriver() *DirectPinDriver {
+	a := newGpioInputPullupTestAdaptor()
+	a.testAdaptorDigitalRead = func() (val int, err error) {
+		val = 1
+		return
+	}
+	a.testAdaptorDigitalReadInputPullup = func() (val int, err error) {
+		val = 1
+		return
+	}
+	a.testAdaptorDigitalWrite = func() (err error) {
+		return errors.New("write error")
+	}
+	a.testAdaptorPwmWrite = func() (err error) {
+		return errors.New("write error")
+	}
+	a.testAdaptorServoWrite = func() (err error) {
+		return errors.New("write error")
+	}
+	return NewDirectPinDriver(a, "1")
+}
+
 func TestDirectPinDriver(t *testing.T) {
 	var ret map[string]interface{}
 	var err interface{}
@@ -168,4 +190,24 @@ func TestDirectPinDriverSetName(t *testing.T) {
 	d := initTestDirectPinDriver()
 	d.SetName("mybot")
 	gobottest.Assert(t, d.Name(), "mybot")
+}
+
+func TestDirectPinDriverSetInputPullup(t *testing.T) {
+	d := initTestDirectPinInputPullupDriver()
+	err := d.SetInputPullup()
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, d.IsInputPullup(), true)
+
+	d = initTestDirectPinDriver()
+	err = d.SetInputPullup()
+	gobottest.Assert(t, err, ErrDigitalReadInputPullupUnsupported)
+}
+
+func TestDirectPinDriverDigitalReadInputPullup(t *testing.T) {
+	d := initTestDirectPinInputPullupDriver()
+	err := d.SetInputPullup()
+	gobottest.Assert(t, err, nil)
+	ret, err := d.DigitalRead()
+	gobottest.Assert(t, ret, 1)
+	gobottest.Assert(t, err, nil)
 }

--- a/drivers/gpio/easy_driver_test.go
+++ b/drivers/gpio/easy_driver_test.go
@@ -183,4 +183,3 @@ func TestEasyDriverDisable(t *testing.T) {
 	gobottest.Assert(t, d.IsEnabled(), false)
 	gobottest.Assert(t, d.IsMoving(), false)
 }
-

--- a/drivers/gpio/gpio.go
+++ b/drivers/gpio/gpio.go
@@ -20,6 +20,9 @@ var (
 	// ErrDigitalReadUnsupported is the error resulting when a driver attempts to use
 	// hardware capabilities which a connection does not support
 	ErrDigitalReadUnsupported = errors.New("DigitalRead is not supported by this platform")
+	// ErrDigitalReadInputPullupUnsupported is the error resulting when a driver attempts to use
+	// hardware capabilities which a connection does not support
+	ErrDigitalReadInputPullupUnsupported = errors.New("DigitalRead with INPUT_PULLUP is not supported by this platform")
 	// ErrServoOutOfRange is the error resulting when a driver attempts to use
 	// hardware capabilities which a connection does not support
 	ErrServoOutOfRange = errors.New("servo angle must be between 0-180")
@@ -60,4 +63,9 @@ type DigitalWriter interface {
 // DigitalReader interface represents an Adaptor which has DigitalRead capabilities
 type DigitalReader interface {
 	DigitalRead(string) (val int, err error)
+}
+
+// DigitalReaderInputPullup interface represents an Adaptor which has DigitalRead capabilities with INPUT_PULLUP
+type DigitalReaderInputPullup interface {
+	DigitalReadInputPullup(string) (val int, err error)
 }

--- a/drivers/gpio/helpers_test.go
+++ b/drivers/gpio/helpers_test.go
@@ -26,6 +26,11 @@ type gpioTestAdaptor struct {
 	testAdaptorDigitalRead  func() (val int, err error)
 }
 
+type gpioInputPullupTestAdaptor struct {
+	testAdaptorDigitalReadInputPullup func() (val int, err error)
+	gpioTestAdaptor
+}
+
 func (t *gpioTestAdaptor) TestAdaptorDigitalWrite(f func() (err error)) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
@@ -99,6 +104,42 @@ func newGpioTestAdaptor() *gpioTestAdaptor {
 			return 99, nil
 		},
 		testAdaptorDigitalRead: func() (val int, err error) {
+			return 1, nil
+		},
+	}
+}
+
+func (t *gpioInputPullupTestAdaptor) TestAdaptorDigitalReadInputPullup(f func() (val int, err error)) {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	t.testAdaptorDigitalReadInputPullup = f
+}
+func (t *gpioInputPullupTestAdaptor) DigitalReadInputPullup(string) (val int, err error) {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	return t.testAdaptorDigitalRead()
+}
+func newGpioInputPullupTestAdaptor() *gpioInputPullupTestAdaptor {
+	return &gpioInputPullupTestAdaptor{
+		gpioTestAdaptor: gpioTestAdaptor{
+			port: "/dev/null",
+			testAdaptorDigitalWrite: func() (err error) {
+				return nil
+			},
+			testAdaptorServoWrite: func() (err error) {
+				return nil
+			},
+			testAdaptorPwmWrite: func() (err error) {
+				return nil
+			},
+			testAdaptorAnalogRead: func() (val int, err error) {
+				return 99, nil
+			},
+			testAdaptorDigitalRead: func() (val int, err error) {
+				return 1, nil
+			},
+		},
+		testAdaptorDigitalReadInputPullup: func() (val int, err error) {
 			return 1, nil
 		},
 	}

--- a/drivers/gpio/pir_motion_driver_test.go
+++ b/drivers/gpio/pir_motion_driver_test.go
@@ -18,6 +18,10 @@ func initTestPIRMotionDriver() *PIRMotionDriver {
 	return NewPIRMotionDriver(newGpioTestAdaptor(), "1")
 }
 
+func initTestPIRMotionInputPullupDriver() *PIRMotionDriver {
+	return NewPIRMotionDriver(newGpioInputPullupTestAdaptor(), "1")
+}
+
 func TestPIRMotionDriverHalt(t *testing.T) {
 	d := initTestPIRMotionDriver()
 	go func() {
@@ -98,4 +102,73 @@ func TestPIRDriverSetName(t *testing.T) {
 	d := initTestPIRMotionDriver()
 	d.SetName("mybot")
 	gobottest.Assert(t, d.Name(), "mybot")
+}
+
+func TestPIRDriverSetInputPullup(t *testing.T) {
+	d := initTestPIRMotionInputPullupDriver()
+	err := d.SetInputPullup()
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, d.IsInputPullup(), true)
+
+	d = initTestPIRMotionDriver()
+	err = d.SetInputPullup()
+	gobottest.Assert(t, err, ErrDigitalReadInputPullupUnsupported)
+}
+
+func TestPIRMotionInputPullupDriverStart(t *testing.T) {
+	sem := make(chan bool, 0)
+	a := newGpioInputPullupTestAdaptor()
+	d := NewPIRMotionDriver(a, "1")
+
+	err := d.SetInputPullup()
+	gobottest.Assert(t, err, nil)
+
+	gobottest.Assert(t, d.Start(), nil)
+
+	d.Once(MotionDetected, func(data interface{}) {
+		gobottest.Assert(t, d.Active, true)
+		sem <- true
+	})
+
+	a.TestAdaptorDigitalRead(func() (val int, err error) {
+		val = 1
+		return
+	})
+
+	select {
+	case <-sem:
+	case <-time.After(motionTestDelay * time.Millisecond):
+		t.Errorf("PIRMotionDriver Event \"MotionDetected\" was not published")
+	}
+
+	d.Once(MotionStopped, func(data interface{}) {
+		gobottest.Assert(t, d.Active, false)
+		sem <- true
+	})
+
+	a.TestAdaptorDigitalRead(func() (val int, err error) {
+		val = 0
+		return
+	})
+
+	select {
+	case <-sem:
+	case <-time.After(motionTestDelay * time.Millisecond):
+		t.Errorf("PIRMotionDriver Event \"MotionStopped\" was not published")
+	}
+
+	d.Once(Error, func(data interface{}) {
+		sem <- true
+	})
+
+	a.TestAdaptorDigitalRead(func() (val int, err error) {
+		err = errors.New("digital read error")
+		return
+	})
+
+	select {
+	case <-sem:
+	case <-time.After(motionTestDelay * time.Millisecond):
+		t.Errorf("PIRMotionDriver Event \"Error\" was not published")
+	}
 }

--- a/drivers/gpio/tm1638_driver.go
+++ b/drivers/gpio/tm1638_driver.go
@@ -33,7 +33,7 @@ const (
 // Ported from the Arduino driver https://github.com/rjbatista/tm1638-library
 
 type TM1638Driver struct {
-	pinClock  *DirectPinDriver
+	pinClock   *DirectPinDriver
 	pinData    *DirectPinDriver
 	pinStrobe  *DirectPinDriver
 	fonts      map[string]byte
@@ -46,7 +46,7 @@ type TM1638Driver struct {
 func NewTM1638Driver(a gobot.Connection, clockPin string, dataPin string, strobePin string) *TM1638Driver {
 	t := &TM1638Driver{
 		name:       gobot.DefaultName("TM1638"),
-		pinClock:  NewDirectPinDriver(a, clockPin),
+		pinClock:   NewDirectPinDriver(a, clockPin),
 		pinData:    NewDirectPinDriver(a, dataPin),
 		pinStrobe:  NewDirectPinDriver(a, strobePin),
 		fonts:      NewTM1638Fonts(),

--- a/drivers/i2c/adxl345_driver_test.go
+++ b/drivers/i2c/adxl345_driver_test.go
@@ -116,7 +116,6 @@ func TestADXL345DriverXYZError(t *testing.T) {
 	gobottest.Assert(t, err, errors.New("read error"))
 }
 
-
 func TestADXL345DriverRawXYZ(t *testing.T) {
 	d, adaptor := initTestADXL345DriverWithStubbedAdaptor()
 	d.Start()

--- a/drivers/i2c/bh1750_driver.go
+++ b/drivers/i2c/bh1750_driver.go
@@ -1,8 +1,8 @@
 package i2c
 
 import (
-	"time"
 	"errors"
+	"time"
 
 	"gobot.io/x/gobot"
 )
@@ -44,7 +44,7 @@ func NewBH1750Driver(a Connector, options ...func(Config)) *BH1750Driver {
 		name:      gobot.DefaultName("BH1750"),
 		connector: a,
 		Config:    NewConfig(),
-		mode: BH1750_CONTINUOUS_HIGH_RES_MODE,
+		mode:      BH1750_CONTINUOUS_HIGH_RES_MODE,
 	}
 
 	for _, option := range options {

--- a/drivers/i2c/bh1750_driver_test.go
+++ b/drivers/i2c/bh1750_driver_test.go
@@ -145,4 +145,3 @@ func TestBH1750DriverRawSensorDataError(t *testing.T) {
 	_, err := d.RawSensorData()
 	gobottest.Assert(t, err, errors.New("wrong number of bytes read"))
 }
-

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,7 @@ go.bug.st/serial.v1 v0.0.0-20180827123349-5f7892a7bb45 h1:mACY1anK6HNCZtm/DK2Rf2
 go.bug.st/serial.v1 v0.0.0-20180827123349-5f7892a7bb45/go.mod h1:dRSl/CVCTf56CkXgJMDOdSwNfo2g1orOGE/gBGdvjZw=
 gocv.io/x/gocv v0.20.0 h1:2q75zQ8Zel2tB69G6qrmf/E7EdvaCs90qvkHzdSBOAg=
 gocv.io/x/gocv v0.20.0/go.mod h1:vZETJRwLnl11muQ6iL3q4ju+0oJRrdmYdv5xJTH7WYA=
+gocv.io/x/gocv v0.21.0 h1:dVjagrupZrfCRY0qPEaYWgoNMRpBel6GYDH4mvQOK8Y=
 gocv.io/x/gocv v0.21.0/go.mod h1:Rar2PS6DV+T4FL+PM535EImD/h13hGVaHhnCu1xarBs=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=

--- a/platforms/firmata/client/client.go
+++ b/platforms/firmata/client/client.go
@@ -16,11 +16,12 @@ import (
 
 // Pin Modes
 const (
-	Input  = 0x00
-	Output = 0x01
-	Analog = 0x02
-	Pwm    = 0x03
-	Servo  = 0x04
+	Input       = 0x00
+	Output      = 0x01
+	Analog      = 0x02
+	Pwm         = 0x03
+	Servo       = 0x04
+	InputPullup = 0x0B
 )
 
 // Sysex Codes
@@ -411,7 +412,7 @@ func (b *Client) process() (err error) {
 		for i := 0; i < 8; i++ {
 			pinNumber := int((8*byte(port) + byte(i)))
 			if len(b.pins) > pinNumber {
-				if b.pins[pinNumber].Mode == Input {
+				if b.pins[pinNumber].Mode == Input || b.pins[pinNumber].Mode == InputPullup {
 					b.pins[pinNumber].Value = int((portValue >> (byte(i) & 0x07)) & 0x01)
 					b.Publish(b.Event(fmt.Sprintf("DigitalRead%v", pinNumber)), b.pins[pinNumber].Value)
 				}
@@ -444,7 +445,7 @@ func (b *Client) process() (err error) {
 			for _, val := range currentBuffer[2 : len(currentBuffer)-1] {
 				if val == 127 {
 					modes := []int{}
-					for _, mode := range []int{Input, Output, Analog, Pwm, Servo} {
+					for _, mode := range []int{Input, InputPullup, Output, Analog, Pwm, Servo} {
 						if (supportedModes & (1 << byte(mode))) != 0 {
 							modes = append(modes, mode)
 						}

--- a/platforms/firmata/firmata_adaptor_test.go
+++ b/platforms/firmata/firmata_adaptor_test.go
@@ -20,6 +20,7 @@ import (
 // make sure that this Adaptor fullfills all the required interfaces
 var _ gobot.Adaptor = (*Adaptor)(nil)
 var _ gpio.DigitalReader = (*Adaptor)(nil)
+var _ gpio.DigitalReaderInputPullup = (*Adaptor)(nil)
 var _ gpio.DigitalWriter = (*Adaptor)(nil)
 var _ aio.AnalogReader = (*Adaptor)(nil)
 var _ gpio.PwmWriter = (*Adaptor)(nil)
@@ -78,16 +79,17 @@ func (m mockFirmataBoard) Disconnect() error {
 func (m mockFirmataBoard) Pins() []client.Pin {
 	return m.pins
 }
-func (mockFirmataBoard) AnalogWrite(int, int) error      { return nil }
-func (mockFirmataBoard) SetPinMode(int, int) error       { return nil }
-func (mockFirmataBoard) ReportAnalog(int, int) error     { return nil }
-func (mockFirmataBoard) ReportDigital(int, int) error    { return nil }
-func (mockFirmataBoard) DigitalWrite(int, int) error     { return nil }
-func (mockFirmataBoard) I2cRead(int, int) error          { return nil }
-func (mockFirmataBoard) I2cWrite(int, []byte) error      { return nil }
-func (mockFirmataBoard) I2cConfig(int) error             { return nil }
-func (mockFirmataBoard) ServoConfig(int, int, int) error { return nil }
-func (mockFirmataBoard) WriteSysex(data []byte) error    { return nil }
+func (mockFirmataBoard) AnalogWrite(int, int) error              { return nil }
+func (mockFirmataBoard) SetPinMode(int, int) error               { return nil }
+func (mockFirmataBoard) ReportAnalog(int, int) error             { return nil }
+func (mockFirmataBoard) ReportDigital(int, int) error            { return nil }
+func (mockFirmataBoard) ReportDigitalInputPullup(int, int) error { return nil }
+func (mockFirmataBoard) DigitalWrite(int, int) error             { return nil }
+func (mockFirmataBoard) I2cRead(int, int) error                  { return nil }
+func (mockFirmataBoard) I2cWrite(int, []byte) error              { return nil }
+func (mockFirmataBoard) I2cConfig(int) error                     { return nil }
+func (mockFirmataBoard) ServoConfig(int, int, int) error         { return nil }
+func (mockFirmataBoard) WriteSysex(data []byte) error            { return nil }
 
 func initTestAdaptor() *Adaptor {
 	a := NewAdaptor("/dev/null")
@@ -182,6 +184,23 @@ func TestAdaptorDigitalRead(t *testing.T) {
 func TestAdaptorDigitalReadBadPin(t *testing.T) {
 	a := initTestAdaptor()
 	_, err := a.DigitalRead("xyz")
+	gobottest.Refute(t, err, nil)
+}
+
+func TestAdaptorDigitalReadInputPullup(t *testing.T) {
+	a := initTestAdaptor()
+	val, err := a.DigitalReadInputPullup("1")
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, val, 0)
+
+	val, err = a.DigitalReadInputPullup("0")
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, val, 1)
+}
+
+func TestAdaptorDigitalReadInputPullupBadPin(t *testing.T) {
+	a := initTestAdaptor()
+	_, err := a.DigitalReadInputPullup("xyz")
 	gobottest.Refute(t, err, nil)
 }
 

--- a/platforms/leap/leap_motion_driver.go
+++ b/platforms/leap/leap_motion_driver.go
@@ -83,11 +83,11 @@ func enableFeature(l *Driver, feature string) (err error) {
 //		"hand" - Emits Hand when detected in message from Leap.
 //		"gesture" - Emits Gesture when detected in message from Leap.
 func (l *Driver) Start() (err error) {
-	err = enableFeature(l,"enableGestures")
+	err = enableFeature(l, "enableGestures")
 	if err != nil {
 		return err
 	}
-	err = enableFeature(l,"background")
+	err = enableFeature(l, "background")
 	if err != nil {
 		return err
 	}

--- a/platforms/leap/parser.go
+++ b/platforms/leap/parser.go
@@ -6,20 +6,20 @@ import (
 
 // Gesture is a Leap Motion gesture that has been detected
 type Gesture struct {
-	Center        []float64   `json:"center"`
-	Direction     []float64   `json:"direction"`
-	Duration      int         `json:"duration"`
-	HandIDs       []int       `json:"handIds"`
-	ID            int         `json:"id"`
-	Normal        []float64   `json:"normal"`
-	PointableIDs  []int       `json:"pointableIds"`
-	Position      []float64   `json:"position"`
-	Progress      float64     `json:"progress"`
-	Radius        float64     `json:"radius"`
-	Speed         float64     `json:"speed"`
-	StartPosition []float64   `json:"StartPosition"`
-	State         string      `json:"state"`
-	Type          string      `json:"type"`
+	Center        []float64 `json:"center"`
+	Direction     []float64 `json:"direction"`
+	Duration      int       `json:"duration"`
+	HandIDs       []int     `json:"handIds"`
+	ID            int       `json:"id"`
+	Normal        []float64 `json:"normal"`
+	PointableIDs  []int     `json:"pointableIds"`
+	Position      []float64 `json:"position"`
+	Progress      float64   `json:"progress"`
+	Radius        float64   `json:"radius"`
+	Speed         float64   `json:"speed"`
+	StartPosition []float64 `json:"StartPosition"`
+	State         string    `json:"state"`
+	Type          string    `json:"type"`
 }
 
 // Hand is a Leap Motion hand that has been detected
@@ -48,26 +48,26 @@ type Hand struct {
 
 // Pointable is a Leap Motion pointing motion that has been detected
 type Pointable struct {
-	Bases                 [][][]float64  `json:"bases"`
-	BTipPosition          []float64    `json:"btipPosition"`
-	CarpPosition          []float64    `json:"carpPosition"`
-	DipPosition           []float64    `json:"dipPosition"`
-	Direction             []float64    `json:"direction"`
-	Extended              bool         `json:"extended"`
-	HandID                int          `json:"handId"`
-	ID                    int          `json:"id"`
-	Length                float64      `json:"length"`
-	MCPPosition           []float64    `json:"mcpPosition"`
-	PIPPosition           []float64    `json:"pipPosition"`
-	StabilizedTipPosition []float64    `json:"stabilizedTipPosition"`
-	TimeVisible           float64      `json:"timeVisible"`
-	TipPosition           []float64    `json:"tipPosition"`
-	TipVelocity           []float64    `json:"tipVelocity"`
-	Tool                  bool         `json:"tool"`
-	TouchDistance         float64      `json:"touchDistance"`
-	TouchZone             string       `json:"touchZone"`
-	Type                  int          `json:"type"`
-	Width                 float64      `json:"width"`
+	Bases                 [][][]float64 `json:"bases"`
+	BTipPosition          []float64     `json:"btipPosition"`
+	CarpPosition          []float64     `json:"carpPosition"`
+	DipPosition           []float64     `json:"dipPosition"`
+	Direction             []float64     `json:"direction"`
+	Extended              bool          `json:"extended"`
+	HandID                int           `json:"handId"`
+	ID                    int           `json:"id"`
+	Length                float64       `json:"length"`
+	MCPPosition           []float64     `json:"mcpPosition"`
+	PIPPosition           []float64     `json:"pipPosition"`
+	StabilizedTipPosition []float64     `json:"stabilizedTipPosition"`
+	TimeVisible           float64       `json:"timeVisible"`
+	TipPosition           []float64     `json:"tipPosition"`
+	TipVelocity           []float64     `json:"tipVelocity"`
+	Tool                  bool          `json:"tool"`
+	TouchDistance         float64       `json:"touchDistance"`
+	TouchZone             string        `json:"touchZone"`
+	Type                  int           `json:"type"`
+	Width                 float64       `json:"width"`
 }
 
 // InteractionBox is the area within which the gestural interaction has been detected


### PR DESCRIPTION
Add the availability to use INPUT_PULLUP on some GPIO driver:
  - button
  - direct_pin
  - makey_button
  - pir_motion_driver

INPUT_PULLUP on arduino is use to avoid to add some resistor when yous should to read the state of button.
When INPUT_PULLUP is enable, the signal is inverted, so the platform invert signal to be transparent for user.

Sample to use it with button driver:
```go
func main() {
        firmataAdaptor := firmata.NewAdaptor("/dev/ttyACM0")
        button := gpio.NewButtonDriverDriver(firmataAdaptor, "13")
        err := button.SetInputPullup()
        if err != nil {
          panic("Not supported by plateforme")
        }
        work := func() {
                buton.On(gpio.ButtonPush, func(data interface{}) {
                  fmt.Printf("Button pushed")
                }
        }

        robot := gobot.NewRobot("bot",
                []gobot.Connection{firmataAdaptor},
                []gobot.Device{button},
                work,
        )

        robot.Start()
}
```

> Button must be plug on input pin and in GND instead of 5v