### PR TITLE
Feature/pca9501

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ drivers provided using the `gobot/drivers/i2c` package:
 	- MMA7660 3-Axis Accelerometer
 	- MPL115A2 Barometer
 	- MPU6050 Accelerometer/Gyroscope
+	- PCA9501 8-bit I/O port with interrupt, 2-kbit EEPROM
 	- PCA9685 16-channel 12-bit PWM/Servo Driver
 	- PCF8591 8-bit 4xA/D & 1xD/A converter
 	- SHT2x Temperature/Humidity

--- a/drivers/i2c/README.md
+++ b/drivers/i2c/README.md
@@ -38,6 +38,7 @@ Gobot has a extensible system for connecting to hardware devices. The following 
 - MMA7660 3-Axis Accelerometer
 - MPL115A2 Barometer
 - MPU6050 Accelerometer/Gyroscope
+- PCA9501 8-bit I/O port with interrupt, 2-kbit EEPROM
 - PCA9685 16-channel 12-bit PWM/Servo Driver
 - PCF8591 8-bit 4xA/D & 1xD/A converter
 - SHT2x Temperature/Humidity

--- a/drivers/i2c/pca9501_driver.go
+++ b/drivers/i2c/pca9501_driver.go
@@ -1,0 +1,156 @@
+package i2c
+
+// PCA9501 supports addresses from 0x00 to 0x7F
+// 0x00 - 0x3F: GPIO, 0x40 - 0x7F: EEPROM
+//
+// 0 EE A5 A4 A3 A2 A1 A0|rd
+// Lowest bit (rd) is mapped to switch between write(0)/read(1), it is not part of the "real" address.
+// Highest bit (EE) is mapped to switch between GPIO(0)/EEPROM(1).
+//
+// The EEPROM address will be generated from GPIO address in this driver.
+const pca9501DefaultAddress = 0x3F // this applies, if all 6 address pins left open (have pull up resistors)
+
+// PCA9501Driver is a Gobot Driver for the PCA9501 8-bit GPIO & 2-kbit EEPROM with 6 address program pins.
+// 2-kbit EEPROM has 256 byte, means addresses between 0x00-0xFF
+//
+// PCA9501 is the replacement for PCF8574, so this driver should also work for PCF8574 except EEPROM calls
+//
+type PCA9501Driver struct {
+	connectionMem Connection
+	*Driver
+}
+
+// NewPCA9501Driver creates a new driver with specified i2c interface
+// Params:
+//		a Connector - the Adaptor to use with this Driver
+//
+// Optional params:
+//		i2c.WithBus(int):	bus to use with this driver
+//		i2c.WithAddress(int):	address to use with this driver
+//
+func NewPCA9501Driver(a Connector, options ...func(Config)) *PCA9501Driver {
+	p := &PCA9501Driver{
+		Driver: NewDriver(a, "PCA9501", pca9501DefaultAddress, options...),
+	}
+	p.afterStart = p.initialize
+
+	// API commands
+	p.AddCommand("WriteGPIO", func(params map[string]interface{}) interface{} {
+		pin := params["pin"].(uint8)
+		val := params["val"].(uint8)
+		err := p.WriteGPIO(pin, val)
+		return map[string]interface{}{"err": err}
+	})
+
+	p.AddCommand("ReadGPIO", func(params map[string]interface{}) interface{} {
+		pin := params["pin"].(uint8)
+		val, err := p.ReadGPIO(pin)
+		return map[string]interface{}{"val": val, "err": err}
+	})
+
+	p.AddCommand("WriteEEPROM", func(params map[string]interface{}) interface{} {
+		address := params["address"].(uint8)
+		val := params["val"].(uint8)
+		err := p.WriteEEPROM(address, val)
+		return map[string]interface{}{"err": err}
+	})
+
+	p.AddCommand("ReadEEPROM", func(params map[string]interface{}) interface{} {
+		address := params["address"].(uint8)
+		val, err := p.ReadEEPROM(address)
+		return map[string]interface{}{"val": val, "err": err}
+	})
+	return p
+}
+
+// WriteGPIO writes a value to a gpio pin (0-7)
+func (p *PCA9501Driver) WriteGPIO(pin uint8, val uint8) error {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	// read current value of CTRL register, 0 is output, 1 is no output
+	iodir, err := p.connection.ReadByte()
+	if err != nil {
+		return err
+	}
+	// set pin as output by clearing bit
+	iodirVal := clearBit(iodir, uint8(pin))
+	// write CTRL register
+	err = p.connection.WriteByte(uint8(iodirVal))
+	if err != nil {
+		return err
+	}
+	// read current value of port
+	cVal, err := p.connection.ReadByte()
+	if err != nil {
+		return err
+	}
+	// set or reset the bit in value
+	var nVal uint8
+	if val == 0 {
+		nVal = clearBit(cVal, uint8(pin))
+	} else {
+		nVal = setBit(cVal, uint8(pin))
+	}
+	// write new value to port
+	err = p.connection.WriteByte(uint8(nVal))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ReadGPIO reads a value from a given gpio pin (0-7)
+func (p *PCA9501Driver) ReadGPIO(pin uint8) (uint8, error) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	// read current value of CTRL register, 0 is no input, 1 is an input
+	iodir, err := p.connection.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	// set pin as input by setting bit
+	iodirVal := setBit(iodir, uint8(pin))
+	// write CTRL register
+	err = p.connection.WriteByte(uint8(iodirVal))
+	if err != nil {
+		return 0, err
+	}
+	// read port and create return bit
+	val, err := p.connection.ReadByte()
+	if err != nil {
+		return val, err
+	}
+	val = 1 << uint8(pin) & val
+	if val > 1 {
+		val = 1
+	}
+	return val, nil
+}
+
+// ReadEEPROM reads a value from a given address (0x00-0xFF)
+// Note: only this sequence for memory read is supported: "STARTW-DATA1-STARTR-DATA2-STOP"
+// DATA1: EEPROM address, DATA2: read value
+func (p *PCA9501Driver) ReadEEPROM(address uint8) (uint8, error) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	return p.connectionMem.ReadByteData(address)
+}
+
+// WriteEEPROM writes a value to a given address in memory (0x00-0xFF)
+func (p *PCA9501Driver) WriteEEPROM(address uint8, val uint8) error {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	return p.connectionMem.WriteByteData(address, val)
+}
+
+func (p *PCA9501Driver) initialize() (err error) {
+	// initialize the EEPROM connection
+	bus := p.GetBusOrDefault(p.connector.GetDefaultBus())
+	addressMem := p.GetAddressOrDefault(pca9501DefaultAddress) | 0x40
+	p.connectionMem, err = p.connector.GetConnection(addressMem, bus)
+	return
+}

