### PR TITLE
[FIX] stepperDriver Run not using stepper speed

### DIFF
--- a/drivers/gpio/stepper_driver.go
+++ b/drivers/gpio/stepper_driver.go
@@ -119,12 +119,15 @@ func (s *StepperDriver) Run() (err error) {
 	s.moving = true
 	s.mutex.Unlock()
 
+	delay := time.Duration(60000*1000/(s.stepsPerRev*s.speed)) * time.Microsecond
+	
 	go func() {
 		for {
 			if s.moving == false {
 				break
 			}
 			s.step()
+			time.Sleep(delay)
 		}
 	}()
 


### PR DESCRIPTION
I'm not sure if anyone using it like this? Like blasting the stepperDriver with full force for loop steps.
At least my stepper is making noises like a badly wounded rabbit and is not moving anywhere.
Using a delay in Run() like in Move() fixed that. I'm pretty sure it was intended in that way.