### PR TITLE
MCP3004: correct number of channels

### DIFF
--- a/drivers/spi/mcp3004.go
+++ b/drivers/spi/mcp3004.go
@@ -8,7 +8,7 @@ import (
 )
 
 // MCP3004DriverMaxChannel is the number of channels of this A/D converter.
-const MCP3004DriverMaxChannel = 3
+const MCP3004DriverMaxChannel = 4
 
 // MCP3004Driver is a driver for the MCP3008 A/D converter.
 type MCP3004Driver struct {


### PR DESCRIPTION
the MCP3004 has 4 channels, not 3.

Fixes: b0160105("spi: Add MCP3202, MCP3204, MCP3208, and MCP3304
drivers")

Signed-off-by: Tim Froidcoeur <tim.froidcoeur@gmail.com>