--- a/drivers/i2c/pca9501_driver_test.go
+++ b/drivers/i2c/pca9501_driver_test.go
@@ -1,0 +1,412 @@
+package i2c
+
+import (
+	"errors"
+	"testing"
+
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/gobottest"
+)
+
+// this ensures that the implementation is based on i2c.Driver, which implements the gobot.Driver
+// and tests all implementations, so no further tests needed here for gobot.Driver interface
+var _ gobot.Driver = (*PCA9501Driver)(nil)
+
+var (
+	pinVal = map[string]interface{}{
+		"pin": uint8(7),
+		"val": uint8(0),
+	}
+	pin = map[string]interface{}{
+		"pin": uint8(7),
+	}
+	addressVal = map[string]interface{}{
+		"address": uint8(15),
+		"val":     uint8(7),
+	}
+	address = map[string]interface{}{
+		"address": uint8(15),
+	}
+)
+
+func initPCA9501WithStubbedAdaptor() (*PCA9501Driver, *i2cTestAdaptor) {
+	a := newI2cTestAdaptor()
+	d := NewPCA9501Driver(a)
+	d.Start()
+	return d, a
+}
+
+func TestNewPCA9501Driver(t *testing.T) {
+	// arrange, act
+	var di interface{} = NewPCA9501Driver(newI2cTestAdaptor())
+	// assert
+	d, ok := di.(*PCA9501Driver)
+	if !ok {
+		t.Errorf("NewPCA9501Driver() should have returned a *PCA9501Driver")
+	}
+	gobottest.Refute(t, d.Driver, nil)
+}
+
+func TestPCA9501CommandsWriteGPIO(t *testing.T) {
+	// arrange
+	d, a := initPCA9501WithStubbedAdaptor()
+	a.i2cReadImpl = func(b []byte) (int, error) {
+		return len(b), nil
+	}
+	a.i2cWriteImpl = func([]byte) (int, error) {
+		return 0, nil
+	}
+	// act
+	result := d.Command("WriteGPIO")(pinVal)
+	// assert
+	gobottest.Assert(t, result.(map[string]interface{})["err"], nil)
+}
+
+func TestPCA9501CommandsReadGPIO(t *testing.T) {
+	// arrange
+	d, a := initPCA9501WithStubbedAdaptor()
+	a.i2cReadImpl = func(b []byte) (int, error) {
+		return len(b), nil
+	}
+	// act
+	result := d.Command("ReadGPIO")(pin)
+	// assert
+	gobottest.Assert(t, result.(map[string]interface{})["err"], nil)
+}
+
+func TestPCA9501CommandsWriteEEPROM(t *testing.T) {
+	// arrange
+	d, a := initPCA9501WithStubbedAdaptor()
+	a.i2cWriteImpl = func([]byte) (int, error) {
+		return 0, nil
+	}
+	// act
+	result := d.Command("WriteEEPROM")(addressVal)
+	// assert
+	gobottest.Assert(t, result.(map[string]interface{})["err"], nil)
+}
+
+func TestPCA9501CommandsReadEEPROM(t *testing.T) {
+	// arrange
+	d, a := initPCA9501WithStubbedAdaptor()
+	a.i2cWriteImpl = func([]byte) (int, error) {
+		return 0, nil
+	}
+	a.i2cReadImpl = func(b []byte) (int, error) {
+		return len(b), nil
+	}
+	// act
+	result := d.Command("ReadEEPROM")(address)
+	// assert
+	gobottest.Assert(t, result.(map[string]interface{})["err"], nil)
+}
+
+func TestPCA9501WriteGPIO(t *testing.T) {
+	var tests = map[string]struct {
+		setVal          uint8
+		ioDirAllInput   uint8
+		ioStateAllInput uint8
+		pin             uint8
+		wantPin         uint8
+		wantState       uint8
+	}{
+		"clear_bit": {
+			setVal:          0,
+			ioDirAllInput:   0xF1,
+			ioStateAllInput: 0xF2,
+			pin:             6,
+			wantPin:         0xB1,
+			wantState:       0xB2,
+		},
+		"set_bit": {
+			setVal:          2,
+			ioDirAllInput:   0x1F,
+			ioStateAllInput: 0x20,
+			pin:             3,
+			wantPin:         0x17,
+			wantState:       0x28,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			d, a := initPCA9501WithStubbedAdaptor()
+			// prepare all reads
+			numCallsRead := 0
+			a.i2cReadImpl = func(b []byte) (int, error) {
+				numCallsRead++
+				if numCallsRead == 1 {
+					// first call read current io direction of all pins
+					b[0] = tc.ioDirAllInput
+				}
+				if numCallsRead == 2 {
+					// second call read current state of all pins
+					b[0] = tc.ioStateAllInput
+				}
+				return len(b), nil
+			}
+			// act
+			err := d.WriteGPIO(tc.pin, tc.setVal)
+			// assert
+			gobottest.Assert(t, err, nil)
+			gobottest.Assert(t, numCallsRead, 2)
+			gobottest.Assert(t, len(a.written), 2)
+			gobottest.Assert(t, a.written[0], tc.wantPin)
+			gobottest.Assert(t, a.written[1], tc.wantState)
+		})
+	}
+}
+
+func TestPCA9501WriteGPIOErrorAtWriteDirection(t *testing.T) {
+	// arrange
+	d, a := initPCA9501WithStubbedAdaptor()
+	wantErr := errors.New("write error")
+	// prepare all reads
+	numCallsRead := 0
+	a.i2cReadImpl = func(b []byte) (int, error) {
+		numCallsRead++
+		return len(b), nil
+	}
+	// prepare all writes
+	numCallsWrite := 0
+	a.i2cWriteImpl = func([]byte) (int, error) {
+		numCallsWrite++
+		if numCallsWrite == 1 {
+			// first call writes the CTRL register for port direction
+			return 0, wantErr
+		}
+		return 0, nil
+	}
+	// act
+	err := d.WriteGPIO(7, 0)
+	// assert
+	gobottest.Assert(t, err, wantErr)
+	gobottest.Assert(t, numCallsRead < 2, true)
+	gobottest.Assert(t, numCallsWrite, 1)
+}
+
+func TestPCA9501WriteGPIOErrorAtWriteValue(t *testing.T) {
+	// arrange
+	d, a := initPCA9501WithStubbedAdaptor()
+	wantErr := errors.New("write error")
+	// prepare all reads
+	a.i2cReadImpl = func(b []byte) (int, error) {
+		return len(b), nil
+	}
+	// prepare all writes
+	numCallsWrite := 0
+	a.i2cWriteImpl = func([]byte) (int, error) {
+		numCallsWrite++
+		if numCallsWrite == 2 {
+			// second call writes the value to IO port
+			return 0, wantErr
+		}
+		return 0, nil
+	}
+	// act
+	err := d.WriteGPIO(7, 0)
+	// assert
+	gobottest.Assert(t, err, wantErr)
+	gobottest.Assert(t, numCallsWrite, 2)
+}
+
+func TestPCA9501ReadGPIO(t *testing.T) {
+	var tests = map[string]struct {
+		ctrlState uint8
+		want      uint8
+	}{
+		"pin_is_set":     {ctrlState: 0x80, want: 1},
+		"pin_is_not_set": {ctrlState: 0x7F, want: 0},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			const (
+				pin           = uint8(7)
+				wantCtrlState = uint8(0x80)
+			)
+			d, a := initPCA9501WithStubbedAdaptor()
+			// prepare all reads
+			numCallsRead := 0
+			a.i2cReadImpl = func(b []byte) (int, error) {
+				numCallsRead++
+				if numCallsRead == 1 {
+					// current state of io
+					b[0] = 0x00
+				}
+				if numCallsRead == 2 {
+					b[0] = tc.ctrlState
+				}
+				return len(b), nil
+			}
+			// act
+			got, err := d.ReadGPIO(pin)
+			// assert
+			gobottest.Assert(t, err, nil)
+			gobottest.Assert(t, got, tc.want)
+			gobottest.Assert(t, numCallsRead, 2)
+			gobottest.Assert(t, len(a.written), 1)
+			gobottest.Assert(t, a.written[0], wantCtrlState)
+		})
+	}
+}
+
+func TestPCA9501ReadGPIOErrorAtReadDirection(t *testing.T) {
+	// arrange
+	d, a := initPCA9501WithStubbedAdaptor()
+	wantErr := errors.New("read error")
+	// prepare all reads
+	numCallsRead := 0
+	a.i2cReadImpl = func(b []byte) (int, error) {
+		numCallsRead++
+		if numCallsRead == 1 {
+			// first read gets the CTRL register for pin direction
+			return 0, wantErr
+		}
+		return len(b), nil
+	}
+	// prepare all writes
+	numCallsWrite := 0
+	a.i2cWriteImpl = func([]byte) (int, error) {
+		numCallsWrite++
+		return 0, nil
+	}
+	// act
+	_, err := d.ReadGPIO(1)
+	// assert
+	gobottest.Assert(t, err, wantErr)
+	gobottest.Assert(t, numCallsRead, 1)
+	gobottest.Assert(t, numCallsWrite, 0)
+}
+
+func TestPCA9501ReadGPIOErrorAtReadValue(t *testing.T) {
+	// arrange
+	d, a := initPCA9501WithStubbedAdaptor()
+	wantErr := errors.New("read error")
+	// prepare all reads
+	numCallsRead := 0
+	a.i2cReadImpl = func(b []byte) (int, error) {
+		numCallsRead++
+		if numCallsRead == 2 {
+			// second read gets the value from IO port
+			return 0, wantErr
+		}
+		return len(b), nil
+	}
+	// prepare all writes
+	numCallsWrite := 0
+	a.i2cWriteImpl = func([]byte) (int, error) {
+		numCallsWrite++
+		return 0, nil
+	}
+	// act
+	_, err := d.ReadGPIO(2)
+	// assert
+	gobottest.Assert(t, err, wantErr)
+	gobottest.Assert(t, numCallsWrite, 1)
+}
+
+func TestPCA9501WriteEEPROM(t *testing.T) {
+	// arrange
+	const (
+		addressEEPROM = uint8(0x52)
+		want          = uint8(0x25)
+	)
+	d, a := initPCA9501WithStubbedAdaptor()
+	// prepare all writes
+	numCallsWrite := 0
+	a.i2cWriteImpl = func([]byte) (int, error) {
+		numCallsWrite++
+		return 0, nil
+	}
+	// act
+	err := d.WriteEEPROM(addressEEPROM, want)
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, numCallsWrite, 1)
+	gobottest.Assert(t, a.written[0], addressEEPROM)
+	gobottest.Assert(t, a.written[1], want)
+}
+
+func TestPCA9501ReadEEPROM(t *testing.T) {
+	// arrange
+	const (
+		addressEEPROM = uint8(51)
+		want          = uint8(0x44)
+	)
+	d, a := initPCA9501WithStubbedAdaptor()
+	// prepare all writes
+	numCallsWrite := 0
+	a.i2cWriteImpl = func(b []byte) (int, error) {
+		numCallsWrite++
+		return 0, nil
+	}
+	// prepare all reads
+	numCallsRead := 0
+	a.i2cReadImpl = func(b []byte) (int, error) {
+		numCallsRead++
+		b[0] = want
+		return len(b), nil
+	}
+	// act
+	val, err := d.ReadEEPROM(addressEEPROM)
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, val, want)
+	gobottest.Assert(t, numCallsWrite, 1)
+	gobottest.Assert(t, a.written[0], addressEEPROM)
+	gobottest.Assert(t, numCallsRead, 1)
+}
+
+func TestPCA9501ReadEEPROMErrorWhileWriteAddress(t *testing.T) {
+	// arrange
+	d, a := initPCA9501WithStubbedAdaptor()
+	wantErr := errors.New("error while write")
+	// prepare all writes
+	a.i2cWriteImpl = func([]byte) (int, error) {
+		return 0, wantErr
+	}
+	// prepare all reads
+	numCallsRead := 0
+	a.i2cReadImpl = func(b []byte) (int, error) {
+		numCallsRead++
+		return len(b), nil
+	}
+	// act
+	_, err := d.ReadEEPROM(15)
+	// assert
+	gobottest.Assert(t, err, wantErr)
+	gobottest.Assert(t, numCallsRead, 0)
+}
+
+func TestPCA9501ReadEEPROMErrorWhileReadValue(t *testing.T) {
+	// arrange
+	d, a := initPCA9501WithStubbedAdaptor()
+	wantErr := errors.New("error while read")
+	// prepare all writes
+	numCallsWrite := 0
+	a.i2cWriteImpl = func([]byte) (int, error) {
+		numCallsWrite++
+		return 0, nil
+	}
+	// prepare all reads
+	a.i2cReadImpl = func(b []byte) (int, error) {
+		return len(b), wantErr
+	}
+	// act
+	_, err := d.ReadEEPROM(15)
+	// assert
+	gobottest.Assert(t, numCallsWrite, 1)
+	gobottest.Assert(t, err, wantErr)
+}
+
+func TestPCA9501_initialize(t *testing.T) {
+	// arrange
+	const want = 0x7f
+	d, a := initPCA9501WithStubbedAdaptor()
+	// act
+	err := d.initialize()
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, a.address, want)
+}

