### PR TITLE
fix helper_test ReadByteData, ReadWordData to use reg

### DIFF
--- a/drivers/i2c/bmp388_driver_test.go
+++ b/drivers/i2c/bmp388_driver_test.go
@@ -84,16 +84,18 @@ func TestBMP388DriverMeasurements(t *testing.T) {
 	bmp388, adaptor := initTestBMP388DriverWithStubbedAdaptor()
 	adaptor.i2cReadImpl = func(b []byte) (int, error) {
 		buf := new(bytes.Buffer)
-		if len(adaptor.written) == 0 {
+		lastWritten := adaptor.written[len(adaptor.written)-1]
+		switch lastWritten {
+		case bmp388RegisterChipID:
 			// Simulate returning of 0x50 for the
 			// ReadByteData(bmp388RegisterChipID) call in initialisation()
 			binary.Write(buf, binary.LittleEndian, uint8(0x50))
-		} else if adaptor.written[len(adaptor.written)-1] == bmp388RegisterCalib00 {
+		case bmp388RegisterCalib00:
 			// Values produced by dumping data from actual sensor
 			buf.Write([]byte{36, 107, 156, 73, 246, 104, 255, 189, 245, 35, 0, 151, 101, 184, 122, 243, 246, 211, 64, 14, 196, 0, 0, 0})
-		} else if adaptor.written[len(adaptor.written)-1] == bmp388RegisterTempData {
+		case bmp388RegisterTempData:
 			buf.Write([]byte{0, 28, 127})
-		} else if adaptor.written[len(adaptor.written)-1] == bmp388RegisterPressureData {
+		case bmp388RegisterPressureData:
 			buf.Write([]byte{0, 66, 113})
 		}
 

--- a/drivers/i2c/drv2605l_driver_test.go
+++ b/drivers/i2c/drv2605l_driver_test.go
@@ -61,11 +61,16 @@ func TestDRVD2605DriverStartReadError(t *testing.T) {
 }
 
 func TestDRV2605LDriverHalt(t *testing.T) {
+	writeStopPlaybackData := []byte{drv2605RegGo, 0}
+	// single-byte-read starts with a write operation to set the register for reading
+	// see section 8.5.3.5 of data sheet
+	readCurrentStandbyModeData := byte(drv2605RegMode)
+	writeNewStandbyModeData := []byte{drv2605RegMode, 42 | drv2605Standby}
 	d, adaptor := initTestDriverAndAdaptor()
 	gobottest.Assert(t, d.Start(), nil)
 	adaptor.written = []byte{}
 	gobottest.Assert(t, d.Halt(), nil)
-	gobottest.Assert(t, adaptor.written, []byte{drv2605RegGo, 0, drv2605RegMode, 42 | drv2605Standby})
+	gobottest.Assert(t, adaptor.written, append(append(writeStopPlaybackData, readCurrentStandbyModeData), writeNewStandbyModeData...))
 }
 
 func TestDRVD2605DriverHaltWriteError(t *testing.T) {

--- a/drivers/i2c/helpers_test.go
+++ b/drivers/i2c/helpers_test.go
@@ -80,6 +80,9 @@ func (t *i2cTestAdaptor) ReadByte() (val byte, err error) {
 }
 
 func (t *i2cTestAdaptor) ReadByteData(reg uint8) (val uint8, err error) {
+	if err = t.WriteByte(reg); err != nil {
+		return
+	}
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 	bytes := []byte{0}
@@ -95,6 +98,9 @@ func (t *i2cTestAdaptor) ReadByteData(reg uint8) (val uint8, err error) {
 }
 
 func (t *i2cTestAdaptor) ReadWordData(reg uint8) (val uint16, err error) {
+	if err = t.WriteByte(reg); err != nil {
+		return
+	}
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 	bytes := []byte{0, 0}


### PR DESCRIPTION
will fix #789 
* fix helper
* fix drv2605l test, see section 8.5.3.5 of data sheet for single-byte-read
* fix bmp388 test, see section 5.2.2 of data sheet for i2c read