### PR TITLE
bugfix for digispark i2c readwritebyte

### DIFF
--- a/platforms/digispark/digispark_adaptor_test.go
+++ b/platforms/digispark/digispark_adaptor_test.go
@@ -2,13 +2,11 @@ package digispark
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 	"testing"
 
 	"gobot.io/x/gobot"
 	"gobot.io/x/gobot/drivers/gpio"
-	"gobot.io/x/gobot/drivers/i2c"
 	"gobot.io/x/gobot/gobottest"
 )
 
@@ -17,7 +15,6 @@ var _ gobot.Adaptor = (*Adaptor)(nil)
 var _ gpio.DigitalWriter = (*Adaptor)(nil)
 var _ gpio.PwmWriter = (*Adaptor)(nil)
 var _ gpio.ServoWriter = (*Adaptor)(nil)
-var _ i2c.Connector = (*Adaptor)(nil)
 
 type mock struct {
 	locationA         uint8
@@ -28,11 +25,9 @@ type mock struct {
 	pin               uint8
 	mode              uint8
 	state             uint8
-	address           int
-	duration          uint
-	direction         uint8
 }
 
+// setup mock for GPIO, PWM and servo tests
 func (l *mock) digitalWrite(pin uint8, state uint8) error {
 	l.pin = pin
 	l.state = state
@@ -64,52 +59,16 @@ func (l *mock) servoUpdateLocation(locationA uint8, locationB uint8) error {
 	return l.error()
 }
 
-const availableI2cAddress = 0x40
-const maxUint8 = ^uint8(0)
-
-var i2cData = []byte{5, 4, 3, 2, 1, 0}
-
-func (l *mock) i2cInit() error {
-	l.direction = maxUint8
-	return l.error()
-}
-
-func (l *mock) i2cStart(address7bit uint8, direction uint8) error {
-	if address7bit != availableI2cAddress {
-		return fmt.Errorf("Invalid address, only %d is supported", availableI2cAddress)
-	}
-	if err := l.error(); err != nil {
-		return err
-	}
-	l.direction = direction
-	return nil
-}
-
-func (l *mock) i2cWrite(sendBuffer []byte, length int, endWithStop uint8) error {
-	l.direction = 0
-	return l.error()
-}
-
-func (l *mock) i2cRead(readBuffer []byte, length int, endWithStop uint8) error {
-	l.direction = 1
-	if len(readBuffer) < length {
-		length = len(readBuffer)
-	}
-	if len(i2cData) < length {
-		length = len(i2cData)
-	}
-	copy(readBuffer[:length], i2cData[:length])
-	return l.error()
-}
-
-func (l *mock) i2cUpdateDelay(duration uint) error {
-	l.duration = duration
-	return l.error()
-}
-
 var errorFunc = func() error { return nil }
 
 func (l *mock) error() error { return errorFunc() }
+
+// i2c functions unused in this test scenarios
+func (l *mock) i2cInit() error                                                  { return nil }
+func (l *mock) i2cStart(address7bit uint8, direction uint8) error               { return nil }
+func (l *mock) i2cWrite(sendBuffer []byte, length int, endWithStop uint8) error { return nil }
+func (l *mock) i2cRead(readBuffer []byte, length int, endWithStop uint8) error  { return nil }
+func (l *mock) i2cUpdateDelay(duration uint) error                              { return nil }
 
 func initTestAdaptor() *Adaptor {
 	a := NewAdaptor()
@@ -127,17 +86,17 @@ func TestDigisparkAdaptorName(t *testing.T) {
 	gobottest.Assert(t, a.Name(), "NewName")
 }
 
-func TestAdaptorConnect(t *testing.T) {
+func TestDigisparkAdaptorConnect(t *testing.T) {
 	a := initTestAdaptor()
 	gobottest.Assert(t, a.Connect(), nil)
 }
 
-func TestAdaptorFinalize(t *testing.T) {
+func TestDigisparkAdaptorFinalize(t *testing.T) {
 	a := initTestAdaptor()
 	gobottest.Assert(t, a.Finalize(), nil)
 }
 
-func TestAdaptorDigitalWrite(t *testing.T) {
+func TestDigisparkAdaptorDigitalWrite(t *testing.T) {
 	a := initTestAdaptor()
 	err := a.DigitalWrite("0", uint8(1))
 	gobottest.Assert(t, err, nil)
@@ -152,7 +111,7 @@ func TestAdaptorDigitalWrite(t *testing.T) {
 	gobottest.Assert(t, err, errors.New("pin mode error"))
 }
 
-func TestAdaptorServoWrite(t *testing.T) {
+func TestDigisparkAdaptorServoWrite(t *testing.T) {
 	a := initTestAdaptor()
 	err := a.ServoWrite("2", uint8(80))
 	gobottest.Assert(t, err, nil)
@@ -165,7 +124,7 @@ func TestAdaptorServoWrite(t *testing.T) {
 	gobottest.Assert(t, err, errors.New("servo error"))
 }
 
-func TestAdaptorPwmWrite(t *testing.T) {
+func TestDigisparkAdaptorPwmWrite(t *testing.T) {
 	a := initTestAdaptor()
 	err := a.PwmWrite("1", uint8(100))
 	gobottest.Assert(t, err, nil)
@@ -181,46 +140,4 @@ func TestAdaptorPwmWrite(t *testing.T) {
 	errorFunc = func() error { return errors.New("pwm error") }
 	err = a.PwmWrite("1", uint8(100))
 	gobottest.Assert(t, err, errors.New("pwm error"))
-}
-
-func TestAdaptorI2c(t *testing.T) {
-	var c i2c.Connection
-	var err error
-	data := []byte{0, 1, 2, 3, 4}
-	dataLen := len(data)
-	count := 0
-
-	a := initTestAdaptor()
-	c, err = a.GetConnection(0x40, 1)
-	gobottest.Assert(t, err, errors.New("Invalid bus number 1, only 0 is supported"))
-	gobottest.Assert(t, c, nil)
-	// init couldn't run, direction is still 0
-	gobottest.Assert(t, a.littleWire.(*mock).direction, uint8(0))
-
-	// connection inits, but start will fail
-	c, err = a.GetConnection(0x39, a.GetDefaultBus())
-	gobottest.Assert(t, err, nil)
-	gobottest.Refute(t, c, nil)
-	gobottest.Assert(t, a.littleWire.(*mock).direction, maxUint8)
-	err = c.(*digisparkI2cConnection).UpdateDelay(uint(100))
-	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, a.littleWire.(*mock).duration, uint(100))
-	count, err = c.Write(data)
-	gobottest.Assert(t, count, 0)
-	gobottest.Assert(t, err, fmt.Errorf("Invalid address, only %d is supported", availableI2cAddress))
-	gobottest.Assert(t, a.littleWire.(*mock).direction, maxUint8)
-
-	// connection inits, but start will succeed
-	c, err = a.GetConnection(availableI2cAddress, a.GetDefaultBus())
-	gobottest.Assert(t, err, nil)
-	gobottest.Refute(t, c, nil)
-	count, err = c.Write(data)
-	gobottest.Assert(t, count, dataLen)
-	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, a.littleWire.(*mock).direction, uint8(0))
-	count, err = c.Read(data)
-	gobottest.Assert(t, count, dataLen)
-	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, a.littleWire.(*mock).direction, uint8(1))
-	gobottest.Assert(t, data, i2cData[:dataLen])
 }

--- a/platforms/digispark/digispark_i2c.go
+++ b/platforms/digispark/digispark_i2c.go
@@ -2,6 +2,7 @@ package digispark
 
 import (
 	"errors"
+	"fmt"
 )
 
 type digisparkI2cConnection struct {
@@ -44,7 +45,7 @@ func (c *digisparkI2cConnection) UpdateDelay(duration uint) error {
 
 // Read tries to read a full buffer from the i2c device.
 // Returns an empty array if the response from the board has timed out.
-func (c *digisparkI2cConnection) Read(b []byte) (read int, err error) {
+func (c *digisparkI2cConnection) Read(b []byte) (countRead int, err error) {
 	if !c.adaptor.i2c {
 		err = errors.New("Digispark i2c not initialized")
 		return
@@ -56,19 +57,20 @@ func (c *digisparkI2cConnection) Read(b []byte) (read int, err error) {
 	stop := uint8(0)
 
 	for stop == 0 {
-		if read+l >= len(b) {
-			l = len(b) - read
+		if countRead+l >= len(b) {
+			l = len(b) - countRead
 			stop = 1
 		}
-		if err = c.adaptor.littleWire.i2cRead(b[read:read+l], l, stop); err != nil {
+		if err = c.adaptor.littleWire.i2cRead(b[countRead:countRead+l], l, stop); err != nil {
 			return
 		}
-		read += l
+		countRead += l
 	}
 	return
 }
 
-func (c *digisparkI2cConnection) Write(data []byte) (written int, err error) {
+// Write writes the buffer content in data to the i2c device.
+func (c *digisparkI2cConnection) Write(data []byte) (countWritten int, err error) {
 	if !c.adaptor.i2c {
 		err = errors.New("Digispark i2c not initialized")
 		return
@@ -80,31 +82,34 @@ func (c *digisparkI2cConnection) Write(data []byte) (written int, err error) {
 	stop := uint8(0)
 
 	for stop == 0 {
-		if written+l >= len(data) {
-			l = len(data) - written
+		if countWritten+l >= len(data) {
+			l = len(data) - countWritten
 			stop = 1
 		}
-		if err = c.adaptor.littleWire.i2cWrite(data[written:written+l], l, stop); err != nil {
+		if err = c.adaptor.littleWire.i2cWrite(data[countWritten:countWritten+l], l, stop); err != nil {
 			return
 		}
-		written += l
+		countWritten += l
 	}
 	return
 }
 
+// Close do nothing than return nil.
 func (c *digisparkI2cConnection) Close() error {
 	return nil
 }
 
+// ReadByte reads one byte from the i2c device.
 func (c *digisparkI2cConnection) ReadByte() (val byte, err error) {
-	b := make([]byte, 1)
-	if err = c.adaptor.littleWire.i2cRead(b, 1, 1); err != nil {
+	buf := []byte{0}
+	if err = c.readAndCheckCount(buf); err != nil {
 		return
 	}
-	val = b[0]
+	val = buf[0]
 	return
 }
 
+// ReadByteData reads one byte of the given register address from the i2c device.
 func (c *digisparkI2cConnection) ReadByteData(reg uint8) (val uint8, err error) {
 	if err = c.WriteByte(reg); err != nil {
 		return
@@ -112,13 +117,14 @@ func (c *digisparkI2cConnection) ReadByteData(reg uint8) (val uint8, err error) 
 	return c.ReadByte()
 }
 
+// ReadWordData reads two bytes of the given register address from the i2c device.
 func (c *digisparkI2cConnection) ReadWordData(reg uint8) (val uint16, err error) {
 	if err = c.WriteByte(reg); err != nil {
 		return
 	}
 
 	buf := []byte{0, 0}
-	if _, err = c.Read(buf); err != nil {
+	if err = c.readAndCheckCount(buf); err != nil {
 		return
 	}
 	low, high := buf[0], buf[1]
@@ -127,26 +133,27 @@ func (c *digisparkI2cConnection) ReadWordData(reg uint8) (val uint16, err error)
 	return
 }
 
+// WriteByte writes one byte to the i2c device.
 func (c *digisparkI2cConnection) WriteByte(val byte) (err error) {
-	b := []byte{val}
-	err = c.adaptor.littleWire.i2cWrite(b, 1, 1)
-	return
+	buf := []byte{val}
+	return c.writeAndCheckCount(buf)
 }
 
+// WriteByteData writes one byte to the given register address of the i2c device.
 func (c *digisparkI2cConnection) WriteByteData(reg uint8, val byte) (err error) {
 	buf := []byte{reg, val}
-	_, err = c.Write(buf)
-	return
+	return c.writeAndCheckCount(buf)
 }
 
+// WriteWordData writes two bytes to the given register address of the i2c device.
 func (c *digisparkI2cConnection) WriteWordData(reg uint8, val uint16) (err error) {
 	low := uint8(val & 0xff)
 	high := uint8((val >> 8) & 0xff)
 	buf := []byte{reg, low, high}
-	_, err = c.Write(buf)
-	return
+	return c.writeAndCheckCount(buf)
 }
 
+// WriteBlockData writes a block of maximum 32 bytes to the given register address of the i2c device.
 func (c *digisparkI2cConnection) WriteBlockData(reg uint8, data []byte) (err error) {
 	if len(data) > 32 {
 		data = data[:32]
@@ -155,6 +162,31 @@ func (c *digisparkI2cConnection) WriteBlockData(reg uint8, data []byte) (err err
 	buf := make([]byte, len(data)+1)
 	copy(buf[:1], data)
 	buf[0] = reg
-	_, err = c.Write(buf)
+	return c.writeAndCheckCount(buf)
+}
+
+func (c *digisparkI2cConnection) writeAndCheckCount(buf []byte) (err error) {
+	countWritten := 0
+	if countWritten, err = c.Write(buf); err != nil {
+		return
+	}
+	expectedCount := len(buf)
+	if countWritten != expectedCount {
+		err = fmt.Errorf("Digispark i2c write %d bytes, expected %d bytes", countWritten, expectedCount)
+		return
+	}
+	return
+}
+
+func (c *digisparkI2cConnection) readAndCheckCount(buf []byte) (err error) {
+	countRead := 0
+	if countRead, err = c.Read(buf); err != nil {
+		return
+	}
+	expectedCount := len(buf)
+	if countRead != expectedCount {
+		err = fmt.Errorf("Digispark i2c read %d bytes, expected %d bytes", countRead, expectedCount)
+		return
+	}
 	return
 }

--- a/platforms/digispark/digispark_i2c_test.go
+++ b/platforms/digispark/digispark_i2c_test.go
@@ -1,0 +1,292 @@
+package digispark
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"gobot.io/x/gobot/drivers/i2c"
+	"gobot.io/x/gobot/gobottest"
+)
+
+const availableI2cAddress = 0x40
+const maxUint8 = ^uint8(0)
+
+var _ i2c.Connector = (*Adaptor)(nil)
+var i2cData = []byte{5, 4, 3, 2, 1, 0}
+
+type i2cMock struct {
+	address      int
+	duration     uint
+	direction    uint8
+	dataWritten  []byte
+	startWasSend bool
+	stopWasSend  bool
+}
+
+func initTestAdaptorI2c() *Adaptor {
+	a := NewAdaptor()
+	a.connect = func(a *Adaptor) (err error) { return nil }
+	a.littleWire = new(i2cMock)
+	errorFunc = func() error { return nil }
+	pwmInitErrorFunc = func() error { return nil }
+	return a
+}
+
+func TestDigisparkAdaptorI2cGetConnection(t *testing.T) {
+	// arrange
+	var c i2c.Connection
+	var err error
+	a := initTestAdaptorI2c()
+
+	// act
+	c, err = a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Refute(t, c, nil)
+}
+
+func TestDigisparkAdaptorI2cGetConnectionFailWithInvalidBus(t *testing.T) {
+	// arrange
+	a := initTestAdaptorI2c()
+
+	// act
+	c, err := a.GetConnection(0x40, 1)
+
+	// assert
+	gobottest.Assert(t, err, errors.New("Invalid bus number 1, only 0 is supported"))
+	gobottest.Assert(t, c, nil)
+}
+
+func TestDigisparkAdaptorI2cStartFailWithWrongAddress(t *testing.T) {
+	// arrange
+	data := []byte{0, 1, 2, 3, 4}
+	a := initTestAdaptorI2c()
+	c, err := a.GetConnection(0x39, a.GetDefaultBus())
+
+	// act
+	count, err := c.Write(data)
+
+	// assert
+	gobottest.Assert(t, count, 0)
+	gobottest.Assert(t, err, fmt.Errorf("Invalid address, only %d is supported", availableI2cAddress))
+	gobottest.Assert(t, a.littleWire.(*i2cMock).direction, maxUint8)
+}
+
+func TestDigisparkAdaptorI2cWrite(t *testing.T) {
+	// arrange
+	data := []byte{0, 1, 2, 3, 4}
+	dataLen := len(data)
+	a := initTestAdaptorI2c()
+	c, err := a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+
+	// act
+	count, err := c.Write(data)
+
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).startWasSend, true)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).direction, uint8(0))
+	gobottest.Assert(t, count, dataLen)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).dataWritten, data)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).stopWasSend, true)
+}
+
+func TestDigisparkAdaptorI2cWriteByte(t *testing.T) {
+	// arrange
+	data := byte(0x02)
+	a := initTestAdaptorI2c()
+	c, err := a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+
+	// act
+	err = c.WriteByte(data)
+
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).startWasSend, true)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).direction, uint8(0))
+	gobottest.Assert(t, a.littleWire.(*i2cMock).dataWritten, []byte{data})
+	gobottest.Assert(t, a.littleWire.(*i2cMock).stopWasSend, true)
+}
+
+func TestDigisparkAdaptorI2cWriteByteData(t *testing.T) {
+	// arrange
+	reg := uint8(0x03)
+	data := byte(0x09)
+	a := initTestAdaptorI2c()
+	c, err := a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+
+	// act
+	err = c.WriteByteData(reg, data)
+
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).startWasSend, true)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).direction, uint8(0))
+	gobottest.Assert(t, a.littleWire.(*i2cMock).dataWritten, []byte{reg, data})
+	gobottest.Assert(t, a.littleWire.(*i2cMock).stopWasSend, true)
+}
+
+func TestDigisparkAdaptorI2cWriteWordData(t *testing.T) {
+	// arrange
+	reg := uint8(0x04)
+	data := uint16(0x0508)
+	a := initTestAdaptorI2c()
+	c, err := a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+
+	// act
+	err = c.WriteWordData(reg, data)
+
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).startWasSend, true)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).direction, uint8(0))
+	gobottest.Assert(t, a.littleWire.(*i2cMock).dataWritten, []byte{reg, 0x08, 0x05})
+	gobottest.Assert(t, a.littleWire.(*i2cMock).stopWasSend, true)
+}
+
+func TestDigisparkAdaptorI2cRead(t *testing.T) {
+	// arrange
+	data := []byte{0, 1, 2, 3, 4}
+	dataLen := len(data)
+	a := initTestAdaptorI2c()
+	c, err := a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+
+	// act
+	count, err := c.Read(data)
+
+	// assert
+	gobottest.Assert(t, count, dataLen)
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).startWasSend, true)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).direction, uint8(1))
+	gobottest.Assert(t, data, i2cData[:dataLen])
+	gobottest.Assert(t, a.littleWire.(*i2cMock).stopWasSend, true)
+}
+
+func TestDigisparkAdaptorI2cReadByte(t *testing.T) {
+	// arrange
+	a := initTestAdaptorI2c()
+	c, err := a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+
+	// act
+	data, err := c.ReadByte()
+
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).startWasSend, true)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).direction, uint8(1))
+	gobottest.Assert(t, data, i2cData[0])
+	gobottest.Assert(t, a.littleWire.(*i2cMock).stopWasSend, true)
+}
+
+func TestDigisparkAdaptorI2cReadByteData(t *testing.T) {
+	// arrange
+	reg := uint8(0x04)
+	a := initTestAdaptorI2c()
+	c, err := a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+
+	// act
+	data, err := c.ReadByteData(reg)
+
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).startWasSend, true)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).direction, uint8(1))
+	gobottest.Assert(t, a.littleWire.(*i2cMock).dataWritten, []byte{reg})
+	gobottest.Assert(t, data, i2cData[0])
+	gobottest.Assert(t, a.littleWire.(*i2cMock).stopWasSend, true)
+}
+
+func TestDigisparkAdaptorI2cReadWordData(t *testing.T) {
+	// arrange
+	reg := uint8(0x05)
+	// 2 bytes of i2cData are used swapped
+	expectedValue := uint16(0x0405)
+	a := initTestAdaptorI2c()
+	c, err := a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+
+	// act
+	data, err := c.ReadWordData(reg)
+
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).startWasSend, true)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).direction, uint8(1))
+	gobottest.Assert(t, a.littleWire.(*i2cMock).dataWritten, []byte{reg})
+	gobottest.Assert(t, data, expectedValue)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).stopWasSend, true)
+}
+
+func TestDigisparkAdaptorI2cUpdateDelay(t *testing.T) {
+	// arrange
+	var c i2c.Connection
+	var err error
+	a := initTestAdaptorI2c()
+	c, err = a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+
+	// act
+	err = c.(*digisparkI2cConnection).UpdateDelay(uint(100))
+
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, a.littleWire.(*i2cMock).duration, uint(100))
+}
+
+// setup mock for i2c tests
+func (l *i2cMock) i2cInit() error {
+	l.direction = maxUint8
+	return l.error()
+}
+
+func (l *i2cMock) i2cStart(address7bit uint8, direction uint8) error {
+	if address7bit != availableI2cAddress {
+		return fmt.Errorf("Invalid address, only %d is supported", availableI2cAddress)
+	}
+	if err := l.error(); err != nil {
+		return err
+	}
+	l.direction = direction
+	l.startWasSend = true
+	return nil
+}
+
+func (l *i2cMock) i2cWrite(sendBuffer []byte, length int, endWithStop uint8) error {
+	l.dataWritten = append(l.dataWritten, sendBuffer...)
+	if endWithStop > 0 {
+		l.stopWasSend = true
+	}
+	return l.error()
+}
+
+func (l *i2cMock) i2cRead(readBuffer []byte, length int, endWithStop uint8) error {
+	if len(readBuffer) < length {
+		length = len(readBuffer)
+	}
+	if len(i2cData) < length {
+		length = len(i2cData)
+	}
+	copy(readBuffer[:length], i2cData[:length])
+
+	if endWithStop > 0 {
+		l.stopWasSend = true
+	}
+	return l.error()
+}
+
+func (l *i2cMock) i2cUpdateDelay(duration uint) error {
+	l.duration = duration
+	return l.error()
+}
+
+// GPIO, PWM and servo functions unused in this test scenarios
+func (l *i2cMock) digitalWrite(pin uint8, state uint8) error                  { return nil }
+func (l *i2cMock) pinMode(pin uint8, mode uint8) error                        { return nil }
+func (l *i2cMock) pwmInit() error                                             { return nil }
+func (l *i2cMock) pwmStop() error                                             { return nil }
+func (l *i2cMock) pwmUpdateCompare(channelA uint8, channelB uint8) error      { return nil }
+func (l *i2cMock) pwmUpdatePrescaler(value uint) error                        { return nil }
+func (l *i2cMock) servoInit() error                                           { return nil }
+func (l *i2cMock) servoUpdateLocation(locationA uint8, locationB uint8) error { return nil }
+func (l *i2cMock) error() error                                               { return nil }

--- a/platforms/digispark/digispark_i2c_test.go
+++ b/platforms/digispark/digispark_i2c_test.go
@@ -28,8 +28,6 @@ func initTestAdaptorI2c() *Adaptor {
 	a := NewAdaptor()
 	a.connect = func(a *Adaptor) (err error) { return nil }
 	a.littleWire = new(i2cMock)
-	errorFunc = func() error { return nil }
-	pwmInitErrorFunc = func() error { return nil }
 	return a
 }
 


### PR DESCRIPTION
will fix #787
additionally:
* split unit tests for i2c
* add unit tests for nearly all functions (e.g. no test for WriteBlockData yet)
 