--- a/examples/digispark_pca9501.go
+++ b/examples/digispark_pca9501.go
@@ -1,0 +1,88 @@
+// +build example
+//
+// Do not build by default.
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/drivers/i2c"
+	"gobot.io/x/gobot/platforms/digispark"
+)
+
+// Program use EEPROM with GPIO to rotate pins, get best experience, when
+// add LED's between +5V and each pin with an resistor of ~180 Ohm.
+//
+// Procedure:
+// * write value to EEPROM
+// * read value back from EEPROM and check for differences
+// * use read value to set GPIO
+func main() {
+	board := digispark.NewAdaptor()
+	pca := i2c.NewPCA9501Driver(board, i2c.WithAddress(0x04))
+	var addressMem uint8 = 0x00
+	var valMemW uint8 = 0xFF
+	var valMemR uint8
+	var pin uint8 = 0
+	var newPin uint8 = 0
+	var pinState uint8 = 0
+	var err error
+
+	work := func() {
+		gobot.Every(50*time.Millisecond, func() {
+			// write a value 0-255 to EEPROM address 255-0
+			addressMem--
+			valMemW++
+			err = pca.WriteEEPROM(addressMem, valMemW)
+			if err != nil {
+				fmt.Println("err MEMw:", err)
+			}
+
+			// write process needs some time, so wait at least 5ms before read a value
+			// when decreasing to much, the check below will fail
+			time.Sleep(5 * time.Millisecond)
+
+			// read value back and check for unexpected differences
+			valMemR, err = pca.ReadEEPROM(addressMem)
+			if err != nil {
+				fmt.Println("err MEMr:", err)
+			}
+			if valMemW != valMemR {
+				fmt.Printf("addr: %d valMemW: %d differ valMemR: %d\n", addressMem, valMemW, valMemR)
+			}
+			// convert it to a pin 0-7
+			newPin = valMemR % 8
+			// write only when something has changed
+			if newPin != pin {
+				pin = newPin
+				fmt.Println("set Pin:", pin, "to:", pinState)
+				err = pca.WriteGPIO(pin, pinState)
+				if err != nil {
+					fmt.Println("err GPIO:", err)
+				}
+				// when all LED's are on switch off
+				if pin >= 7 {
+					if pinState == 0 {
+						pinState = 1
+					} else {
+						pinState = 0
+					}
+				}
+			}
+		})
+	}
+
+	robot := gobot.NewRobot("rotatePinsI2c",
+		[]gobot.Connection{board},
+		[]gobot.Device{pca},
+		work,
+	)
+
+	err = robot.Start()
+	if err != nil {
+		fmt.Println(err)
+	}
+}


### PR DESCRIPTION
introduce PCA9501 i2c driver inspired by mcp23017 driver
* GPIO work fine with digispark
* EEPROM read/write work fine with digispark
* EEPROM roughly tested with work in progress mcp2221 board from adafruit
* mutex needed, because read-write sequences must not be interrupted