### PR TITLE
Fix doc typo in mqtt_adaptor.go

### DIFF
--- a/platforms/mqtt/mqtt_adaptor.go
+++ b/platforms/mqtt/mqtt_adaptor.go
@@ -145,7 +145,7 @@ func (a *Adaptor) Publish(topic string, message []byte) bool {
 	return true
 }
 
-// PublishWithQOS allows per-publish QOS values to be set and returns a poken.Token
+// PublishWithQOS allows per-publish QOS values to be set and returns a paho.Token
 func (a *Adaptor) PublishWithQOS(topic string, qos int, message []byte) (paho.Token, error) {
 	if a.client == nil {
 		return nil, ErrNilClient


### PR DESCRIPTION
`poken.Token` -> `paho.Token`