### PR TITLE
Update value written via DigitalWrite if RelayDriver.Inverted is true

### DIFF
--- a/drivers/gpio/button_driver_test.go
+++ b/drivers/gpio/button_driver_test.go
@@ -44,7 +44,7 @@ func TestButtonDriverStart(t *testing.T) {
 		sem <- true
 	})
 
-	a.TestAdaptorDigitalRead(func() (val int, err error) {
+	a.TestAdaptorDigitalRead(func(string) (val int, err error) {
 		val = 1
 		return
 	})
@@ -62,7 +62,7 @@ func TestButtonDriverStart(t *testing.T) {
 		sem <- true
 	})
 
-	a.TestAdaptorDigitalRead(func() (val int, err error) {
+	a.TestAdaptorDigitalRead(func(string) (val int, err error) {
 		val = 0
 		return
 	})
@@ -77,7 +77,7 @@ func TestButtonDriverStart(t *testing.T) {
 		sem <- true
 	})
 
-	a.TestAdaptorDigitalRead(func() (val int, err error) {
+	a.TestAdaptorDigitalRead(func(string) (val int, err error) {
 		err = errors.New("digital read error")
 		return
 	})
@@ -94,7 +94,7 @@ func TestButtonDriverStart(t *testing.T) {
 
 	d.halt <- true
 
-	a.TestAdaptorDigitalRead(func() (val int, err error) {
+	a.TestAdaptorDigitalRead(func(string) (val int, err error) {
 		val = 1
 		return
 	})
@@ -117,7 +117,7 @@ func TestButtonDriverDefaultState(t *testing.T) {
 		sem <- true
 	})
 
-	a.TestAdaptorDigitalRead(func() (val int, err error) {
+	a.TestAdaptorDigitalRead(func(string) (val int, err error) {
 		val = 0
 		return
 	})
@@ -135,7 +135,7 @@ func TestButtonDriverDefaultState(t *testing.T) {
 		sem <- true
 	})
 
-	a.TestAdaptorDigitalRead(func() (val int, err error) {
+	a.TestAdaptorDigitalRead(func(string) (val int, err error) {
 		val = 1
 		return
 	})

--- a/drivers/gpio/buzzer_driver_test.go
+++ b/drivers/gpio/buzzer_driver_test.go
@@ -53,7 +53,7 @@ func TestBuzzerDriverTone(t *testing.T) {
 func TestBuzzerDriverOnError(t *testing.T) {
 	a := newGpioTestAdaptor()
 	d := initTestBuzzerDriver(a)
-	a.TestAdaptorDigitalWrite(func() (err error) {
+	a.TestAdaptorDigitalWrite(func(string, byte) (err error) {
 		return errors.New("write error")
 	})
 
@@ -63,7 +63,7 @@ func TestBuzzerDriverOnError(t *testing.T) {
 func TestBuzzerDriverOffError(t *testing.T) {
 	a := newGpioTestAdaptor()
 	d := initTestBuzzerDriver(a)
-	a.TestAdaptorDigitalWrite(func() (err error) {
+	a.TestAdaptorDigitalWrite(func(string, byte) (err error) {
 		return errors.New("write error")
 	})
 
@@ -73,7 +73,7 @@ func TestBuzzerDriverOffError(t *testing.T) {
 func TestBuzzerDriverToneError(t *testing.T) {
 	a := newGpioTestAdaptor()
 	d := initTestBuzzerDriver(a)
-	a.TestAdaptorDigitalWrite(func() (err error) {
+	a.TestAdaptorDigitalWrite(func(string, byte) (err error) {
 		return errors.New("write error")
 	})
 

--- a/drivers/gpio/direct_pin_driver_test.go
+++ b/drivers/gpio/direct_pin_driver_test.go
@@ -13,17 +13,17 @@ var _ gobot.Driver = (*DirectPinDriver)(nil)
 
 func initTestDirectPinDriver() *DirectPinDriver {
 	a := newGpioTestAdaptor()
-	a.testAdaptorDigitalRead = func() (val int, err error) {
+	a.testAdaptorDigitalRead = func(string) (val int, err error) {
 		val = 1
 		return
 	}
-	a.testAdaptorDigitalWrite = func() (err error) {
+	a.testAdaptorDigitalWrite = func(string, byte) (err error) {
 		return errors.New("write error")
 	}
-	a.testAdaptorPwmWrite = func() (err error) {
+	a.testAdaptorPwmWrite = func(string, byte) (err error) {
 		return errors.New("write error")
 	}
-	a.testAdaptorServoWrite = func() (err error) {
+	a.testAdaptorServoWrite = func(string, byte) (err error) {
 		return errors.New("write error")
 	}
 	return NewDirectPinDriver(a, "1")

--- a/drivers/gpio/grove_drivers_test.go
+++ b/drivers/gpio/grove_drivers_test.go
@@ -53,7 +53,7 @@ func TestDigitalDriverHalt(t *testing.T) {
 	for _, driver := range drivers {
 
 		var callCount int32
-		testAdaptor.testAdaptorDigitalRead = func() (int, error) {
+		testAdaptor.testAdaptorDigitalRead = func(string) (int, error) {
 			atomic.AddInt32(&callCount, 1)
 			return 42, nil
 		}
@@ -85,7 +85,7 @@ func TestDriverPublishesError(t *testing.T) {
 	for _, driver := range drivers {
 		sem := make(chan struct{}, 1)
 		// send error
-		returnErr := func() (val int, err error) {
+		returnErr := func(string) (val int, err error) {
 			err = errors.New("read error")
 			return
 		}

--- a/drivers/gpio/helpers_test.go
+++ b/drivers/gpio/helpers_test.go
@@ -19,63 +19,63 @@ type gpioTestAdaptor struct {
 	name                    string
 	port                    string
 	mtx                     sync.Mutex
-	testAdaptorDigitalWrite func() (err error)
-	testAdaptorServoWrite   func() (err error)
-	testAdaptorPwmWrite     func() (err error)
-	testAdaptorAnalogRead   func() (val int, err error)
-	testAdaptorDigitalRead  func() (val int, err error)
+	testAdaptorDigitalWrite func(pin string, val byte) (err error)
+	testAdaptorServoWrite   func(pin string, val byte) (err error)
+	testAdaptorPwmWrite     func(pin string, val byte) (err error)
+	testAdaptorAnalogRead   func(ping string) (val int, err error)
+	testAdaptorDigitalRead  func(ping string) (val int, err error)
 }
 
-func (t *gpioTestAdaptor) TestAdaptorDigitalWrite(f func() (err error)) {
+func (t *gpioTestAdaptor) TestAdaptorDigitalWrite(f func(pin string, val byte) (err error)) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 	t.testAdaptorDigitalWrite = f
 }
-func (t *gpioTestAdaptor) TestAdaptorServoWrite(f func() (err error)) {
+func (t *gpioTestAdaptor) TestAdaptorServoWrite(f func(pin string, val byte) (err error)) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 	t.testAdaptorServoWrite = f
 }
-func (t *gpioTestAdaptor) TestAdaptorPwmWrite(f func() (err error)) {
+func (t *gpioTestAdaptor) TestAdaptorPwmWrite(f func(pin string, val byte) (err error)) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 	t.testAdaptorPwmWrite = f
 }
-func (t *gpioTestAdaptor) TestAdaptorAnalogRead(f func() (val int, err error)) {
+func (t *gpioTestAdaptor) TestAdaptorAnalogRead(f func(pin string) (val int, err error)) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 	t.testAdaptorAnalogRead = f
 }
-func (t *gpioTestAdaptor) TestAdaptorDigitalRead(f func() (val int, err error)) {
+func (t *gpioTestAdaptor) TestAdaptorDigitalRead(f func(pin string) (val int, err error)) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 	t.testAdaptorDigitalRead = f
 }
 
-func (t *gpioTestAdaptor) ServoWrite(string, byte) (err error) {
+func (t *gpioTestAdaptor) ServoWrite(pin string, val byte) (err error) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-	return t.testAdaptorServoWrite()
+	return t.testAdaptorServoWrite(pin, val)
 }
-func (t *gpioTestAdaptor) PwmWrite(string, byte) (err error) {
+func (t *gpioTestAdaptor) PwmWrite(pin string, val byte) (err error) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-	return t.testAdaptorPwmWrite()
+	return t.testAdaptorPwmWrite(pin, val)
 }
-func (t *gpioTestAdaptor) AnalogRead(string) (val int, err error) {
+func (t *gpioTestAdaptor) AnalogRead(pin string) (val int, err error) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-	return t.testAdaptorAnalogRead()
+	return t.testAdaptorAnalogRead(pin)
 }
-func (t *gpioTestAdaptor) DigitalRead(string) (val int, err error) {
+func (t *gpioTestAdaptor) DigitalRead(pin string) (val int, err error) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-	return t.testAdaptorDigitalRead()
+	return t.testAdaptorDigitalRead(pin)
 }
-func (t *gpioTestAdaptor) DigitalWrite(string, byte) (err error) {
+func (t *gpioTestAdaptor) DigitalWrite(pin string, val byte) (err error) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-	return t.testAdaptorDigitalWrite()
+	return t.testAdaptorDigitalWrite(pin, val)
 }
 func (t *gpioTestAdaptor) Connect() (err error)  { return }
 func (t *gpioTestAdaptor) Finalize() (err error) { return }
@@ -86,19 +86,19 @@ func (t *gpioTestAdaptor) Port() string          { return t.port }
 func newGpioTestAdaptor() *gpioTestAdaptor {
 	return &gpioTestAdaptor{
 		port: "/dev/null",
-		testAdaptorDigitalWrite: func() (err error) {
+		testAdaptorDigitalWrite: func(pin string, val byte) (err error) {
 			return nil
 		},
-		testAdaptorServoWrite: func() (err error) {
+		testAdaptorServoWrite: func(pin string, val byte) (err error) {
 			return nil
 		},
-		testAdaptorPwmWrite: func() (err error) {
+		testAdaptorPwmWrite: func(pin string, val byte) (err error) {
 			return nil
 		},
-		testAdaptorAnalogRead: func() (val int, err error) {
+		testAdaptorAnalogRead: func(pin string) (val int, err error) {
 			return 99, nil
 		},
-		testAdaptorDigitalRead: func() (val int, err error) {
+		testAdaptorDigitalRead: func(pin string) (val int, err error) {
 			return 1, nil
 		},
 	}

--- a/drivers/gpio/led_driver_test.go
+++ b/drivers/gpio/led_driver_test.go
@@ -13,10 +13,10 @@ var _ gobot.Driver = (*LedDriver)(nil)
 
 func initTestLedDriver() *LedDriver {
 	a := newGpioTestAdaptor()
-	a.testAdaptorDigitalWrite = func() (err error) {
+	a.testAdaptorDigitalWrite = func(string, byte) (err error) {
 		return nil
 	}
-	a.testAdaptorPwmWrite = func() (err error) {
+	a.testAdaptorPwmWrite = func(string, byte) (err error) {
 		return nil
 	}
 	return NewLedDriver(a, "1")
@@ -30,10 +30,10 @@ func TestLedDriver(t *testing.T) {
 	gobottest.Assert(t, d.Pin(), "1")
 	gobottest.Refute(t, d.Connection(), nil)
 
-	a.testAdaptorDigitalWrite = func() (err error) {
+	a.testAdaptorDigitalWrite = func(string, byte) (err error) {
 		return errors.New("write error")
 	}
-	a.testAdaptorPwmWrite = func() (err error) {
+	a.testAdaptorPwmWrite = func(string, byte) (err error) {
 		return errors.New("pwm error")
 	}
 
@@ -73,7 +73,7 @@ func TestLedDriverToggle(t *testing.T) {
 func TestLedDriverBrightness(t *testing.T) {
 	a := newGpioTestAdaptor()
 	d := NewLedDriver(a, "1")
-	a.testAdaptorPwmWrite = func() (err error) {
+	a.testAdaptorPwmWrite = func(string, byte) (err error) {
 		err = errors.New("pwm error")
 		return
 	}

--- a/drivers/gpio/makey_button_driver_test.go
+++ b/drivers/gpio/makey_button_driver_test.go
@@ -54,7 +54,7 @@ func TestMakeyButtonDriverStart(t *testing.T) {
 		sem <- true
 	})
 
-	a.TestAdaptorDigitalRead(func() (val int, err error) {
+	a.TestAdaptorDigitalRead(func(string) (val int, err error) {
 		val = 0
 		return
 	})
@@ -70,7 +70,7 @@ func TestMakeyButtonDriverStart(t *testing.T) {
 		sem <- true
 	})
 
-	a.TestAdaptorDigitalRead(func() (val int, err error) {
+	a.TestAdaptorDigitalRead(func(string) (val int, err error) {
 		val = 1
 		return
 	})
@@ -86,7 +86,7 @@ func TestMakeyButtonDriverStart(t *testing.T) {
 		sem <- true
 	})
 
-	a.TestAdaptorDigitalRead(func() (val int, err error) {
+	a.TestAdaptorDigitalRead(func(string) (val int, err error) {
 		err = errors.New("digital read error")
 		return
 	})
@@ -102,7 +102,7 @@ func TestMakeyButtonDriverStart(t *testing.T) {
 		sem <- true
 	})
 
-	a.TestAdaptorDigitalRead(func() (val int, err error) {
+	a.TestAdaptorDigitalRead(func(string) (val int, err error) {
 		val = 1
 		return
 	})

--- a/drivers/gpio/pir_motion_driver_test.go
+++ b/drivers/gpio/pir_motion_driver_test.go
@@ -46,7 +46,7 @@ func TestPIRMotionDriverStart(t *testing.T) {
 		sem <- true
 	})
 
-	a.TestAdaptorDigitalRead(func() (val int, err error) {
+	a.TestAdaptorDigitalRead(func(string) (val int, err error) {
 		val = 1
 		return
 	})
@@ -62,7 +62,7 @@ func TestPIRMotionDriverStart(t *testing.T) {
 		sem <- true
 	})
 
-	a.TestAdaptorDigitalRead(func() (val int, err error) {
+	a.TestAdaptorDigitalRead(func(string) (val int, err error) {
 		val = 0
 		return
 	})
@@ -77,7 +77,7 @@ func TestPIRMotionDriverStart(t *testing.T) {
 		sem <- true
 	})
 
-	a.TestAdaptorDigitalRead(func() (val int, err error) {
+	a.TestAdaptorDigitalRead(func(string) (val int, err error) {
 		err = errors.New("digital read error")
 		return
 	})

--- a/drivers/gpio/relay_driver.go
+++ b/drivers/gpio/relay_driver.go
@@ -73,7 +73,11 @@ func (l *RelayDriver) State() bool {
 
 // On sets the relay to a high state.
 func (l *RelayDriver) On() (err error) {
-	if err = l.connection.DigitalWrite(l.Pin(), 1); err != nil {
+	newValue := byte(1)
+	if l.Inverted {
+		newValue = 0
+	}
+	if err = l.connection.DigitalWrite(l.Pin(), newValue); err != nil {
 		return
 	}
 
@@ -88,7 +92,11 @@ func (l *RelayDriver) On() (err error) {
 
 // Off sets the relay to a low state.
 func (l *RelayDriver) Off() (err error) {
-	if err = l.connection.DigitalWrite(l.Pin(), 0); err != nil {
+	newValue := byte(0)
+	if l.Inverted {
+		newValue = 1
+	}
+	if err = l.connection.DigitalWrite(l.Pin(), newValue); err != nil {
 		return
 	}
 

--- a/drivers/gpio/relay_driver_test.go
+++ b/drivers/gpio/relay_driver_test.go
@@ -15,10 +15,10 @@ func (l *RelayDriver) High() bool { return l.high }
 
 func initTestRelayDriver() *RelayDriver {
 	a := newGpioTestAdaptor()
-	a.testAdaptorDigitalWrite = func() (err error) {
+	a.testAdaptorDigitalWrite = func(string, byte) (err error) {
 		return nil
 	}
-	a.testAdaptorPwmWrite = func() (err error) {
+	a.testAdaptorPwmWrite = func(string, byte) (err error) {
 		return nil
 	}
 	return NewRelayDriver(a, "1")

--- a/drivers/gpio/relay_driver_test.go
+++ b/drivers/gpio/relay_driver_test.go
@@ -13,7 +13,7 @@ var _ gobot.Driver = (*RelayDriver)(nil)
 // Helper to return low/high value for testing
 func (l *RelayDriver) High() bool { return l.high }
 
-func initTestRelayDriver() *RelayDriver {
+func initTestRelayDriver() (*RelayDriver, *gpioTestAdaptor) {
 	a := newGpioTestAdaptor()
 	a.testAdaptorDigitalWrite = func(string, byte) (err error) {
 		return nil
@@ -21,76 +21,112 @@ func initTestRelayDriver() *RelayDriver {
 	a.testAdaptorPwmWrite = func(string, byte) (err error) {
 		return nil
 	}
-	return NewRelayDriver(a, "1")
+	return NewRelayDriver(a, "1"), a
 }
 
 func TestRelayDriverDefaultName(t *testing.T) {
-	g := initTestRelayDriver()
+	g, _ := initTestRelayDriver()
 	gobottest.Refute(t, g.Connection(), nil)
 	gobottest.Assert(t, strings.HasPrefix(g.Name(), "Relay"), true)
 }
 
 func TestRelayDriverSetName(t *testing.T) {
-	g := initTestRelayDriver()
+	g, _ := initTestRelayDriver()
 	g.SetName("mybot")
 	gobottest.Assert(t, g.Name(), "mybot")
 }
 
 func TestRelayDriverStart(t *testing.T) {
-	d := initTestRelayDriver()
+	d, _ := initTestRelayDriver()
 	gobottest.Assert(t, d.Start(), nil)
 }
 
 func TestRelayDriverHalt(t *testing.T) {
-	d := initTestRelayDriver()
+	d, _ := initTestRelayDriver()
 	gobottest.Assert(t, d.Halt(), nil)
 }
 
 func TestRelayDriverToggle(t *testing.T) {
-	d := initTestRelayDriver()
+	d, a := initTestRelayDriver()
+	var lastVal byte
+	a.TestAdaptorDigitalWrite(func(pin string, val byte) error {
+		lastVal = val
+		return nil
+	})
+
 	d.Off()
+	gobottest.Assert(t, d.State(), false)
+	gobottest.Assert(t, lastVal, byte(0))
 	d.Toggle()
 	gobottest.Assert(t, d.State(), true)
+	gobottest.Assert(t, lastVal, byte(1))
 	d.Toggle()
 	gobottest.Assert(t, d.State(), false)
+	gobottest.Assert(t, lastVal, byte(0))
 }
 
 func TestRelayDriverToggleInverted(t *testing.T) {
-	d := initTestRelayDriver()
+	d, a := initTestRelayDriver()
+	var lastVal byte
+	a.TestAdaptorDigitalWrite(func(pin string, val byte) error {
+		lastVal = val
+		return nil
+	})
+
 	d.Inverted = true
 	d.Off()
 	gobottest.Assert(t, d.State(), false)
+	gobottest.Assert(t, lastVal, byte(1))
 	d.Toggle()
 	gobottest.Assert(t, d.State(), true)
+	gobottest.Assert(t, lastVal, byte(0))
 	d.Toggle()
 	gobottest.Assert(t, d.State(), false)
+	gobottest.Assert(t, lastVal, byte(1))
 }
 
 func TestRelayDriverCommands(t *testing.T) {
-	d := initTestRelayDriver()
+	d, a := initTestRelayDriver()
+	var lastVal byte
+	a.TestAdaptorDigitalWrite(func(pin string, val byte) error {
+		lastVal = val
+		return nil
+	})
+
 	gobottest.Assert(t, d.Command("Off")(nil), nil)
 	gobottest.Assert(t, d.State(), false)
+	gobottest.Assert(t, lastVal, byte(0))
 
 	gobottest.Assert(t, d.Command("On")(nil), nil)
 	gobottest.Assert(t, d.State(), true)
+	gobottest.Assert(t, lastVal, byte(1))
 
 	gobottest.Assert(t, d.Command("Toggle")(nil), nil)
 	gobottest.Assert(t, d.State(), false)
+	gobottest.Assert(t, lastVal, byte(0))
 }
 
 func TestRelayDriverCommandsInverted(t *testing.T) {
-	d := initTestRelayDriver()
+	d, a := initTestRelayDriver()
+	var lastVal byte
+	a.TestAdaptorDigitalWrite(func(pin string, val byte) error {
+		lastVal = val
+		return nil
+	})
 	d.Inverted = true
 
 	gobottest.Assert(t, d.Command("Off")(nil), nil)
 	gobottest.Assert(t, d.High(), true)
 	gobottest.Assert(t, d.State(), false)
+	gobottest.Assert(t, lastVal, byte(1))
 
 	gobottest.Assert(t, d.Command("On")(nil), nil)
 	gobottest.Assert(t, d.High(), false)
 	gobottest.Assert(t, d.State(), true)
+	gobottest.Assert(t, lastVal, byte(0))
 
 	gobottest.Assert(t, d.Command("Toggle")(nil), nil)
 	gobottest.Assert(t, d.High(), true)
 	gobottest.Assert(t, d.State(), false)
+	gobottest.Assert(t, lastVal, byte(1))
 }

--- a/drivers/gpio/rgb_led_driver_test.go
+++ b/drivers/gpio/rgb_led_driver_test.go
@@ -13,10 +13,10 @@ var _ gobot.Driver = (*RgbLedDriver)(nil)
 
 func initTestRgbLedDriver() *RgbLedDriver {
 	a := newGpioTestAdaptor()
-	a.testAdaptorDigitalWrite = func() (err error) {
+	a.testAdaptorDigitalWrite = func(string, byte) (err error) {
 		return nil
 	}
-	a.testAdaptorPwmWrite = func() (err error) {
+	a.testAdaptorPwmWrite = func(string, byte) (err error) {
 		return nil
 	}
 	return NewRgbLedDriver(a, "1", "2", "3")
@@ -34,10 +34,10 @@ func TestRgbLedDriver(t *testing.T) {
 	gobottest.Assert(t, d.BluePin(), "3")
 	gobottest.Refute(t, d.Connection(), nil)
 
-	a.testAdaptorDigitalWrite = func() (err error) {
+	a.testAdaptorDigitalWrite = func(string, byte) (err error) {
 		return errors.New("write error")
 	}
-	a.testAdaptorPwmWrite = func() (err error) {
+	a.testAdaptorPwmWrite = func(string, byte) (err error) {
 		return errors.New("pwm error")
 	}
 
@@ -79,7 +79,7 @@ func TestRgbLedDriverSetLevel(t *testing.T) {
 	gobottest.Assert(t, d.SetLevel("1", 150), nil)
 
 	d = NewRgbLedDriver(a, "1", "2", "3")
-	a.testAdaptorPwmWrite = func() (err error) {
+	a.testAdaptorPwmWrite = func(string, byte) (err error) {
 		err = errors.New("pwm error")
 		return
 	}

--- a/drivers/gpio/servo_driver_test.go
+++ b/drivers/gpio/servo_driver_test.go
@@ -24,7 +24,7 @@ func TestServoDriver(t *testing.T) {
 	gobottest.Assert(t, d.Pin(), "1")
 	gobottest.Refute(t, d.Connection(), nil)
 
-	a.testAdaptorServoWrite = func() (err error) {
+	a.testAdaptorServoWrite = func(string, byte) (err error) {
 		return errors.New("pwm error")
 	}
 


### PR DESCRIPTION
The goal of this PR is to update the RelayDriver to write `0` instead of `1` for `On()` if `Inverted` has been set `true` (and similar inversion for `Off()`, as per [this comment](https://github.com/hybridgroup/gobot/issues/648#issuecomment-605701451) and [initial agreement](https://github.com/hybridgroup/gobot/issues/648#issuecomment-605701691) from @deadprogram 

I ended up making more changes in this PR than I initially expected, but they are broken into three separate commits if that helps:

* Update `gpioTestAdapter` so that the signatures of functions to provide behaviour match the `DigitalWriter` interface methods etc. This paves the way for capturing the values that are written
* Update the `RelayDriver` tests to capture and validate the values that are written via `DigitalWrite`
* Update the RelayDriver to write `0` instead of `1` for `On()` if `Inverted` has been set `true` (and similar inversion for `Off()`

Apologies for the extra changes - I wanted to ensure that there were tests for this change. If there's an alternate way to perform these tests that you'd prefer then let me know.

I believe that this closes #648