### PR TITLE
fix dualshock 4 pairings

### DIFF
--- a/platforms/joystick/events.go
+++ b/platforms/joystick/events.go
@@ -81,6 +81,10 @@ const (
 	OptionsPress = "options_press"
 	// options button release event
 	OptionsRelease = "options_release"
+	// touchpad press event
+	TouchpadPress = "touchpad_press"
+	// touchpad release event
+	TouchpadRelease = "touchpad_release"
 	// home button press event
 	HomePress = "home_press"
 	// home button release event

--- a/platforms/joystick/joystick_dualshock4.go
+++ b/platforms/joystick/joystick_dualshock4.go
@@ -6,19 +6,19 @@ var dualshock4Config = joystickConfig{
 	Axis: []pair{
 		pair{
 			Name: "left_x",
-			ID:   1,
-		},
-		pair{
-			Name: "left_y",
 			ID:   0,
 		},
 		pair{
+			Name: "left_y",
+			ID:   1,
+		},
+		pair{
 			Name: "right_x",
-			ID:   5,
+			ID:   2,
 		},
 		pair{
 			Name: "right_y",
-			ID:   2,
+			ID:   5,
 		},
 	},
 	Buttons: []pair{

--- a/platforms/joystick/joystick_dualshock4.go
+++ b/platforms/joystick/joystick_dualshock4.go
@@ -6,45 +6,37 @@ var dualshock4Config = joystickConfig{
 	Axis: []pair{
 		pair{
 			Name: "left_x",
-			ID:   0,
-		},
-		pair{
-			Name: "left_y",
 			ID:   1,
 		},
 		pair{
+			Name: "left_y",
+			ID:   0,
+		},
+		pair{
 			Name: "right_x",
-			ID:   3,
+			ID:   5,
 		},
 		pair{
 			Name: "right_y",
-			ID:   4,
-		},
-		pair{
-			Name: "l2",
 			ID:   2,
-		},
-		pair{
-			Name: "r2",
-			ID:   5,
 		},
 	},
 	Buttons: []pair{
 		pair{
 			Name: "square",
-			ID:   3,
+			ID:   0,
 		},
 		pair{
 			Name: "triangle",
-			ID:   2,
+			ID:   3,
 		},
 		pair{
 			Name: "circle",
-			ID:   1,
+			ID:   2,
 		},
 		pair{
 			Name: "x",
-			ID:   0,
+			ID:   1,
 		},
 		pair{
 			Name: "l1",
@@ -55,12 +47,20 @@ var dualshock4Config = joystickConfig{
 			ID:   6,
 		},
 		pair{
+			Name: "l3",
+			ID:   10,
+		},
+		pair{
 			Name: "r1",
 			ID:   5,
 		},
 		pair{
 			Name: "r2",
 			ID:   7,
+		},
+		pair{
+			Name: "r3",
+			ID:   11,
 		},
 		pair{
 			Name: "share",
@@ -72,7 +72,11 @@ var dualshock4Config = joystickConfig{
 		},
 		pair{
 			Name: "home",
-			ID:   10,
+			ID:   12,
+		},
+		pair{
+			Name: "touchpad",
+			ID:   13,
 		},
 	},
 	Hats: []hat{


### PR DESCRIPTION
The pairings for my DualShock 4 controller were completely off on MacOS Catalina 10.15.4 so I fixed them by changing the IDs in `joystick_dualshock4.go` and also adding two new event `TouchpadPress` and `TouchpadRelease`. I am not sure if it's just my computer that registers the events of my DualShock controller differently or not, but these changes fixed it for my controller.