### PR TITLE
fix tinkerboard i2c0 to i2c4, improve comments in pin map, improve RE…

### DIFF
--- a/platforms/tinkerboard/README.md
+++ b/platforms/tinkerboard/README.md
@@ -6,7 +6,7 @@ For more info about the Tinker Board, go to [https://www.asus.com/uk/Single-Boar
 
 ## How to Install
 
-We recommend updating to the latest Debian TinkerOS when using the Tinker Board.
+We recommend updating to the [latest Debian TinkerOS](https://github.com/TinkerBoard/debian_kernel/releases) when using the Tinker Board.
 
 You would normally install Go and Gobot on your workstation. Once installed, cross compile your program on your workstation, transfer the final executable to your Tinker Board, and run the program on the Tinker Board as documented here.
 
@@ -18,10 +18,10 @@ go get -d -u gobot.io/x/gobot/...
 
 To enable use of the Tinker Board GPIO pins, you need to perform the following steps as a one-time configuration. Once your Tinker Board has been configured, you do not need to do so again.
 
-Note that these configuration steps must be performed on the Tinker Board itself. The easiest is to login to the Tinker Board via SSH:
+Note that these configuration steps must be performed on the Tinker Board itself. The easiest is to login to the Tinker Board via SSH (option "-4" is used to force IPv4, which is needed for some versions of TinkerOS):
 
 ```
-ssh linaro@192.168.1.xxx
+ssh -4 linaro@192.168.1.xxx
 ```
 
 #### Create a group "gpio"

--- a/platforms/tinkerboard/adaptor.go
+++ b/platforms/tinkerboard/adaptor.go
@@ -22,7 +22,7 @@ type Adaptor struct {
 	pinmap      map[string]sysfsPin
 	digitalPins map[int]*sysfs.DigitalPin
 	pwmPins     map[int]*sysfs.PWMPin
-	i2cBuses    [2]i2c.I2cDevice
+	i2cBuses    [5]i2c.I2cDevice
 	mutex       *sync.Mutex
 }
 
@@ -195,12 +195,13 @@ func (c *Adaptor) PWMPin(pin string) (sysfsPin sysfs.PWMPinner, err error) {
 }
 
 // GetConnection returns a connection to a device on a specified bus.
-// Valid bus number is [0..1] which corresponds to /dev/i2c-0 through /dev/i2c-1.
+// Valid bus number is [0..4] which corresponds to /dev/i2c-0 through /dev/i2c-4.
+// We don't support "/dev/i2c-6 DesignWare HDMI".
 func (c *Adaptor) GetConnection(address int, bus int) (connection i2c.Connection, err error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	if (bus < 0) || (bus > 1) {
+	if (bus < 0) || (bus > 4) {
 		return nil, fmt.Errorf("Bus number %d out of range", bus)
 	}
 	if c.i2cBuses[bus] == nil {

--- a/platforms/tinkerboard/pin_map.go
+++ b/platforms/tinkerboard/pin_map.go
@@ -2,43 +2,43 @@ package tinkerboard
 
 var fixedPins = map[string]sysfsPin{
 	"7": {
-		pin:    17, // GPIO0_C1
+		pin:    17, // GPIO0_C1_CLKOUT
 		pwmPin: -1,
 	},
 	"10": {
-		pin:    160, // GPIO5_B0
+		pin:    160, // GPIO5_B0_UART1RX
 		pwmPin: -1,
 	},
 	"8": {
-		pin:    161, // GPIO5_B1
+		pin:    161, // GPIO5_B1_UART1TX
 		pwmPin: -1,
 	},
 	"16": {
-		pin:    162, // GPIO5_B2
+		pin:    162, // GPIO5_B2_UART1CTSN
 		pwmPin: -1,
 	},
 	"18": {
-		pin:    163, // GPIO5_B3
+		pin:    163, // GPIO5_B3_UART1RTSN
 		pwmPin: -1,
 	},
 	"11": {
-		pin:    164, // GPIO5_B4
+		pin:    164, // GPIO5_B4_SPI0CLK_UART4CTSN
 		pwmPin: -1,
 	},
 	"29": {
-		pin:    165, // GPIO5_B5
+		pin:    165, // GPIO5_B5_SPI0CSN_UART4RTSN
 		pwmPin: -1,
 	},
 	"13": {
-		pin:    166, // GPIO5_B6
+		pin:    166, // GPIO5_B6_SPI0_TXD_UART4TX
 		pwmPin: -1,
 	},
 	"15": {
-		pin:    167, // GPIO5_B7
+		pin:    167, // GPIO5_B7_SPI0_RXD_UART4RX
 		pwmPin: -1,
 	},
 	"31": {
-		pin:    168, // GPIO5_C0
+		pin:    168, // GPIO5_C0_SPI0CSN1
 		pwmPin: -1,
 	},
 	"22": {
@@ -46,71 +46,71 @@ var fixedPins = map[string]sysfsPin{
 		pwmPin: -1,
 	},
 	"12": {
-		pin:    184, // GPIO5_A0
+		pin:    184, // GPIO6_A0_PCM/I2S_CLK
 		pwmPin: -1,
 	},
 	"35": {
-		pin:    185, // GPIO5_A1
+		pin:    185, // GPIO6_A1_PCM/I2S_FS
 		pwmPin: -1,
 	},
 	"38": {
-		pin:    187, // GPIO5_A3
+		pin:    187, // GPIO6_A3_PCM/I2S_SDI
 		pwmPin: -1,
 	},
 	"40": {
-		pin:    188, // GPIO5_A4
+		pin:    188, // GPIO6_A4_PCM/I2S_SDO
 		pwmPin: -1,
 	},
 	"36": {
-		pin:    223, // GPIO5_A7
+		pin:    223, // GPIO7_A7_UART3RX
 		pwmPin: -1,
 	},
 	"37": {
-		pin:    224, // GPIO5_B0
+		pin:    224, // GPIO7_B0_UART3TX
 		pwmPin: -1,
 	},
 	"27": {
-		pin:    233, // GPIO5_C1
+		pin:    233, // GPIO7_C1_I2C4_SDA
 		pwmPin: -1,
 	},
 	"28": {
-		pin:    234, // GPIO5_C2
+		pin:    234, // GPIO7_C2_I2C_SCL
 		pwmPin: -1,
 	},
 	"33": {
-		pin:    238, // GPIO5_C6
+		pin:    238, // GPIO7_C6_UART2RX_PWM2
 		pwmPin: 0,
 	},
 	"32": {
-		pin:    239, // GPIO5_C7
+		pin:    239, // GPIO7_C7_UART2TX_PWM3
 		pwmPin: 1,
 	},
 	"26": {
-		pin:    251, // GPIO5_A3
+		pin:    251, // GPIO8_A3_SPI2CSN1
 		pwmPin: -1,
 	},
 	"3": {
-		pin:    252, // GPIO5_A4
+		pin:    252, // GPIO8_A4_I2C1_SDA
 		pwmPin: -1,
 	},
 	"5": {
-		pin:    253, // GPIO5_A3
+		pin:    253, // GPIO8_A5_I2C1_SCL
 		pwmPin: -1,
 	},
 	"23": {
-		pin:    254, // GPIO5_A6
+		pin:    254, // GPIO8_A6_SPI2CLK
 		pwmPin: -1,
 	},
 	"24": {
-		pin:    255, // GPIO5_A7
+		pin:    255, // GPIO8_A7_SPI2CSN0
 		pwmPin: -1,
 	},
 	"21": {
-		pin:    256, // GPIO5_B0
+		pin:    256, // GPIO8_B0_SPI2RXD
 		pwmPin: -1,
 	},
 	"19": {
-		pin:    257, // GPIO5_B1
+		pin:    257, // GPIO8_B1_SPI2TXD
 		pwmPin: -1,
 	},
 }


### PR DESCRIPTION
will fix #795 

* fix the issue by allow I2C0 - I2C4
* improve/fix comments in pin map, e.g. refer to https://wiki.52pi.com/index.php/ASUS_Tinker_Board_SKU:_EZ-0066
* improve README according to latest TinkerOS