### PR TITLE
Bugfix/mcp23017 pullup polarity

### DIFF
--- a/drivers/i2c/helpers_test.go
+++ b/drivers/i2c/helpers_test.go
@@ -175,8 +175,8 @@ func (t *i2cTestAdaptor) Finalize() (err error) { return }
 func newI2cTestAdaptor() *i2cTestAdaptor {
 	return &i2cTestAdaptor{
 		i2cConnectErr: false,
-		i2cReadImpl: func([]byte) (int, error) {
-			return 0, nil
+		i2cReadImpl: func(b []byte) (int, error) {
+			return len(b), nil
 		},
 		i2cWriteImpl: func([]byte) (int, error) {
 			return 0, nil

--- a/drivers/i2c/i2c.go
+++ b/drivers/i2c/i2c.go
@@ -26,6 +26,13 @@ var (
 	ErrInvalidPosition = errors.New("Invalid position value")
 )
 
+type bitState uint8
+
+const (
+	clear bitState = 0x00
+	set            = 0x01
+)
+
 type I2cOperations interface {
 	io.ReadWriteCloser
 	ReadByte() (val byte, err error)
@@ -181,4 +188,17 @@ func (c *i2cConnection) WriteBlockData(reg uint8, b []byte) (err error) {
 		return err
 	}
 	return c.bus.WriteBlockData(reg, b)
+}
+
+// setBit is used to set a bit at a given position to 1.
+func setBit(n uint8, pos uint8) uint8 {
+	n |= (1 << pos)
+	return n
+}
+
+// clearBit is used to set a bit at a given position to 0.
+func clearBit(n uint8, pos uint8) uint8 {
+	mask := ^uint8(1 << pos)
+	n &= mask
+	return n
 }

--- a/drivers/i2c/i2c_test.go
+++ b/drivers/i2c/i2c_test.go
@@ -173,3 +173,15 @@ func TestI2CWriteBlockDataAddressError(t *testing.T) {
 	err := c.WriteBlockData(0x01, []byte{0x01, 0x02})
 	gobottest.Assert(t, err, errors.New("Setting address failed with syscall.Errno operation not permitted"))
 }
+
+func Test_setBit(t *testing.T) {
+	var expectedVal uint8 = 129
+	actualVal := setBit(1, 7)
+	gobottest.Assert(t, expectedVal, actualVal)
+}
+
+func Test_clearBit(t *testing.T) {
+	var expectedVal uint8
+	actualVal := clearBit(128, 7)
+	gobottest.Assert(t, expectedVal, actualVal)
+}

--- a/drivers/i2c/mcp23017_driver.go
+++ b/drivers/i2c/mcp23017_driver.go
@@ -227,13 +227,8 @@ func (m *MCP23017Driver) WriteGPIO(pin uint8, val uint8, portStr string) (err er
 	if err != nil {
 		return err
 	}
-	// set or clear iodir value, a 1 sets the pin as an input, 0 as an output
-	var iodirVal uint8
-	if val == 1 {
-		iodirVal = clearBit(iodir, uint8(pin))
-	} else {
-		iodirVal = setBit(iodir, uint8(pin))
-	}
+	// set pin as output by clearing bit
+	iodirVal := clearBit(iodir, uint8(pin))
 	// write IODIR register bit
 	err = m.write(selectedPort.IODIR, uint8(pin), uint8(iodirVal))
 	if err != nil {
@@ -263,6 +258,18 @@ func (m *MCP23017Driver) WriteGPIO(pin uint8, val uint8, portStr string) (err er
 // port (A or B).
 func (m *MCP23017Driver) ReadGPIO(pin uint8, portStr string) (val uint8, err error) {
 	selectedPort := m.getPort(portStr)
+	// read current value of IODIR register
+	iodir, err := m.read(selectedPort.IODIR)
+	if err != nil {
+		return 0, err
+	}
+	// set pin as input by setting bit
+	iodirVal := setBit(iodir, uint8(pin))
+	// write IODIR register bit
+	err = m.write(selectedPort.IODIR, uint8(pin), uint8(iodirVal))
+	if err != nil {
+		return 0, err
+	}
 	val, err = m.read(selectedPort.GPIO)
 	if err != nil {
 		return val, err

--- a/drivers/i2c/mcp23017_driver.go
+++ b/drivers/i2c/mcp23017_driver.go
@@ -1,38 +1,50 @@
+/*
+Copyright (c) 2015 Ulises Flynn
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package i2c
 
 import (
+	"fmt"
 	"log"
 	"strings"
 
 	"gobot.io/x/gobot"
 )
 
-const (
-	// default address for device when a2/a1/a0 pins are all tied to ground
-	mcp23017Address = 0x20
-)
+const mcp23017Address = 0x20
 
-var (
-	debug = false // toggle debugging information
-)
+var debug = false // Set this to true to see debugging information
 
-// port contains all the registers for the device.
+// Port contains all the registers for the device.
 type port struct {
 	IODIR   uint8 // I/O direction register: 0=output / 1=input
-	IPOL    uint8 // input polarity register: 0=normal polarity / 1=inversed
-	GPINTEN uint8 // interrupt on change control register: 0=disabled / 1=enabled
-	DEFVAL  uint8 // default compare register for interrupt on change
-	INTCON  uint8 // interrupt control register: bit set to 0= use defval bit value to compare pin value/ bit set to 1= pin value compared to previous pin value
-	IOCON   uint8 // configuration register
-	GPPU    uint8 // pull-up resistor configuration register: 0=enabled / 1=disabled
-	INTF    uint8 // interrupt flag register: 0=no interrupt / 1=pin caused interrupt
-	INTCAP  uint8 // interrupt capture register, captures pin values during interrupt: 0=logic low / 1=logic high
-	GPIO    uint8 // port register, reading from this register reads the port
-	OLAT    uint8 // output latch register, write modifies the pins: 0=logic low / 1=logic high
+	IPOL    uint8 // Input polarity register: 0=normal polarity / 1=inversed
+	GPINTEN uint8 // Interrupt on change control register: 0=disabled / 1=enabled
+	DEFVAL  uint8 // Default compare register for interrupt on change
+	INTCON  uint8 // Interrupt control register: bit set to 0= use defval bit value to compare pin value/ bit set to 1= pin value compared to previous pin value
+	IOCON   uint8 // Configuration register
+	GPPU    uint8 // Pull-up resistor configuration register: 0=enabled / 1=disabled
+	INTF    uint8 // Interrupt flag register: 0=no interrupt / 1=pin caused interrupt
+	INTCAP  uint8 // Interrupt capture register, captures pin values during interrupt: 0=logic low / 1=logic high
+	GPIO    uint8 // Port register, reading from this register reads the port
+	OLAT    uint8 // Output latch register, write modifies the pins: 0=logic low / 1=logic high
 }
 
-// A bank is made up of PortA and PortB pins.
-// Port B pins are on the left side of the chip (starting with pin 1), while port A pins are on the right side.
+// Registers in the MCP23017 have different address based on which bank is used.
+// Each bank is made up of PortA and PortB registers.
 type bank struct {
 	PortA port
 	PortB port
@@ -61,6 +73,136 @@ type MCP23017Driver struct {
 	gobot.Eventer
 }
 
+// NewMCP23017Driver creates a new Gobot Driver to the MCP23017 i2c port expander.
+// Params:
+//		conn Connector - the Adaptor to use with this Driver
+//
+// Optional params:
+//		i2c.WithBus(int):	bus to use with this driver
+//		i2c.WithAddress(int):	address to use with this driver
+//		i2c.WithMCP23017Bank(int):	MCP23017 bank to use with this driver
+//		i2c.WithMCP23017Mirror(int):	MCP23017 mirror to use with this driver
+//		i2c.WithMCP23017Seqop(int):	MCP23017 seqop to use with this driver
+//		i2c.WithMCP23017Disslw(int):	MCP23017 disslw to use with this driver
+//		i2c.WithMCP23017Haen(int):	MCP23017 haen to use with this driver
+//		i2c.WithMCP23017Odr(int):	MCP23017 odr to use with this driver
+//		i2c.WithMCP23017Intpol(int):	MCP23017 intpol to use with this driver
+//
+func NewMCP23017Driver(a Connector, options ...func(Config)) *MCP23017Driver {
+	m := &MCP23017Driver{
+		name:      gobot.DefaultName("MCP23017"),
+		connector: a,
+		Config:    NewConfig(),
+		MCPConf:   MCP23017Config{},
+		Commander: gobot.NewCommander(),
+		Eventer:   gobot.NewEventer(),
+	}
+
+	for _, option := range options {
+		option(m)
+	}
+
+	m.AddCommand("WriteGPIO", func(params map[string]interface{}) interface{} {
+		pin := params["pin"].(uint8)
+		val := params["val"].(uint8)
+		port := params["port"].(string)
+		err := m.WriteGPIO(pin, val, port)
+		return map[string]interface{}{"err": err}
+	})
+
+	m.AddCommand("ReadGPIO", func(params map[string]interface{}) interface{} {
+		pin := params["pin"].(uint8)
+		port := params["port"].(string)
+		val, err := m.ReadGPIO(pin, port)
+		return map[string]interface{}{"val": val, "err": err}
+	})
+
+	return m
+}
+
+// Name return the driver name.
+func (m *MCP23017Driver) Name() string { return m.name }
+
+// SetName set the driver name.
+func (m *MCP23017Driver) SetName(n string) { m.name = n }
+
+// Connection returns the I2c connection.
+func (m *MCP23017Driver) Connection() gobot.Connection { return m.connector.(gobot.Connection) }
+
+// Halt stops the driver.
+func (m *MCP23017Driver) Halt() (err error) { return }
+
+// Start writes the device configuration.
+func (m *MCP23017Driver) Start() (err error) {
+	bus := m.GetBusOrDefault(m.connector.GetDefaultBus())
+	address := m.GetAddressOrDefault(mcp23017Address)
+
+	m.connection, err = m.connector.GetConnection(address, bus)
+	if err != nil {
+		return err
+	}
+	// Set IOCON register with MCP23017 configuration.
+	ioconReg := m.getPort("A").IOCON // IOCON address is the same for Port A or B.
+	ioconVal := m.MCPConf.GetUint8Value()
+	if _, err := m.connection.Write([]uint8{ioconReg, ioconVal}); err != nil {
+		return err
+	}
+	return
+}
+
+// WriteGPIO writes a value to a gpio pin (0-7) and a port (A or B).
+func (m *MCP23017Driver) WriteGPIO(pin uint8, val uint8, portStr string) (err error) {
+	selectedPort := m.getPort(portStr)
+	// Set IODIR register bit for given pin to an output.
+	if err := m.write(selectedPort.IODIR, uint8(pin), 0); err != nil {
+		return err
+	}
+	// Set OLAT register to write a value to the given pin.
+	if err := m.write(selectedPort.OLAT, uint8(pin), uint8(val)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// PinMode set pin mode
+// val (0 output 1 input)
+// port (A or B).
+func (m *MCP23017Driver) PinMode(pin, val uint8, portStr string) (err error) {
+	selectedPort := m.getPort(portStr)
+	// Set IODIR register bit for given pin to an output/input.
+	if err = m.write(selectedPort.IODIR, uint8(pin), val); err != nil {
+		return
+	}
+	return
+}
+
+// ReadGPIO reads a value from a given gpio pin (0-7) and a
+// port (A or B).
+func (m *MCP23017Driver) ReadGPIO(pin uint8, portStr string) (val uint8, err error) {
+	selectedPort := m.getPort(portStr)
+	val, err = m.read(selectedPort.GPIO)
+	if err != nil {
+		return val, err
+	}
+	return (1 << uint8(pin) & val), nil
+}
+
+// SetPullUp sets the pull up state of a given pin based on the value:
+// val = 1 pull up enabled.
+// val = 0 pull up disabled.
+func (m *MCP23017Driver) SetPullUp(pin uint8, val uint8, portStr string) error {
+	selectedPort := m.getPort(portStr)
+	return m.write(selectedPort.GPPU, pin, val)
+}
+
+// SetGPIOPolarity will change a given pin's polarity based on the value:
+// val = 1 opposite logic state of the input pin.
+// val = 0 same logic state of the input pin.
+func (m *MCP23017Driver) SetGPIOPolarity(pin uint8, val uint8, portStr string) (err error) {
+	selectedPort := m.getPort(portStr)
+	return m.write(selectedPort.IPOL, pin, val)
+}
+
 // WithMCP23017Bank option sets the MCP23017Driver bank option
 func WithMCP23017Bank(val uint8) func(Config) {
 	return func(c Config) {
@@ -68,7 +210,7 @@ func WithMCP23017Bank(val uint8) func(Config) {
 		if ok {
 			d.MCPConf.Bank = val
 		} else {
-			panic("trying to set bank for non-MCP23017Driver")
+			panic("Trying to set Bank for non-MCP23017Driver")
 		}
 	}
 }
@@ -145,191 +287,47 @@ func WithMCP23017Intpol(val uint8) func(Config) {
 	}
 }
 
-// NewMCP23017Driver creates a new Gobot Driver to the MCP23017 i2c port expander.
-// Params:
-//		conn Connector - the Adaptor to use with this Driver
-//
-// Optional params:
-//		i2c.WithBus(int):	bus to use with this driver
-//		i2c.WithAddress(int):	address to use with this driver
-//		i2c.WithMCP23017Bank(int):	MCP23017 bank to use with this driver
-//		i2c.WithMCP23017Mirror(int):	MCP23017 mirror to use with this driver
-//		i2c.WithMCP23017Seqop(int):	MCP23017 seqop to use with this driver
-//		i2c.WithMCP23017Disslw(int):	MCP23017 disslw to use with this driver
-//		i2c.WithMCP23017Haen(int):	MCP23017 haen to use with this driver
-//		i2c.WithMCP23017Odr(int):	MCP23017 odr to use with this driver
-//		i2c.WithMCP23017Intpol(int):	MCP23017 intpol to use with this driver
-//
-func NewMCP23017Driver(a Connector, options ...func(Config)) *MCP23017Driver {
-	m := &MCP23017Driver{
-		name:      gobot.DefaultName("MCP23017"),
-		connector: a,
-		Config:    NewConfig(),
-		MCPConf:   MCP23017Config{},
-		Commander: gobot.NewCommander(),
-		Eventer:   gobot.NewEventer(),
-	}
-
-	for _, option := range options {
-		option(m)
-	}
-
-	m.AddCommand("WriteGPIO", func(params map[string]interface{}) interface{} {
-		pin := params["pin"].(uint8)
-		val := params["val"].(uint8)
-		port := params["port"].(string)
-		err := m.WriteGPIO(pin, val, port)
-		return map[string]interface{}{"err": err}
-	})
-
-	m.AddCommand("ReadGPIO", func(params map[string]interface{}) interface{} {
-		pin := params["pin"].(uint8)
-		port := params["port"].(string)
-		val, err := m.ReadGPIO(pin, port)
-		return map[string]interface{}{"val": val, "err": err}
-	})
-
-	return m
-}
-
-// Name return the driver name.
-func (m *MCP23017Driver) Name() string { return m.name }
-
-// SetName set the driver name.
-func (m *MCP23017Driver) SetName(n string) { m.name = n }
-
-// Connection returns the I2c connection.
-func (m *MCP23017Driver) Connection() gobot.Connection { return m.connector.(gobot.Connection) }
-
-// Halt stops the driver.
-func (m *MCP23017Driver) Halt() (err error) { return }
-
-// Start writes the device configuration.
-func (m *MCP23017Driver) Start() (err error) {
-	bus := m.GetBusOrDefault(m.connector.GetDefaultBus())
-	address := m.GetAddressOrDefault(mcp23017Address)
-
-	m.connection, err = m.connector.GetConnection(address, bus)
-	if err != nil {
-		return err
-	}
-	// Set IOCON register with MCP23017 configuration.
-	ioconReg := m.getPort("A").IOCON // IOCON address is the same for Port A or B.
-	ioconVal := m.MCPConf.getUint8Value()
-	if _, err := m.connection.Write([]uint8{ioconReg, ioconVal}); err != nil {
-		return err
-	}
-	return
-}
-
-// WriteGPIO writes a value to a gpio pin (0-7) and a port (A or B).
-func (m *MCP23017Driver) WriteGPIO(pin uint8, val uint8, portStr string) (err error) {
-	selectedPort := m.getPort(portStr)
-	// read current value of IODIR register
-	iodir, err := m.read(selectedPort.IODIR)
-	if err != nil {
-		return err
-	}
-	// set pin as output by clearing bit
-	iodirVal := clearBit(iodir, uint8(pin))
-	// write IODIR register bit
-	err = m.write(selectedPort.IODIR, uint8(pin), uint8(iodirVal))
-	if err != nil {
-		return err
-	}
-	// read current value of OLAT register
-	olat, err := m.read(selectedPort.OLAT)
-	if err != nil {
-		return err
-	}
-	// set or clear olat value, 0 is no output, 1 is an output
-	var olatVal uint8
-	if val == 0 {
-		olatVal = clearBit(olat, uint8(pin))
-	} else {
-		olatVal = setBit(olat, uint8(pin))
-	}
-	// write OLAT register bit
-	err = m.write(selectedPort.OLAT, uint8(pin), uint8(olatVal))
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// ReadGPIO reads a value from a given gpio pin (0-7) and a
-// port (A or B).
-func (m *MCP23017Driver) ReadGPIO(pin uint8, portStr string) (val uint8, err error) {
-	selectedPort := m.getPort(portStr)
-	// read current value of IODIR register
-	iodir, err := m.read(selectedPort.IODIR)
-	if err != nil {
-		return 0, err
-	}
-	// set pin as input by setting bit
-	iodirVal := setBit(iodir, uint8(pin))
-	// write IODIR register bit
-	err = m.write(selectedPort.IODIR, uint8(pin), uint8(iodirVal))
-	if err != nil {
-		return 0, err
-	}
-	val, err = m.read(selectedPort.GPIO)
-	if err != nil {
-		return val, err
-	}
-	val = 1 << uint8(pin) & val
-	if val > 1 {
-		val = 1
-	}
-	return val, nil
-}
-
-// SetPullUp sets the pull up state of a given pin based on the value:
-// val = 1 pull up enabled.
-// val = 0 pull up disabled.
-func (m *MCP23017Driver) SetPullUp(pin uint8, val uint8, portStr string) error {
-	selectedPort := m.getPort(portStr)
-	return m.write(selectedPort.GPPU, pin, val)
-}
-
-// SetGPIOPolarity will change a given pin's polarity based on the value:
-// val = 1 opposite logic state of the input pin.
-// val = 0 same logic state of the input pin.
-func (m *MCP23017Driver) SetGPIOPolarity(pin uint8, val uint8, portStr string) (err error) {
-	selectedPort := m.getPort(portStr)
-	return m.write(selectedPort.IPOL, pin, val)
-}
-
 // write gets the value of the passed in register, and then overwrites
 // the bit specified by the pin, with the given value.
 func (m *MCP23017Driver) write(reg uint8, pin uint8, val uint8) (err error) {
-	if debug {
-		log.Printf("write: MCP address: 0x%X, register:0x%X,value: 0x%X\n", m.GetAddressOrDefault(mcp23017Address), reg, val)
+	var ioval uint8
+	iodir, err := m.read(reg)
+	if err != nil {
+		return err
 	}
-	if _, err = m.connection.Write([]uint8{reg, val}); err != nil {
+	if val == 0 {
+		ioval = clearBit(iodir, uint8(pin))
+	} else if val == 1 {
+		ioval = setBit(iodir, uint8(pin))
+	}
+	if debug {
+		log.Printf("Writing: MCP address: 0x%X, register: 0x%X\t, value: 0x%X\n", m.GetAddressOrDefault(mcp23017Address), reg, ioval)
+	}
+	if _, err = m.connection.Write([]uint8{reg, ioval}); err != nil {
 		return err
 	}
 	return nil
 }
 
-// read get the data from a given register
+// read get the data from a given register. The I2cRead does not read a specific
+// register from the device, rather it will read n bytes starting at the base
+// device address. To read a specific register, read register + 1 bytes, and then index
+// the result with the given register to get the value.
 func (m *MCP23017Driver) read(reg uint8) (val uint8, err error) {
-	buf := []byte{0}
-	if _, err := m.connection.Write([]uint8{reg}); err != nil {
-		return val, err
-	}
+	register := int(reg)
+	bytesToRead := register + 1
+	buf := make([]byte, bytesToRead)
 	bytesRead, err := m.connection.Read(buf)
 	if err != nil {
 		return val, err
 	}
-	if bytesRead != 1 {
-		err = ErrNotEnoughBytes
-		return
+	if bytesRead != bytesToRead {
+		return val, fmt.Errorf("Read was unable to get %d bytes for register: 0x%X\n", bytesToRead, reg)
 	}
 	if debug {
-		log.Printf("reading: MCP address: 0x%X, register:0x%X,value: 0x%X\n", m.GetAddressOrDefault(mcp23017Address), reg, buf)
+		log.Printf("Reading: MCP address: 0x%X, register:0x%X\t,value: 0x%X\n", m.GetAddressOrDefault(mcp23017Address), reg, buf[register])
 	}
-	return buf[0], nil
+	return buf[register], nil
 }
 
 // getPort return the port (A or B) given a string and the bank.
@@ -346,8 +344,8 @@ func (m *MCP23017Driver) getPort(portStr string) (selectedPort port) {
 	}
 }
 
-// getUint8Value returns the configuration data as a packed value.
-func (mc *MCP23017Config) getUint8Value() uint8 {
+// GetUint8Value returns the configuration data as a packed value.
+func (mc *MCP23017Config) GetUint8Value() uint8 {
 	return mc.Bank<<7 | mc.Mirror<<6 | mc.Seqop<<5 | mc.Disslw<<4 | mc.Haen<<3 | mc.Odr<<2 | mc.Intpol<<1
 }
 

--- a/drivers/i2c/mcp23017_driver.go
+++ b/drivers/i2c/mcp23017_driver.go
@@ -12,7 +12,7 @@ import (
 // please consider special handling for MCP23S17
 const mcp23017Address = 0x20
 
-const mcp23017Debug = true // toggle debugging information
+const mcp23017Debug = false // toggle debugging information
 
 // port contains all the registers for the device.
 type port struct {

--- a/drivers/i2c/mcp23017_driver.go
+++ b/drivers/i2c/mcp23017_driver.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) 2015 Ulises Flynn
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package i2c
 
 import (
@@ -71,6 +55,90 @@ type MCP23017Driver struct {
 	MCPConf MCP23017Config
 	gobot.Commander
 	gobot.Eventer
+}
+
+// WithMCP23017Bank option sets the MCP23017Driver bank option
+func WithMCP23017Bank(val uint8) func(Config) {
+	return func(c Config) {
+		d, ok := c.(*MCP23017Driver)
+		if ok {
+			d.MCPConf.Bank = val
+		} else {
+			panic("Trying to set Bank for non-MCP23017Driver")
+		}
+	}
+}
+
+// WithMCP23017Mirror option sets the MCP23017Driver Mirror option
+func WithMCP23017Mirror(val uint8) func(Config) {
+	return func(c Config) {
+		d, ok := c.(*MCP23017Driver)
+		if ok {
+			d.MCPConf.Mirror = val
+		} else {
+			panic("Trying to set Mirror for non-MCP23017Driver")
+		}
+	}
+}
+
+// WithMCP23017Seqop option sets the MCP23017Driver Seqop option
+func WithMCP23017Seqop(val uint8) func(Config) {
+	return func(c Config) {
+		d, ok := c.(*MCP23017Driver)
+		if ok {
+			d.MCPConf.Seqop = val
+		} else {
+			panic("Trying to set Seqop for non-MCP23017Driver")
+		}
+	}
+}
+
+// WithMCP23017Disslw option sets the MCP23017Driver Disslw option
+func WithMCP23017Disslw(val uint8) func(Config) {
+	return func(c Config) {
+		d, ok := c.(*MCP23017Driver)
+		if ok {
+			d.MCPConf.Disslw = val
+		} else {
+			panic("Trying to set Disslw for non-MCP23017Driver")
+		}
+	}
+}
+
+// WithMCP23017Haen option sets the MCP23017Driver Haen option
+func WithMCP23017Haen(val uint8) func(Config) {
+	return func(c Config) {
+		d, ok := c.(*MCP23017Driver)
+		if ok {
+			d.MCPConf.Haen = val
+		} else {
+			panic("Trying to set Haen for non-MCP23017Driver")
+		}
+	}
+}
+
+// WithMCP23017Odr option sets the MCP23017Driver Odr option
+func WithMCP23017Odr(val uint8) func(Config) {
+	return func(c Config) {
+		d, ok := c.(*MCP23017Driver)
+		if ok {
+			d.MCPConf.Odr = val
+		} else {
+			panic("Trying to set Odr for non-MCP23017Driver")
+		}
+	}
+}
+
+// WithMCP23017Intpol option sets the MCP23017Driver Intpol option
+func WithMCP23017Intpol(val uint8) func(Config) {
+	return func(c Config) {
+		d, ok := c.(*MCP23017Driver)
+		if ok {
+			d.MCPConf.Intpol = val
+		} else {
+			panic("Trying to set Intpol for non-MCP23017Driver")
+		}
+	}
 }
 
 // NewMCP23017Driver creates a new Gobot Driver to the MCP23017 i2c port expander.
@@ -164,18 +232,6 @@ func (m *MCP23017Driver) WriteGPIO(pin uint8, val uint8, portStr string) (err er
 	return nil
 }
 
-// PinMode set pin mode
-// val (0 output 1 input)
-// port (A or B).
-func (m *MCP23017Driver) PinMode(pin, val uint8, portStr string) (err error) {
-	selectedPort := m.getPort(portStr)
-	// Set IODIR register bit for given pin to an output/input.
-	if err = m.write(selectedPort.IODIR, uint8(pin), val); err != nil {
-		return
-	}
-	return
-}
-
 // ReadGPIO reads a value from a given gpio pin (0-7) and a
 // port (A or B).
 func (m *MCP23017Driver) ReadGPIO(pin uint8, portStr string) (val uint8, err error) {
@@ -203,88 +259,16 @@ func (m *MCP23017Driver) SetGPIOPolarity(pin uint8, val uint8, portStr string) (
 	return m.write(selectedPort.IPOL, pin, val)
 }
 
-// WithMCP23017Bank option sets the MCP23017Driver bank option
-func WithMCP23017Bank(val uint8) func(Config) {
-	return func(c Config) {
-		d, ok := c.(*MCP23017Driver)
-		if ok {
-			d.MCPConf.Bank = val
-		} else {
-			panic("Trying to set Bank for non-MCP23017Driver")
-		}
+// PinMode set pin mode
+// val (0 output 1 input)
+// port (A or B).
+func (m *MCP23017Driver) PinMode(pin, val uint8, portStr string) (err error) {
+	selectedPort := m.getPort(portStr)
+	// Set IODIR register bit for given pin to an output/input.
+	if err = m.write(selectedPort.IODIR, uint8(pin), val); err != nil {
+		return
 	}
-}
-
-// WithMCP23017Mirror option sets the MCP23017Driver Mirror option
-func WithMCP23017Mirror(val uint8) func(Config) {
-	return func(c Config) {
-		d, ok := c.(*MCP23017Driver)
-		if ok {
-			d.MCPConf.Mirror = val
-		} else {
-			panic("Trying to set Mirror for non-MCP23017Driver")
-		}
-	}
-}
-
-// WithMCP23017Seqop option sets the MCP23017Driver Seqop option
-func WithMCP23017Seqop(val uint8) func(Config) {
-	return func(c Config) {
-		d, ok := c.(*MCP23017Driver)
-		if ok {
-			d.MCPConf.Seqop = val
-		} else {
-			panic("Trying to set Seqop for non-MCP23017Driver")
-		}
-	}
-}
-
-// WithMCP23017Disslw option sets the MCP23017Driver Disslw option
-func WithMCP23017Disslw(val uint8) func(Config) {
-	return func(c Config) {
-		d, ok := c.(*MCP23017Driver)
-		if ok {
-			d.MCPConf.Disslw = val
-		} else {
-			panic("Trying to set Disslw for non-MCP23017Driver")
-		}
-	}
-}
-
-// WithMCP23017Haen option sets the MCP23017Driver Haen option
-func WithMCP23017Haen(val uint8) func(Config) {
-	return func(c Config) {
-		d, ok := c.(*MCP23017Driver)
-		if ok {
-			d.MCPConf.Haen = val
-		} else {
-			panic("Trying to set Haen for non-MCP23017Driver")
-		}
-	}
-}
-
-// WithMCP23017Odr option sets the MCP23017Driver Odr option
-func WithMCP23017Odr(val uint8) func(Config) {
-	return func(c Config) {
-		d, ok := c.(*MCP23017Driver)
-		if ok {
-			d.MCPConf.Odr = val
-		} else {
-			panic("Trying to set Odr for non-MCP23017Driver")
-		}
-	}
-}
-
-// WithMCP23017Intpol option sets the MCP23017Driver Intpol option
-func WithMCP23017Intpol(val uint8) func(Config) {
-	return func(c Config) {
-		d, ok := c.(*MCP23017Driver)
-		if ok {
-			d.MCPConf.Intpol = val
-		} else {
-			panic("Trying to set Intpol for non-MCP23017Driver")
-		}
-	}
+	return
 }
 
 // write gets the value of the passed in register, and then overwrites

--- a/drivers/i2c/mcp23017_driver_test.go
+++ b/drivers/i2c/mcp23017_driver_test.go
@@ -84,12 +84,12 @@ func TestNewMCP23017DriverIntpol(t *testing.T) {
 
 func TestNewMCP23017DriverForceRefresh(t *testing.T) {
 	b := NewMCP23017Driver(newI2cTestAdaptor(), WithMCP23017ForceRefresh(1))
-	gobottest.Assert(t, b.mvpBehav.forceRefresh, true)
+	gobottest.Assert(t, b.mcpBehav.forceRefresh, true)
 }
 
 func TestNewMCP23017DriverAutoIODirOff(t *testing.T) {
 	b := NewMCP23017Driver(newI2cTestAdaptor(), WithMCP23017AutoIODirOff(1))
-	gobottest.Assert(t, b.mvpBehav.autoIODirOff, true)
+	gobottest.Assert(t, b.mcpBehav.autoIODirOff, true)
 }
 
 func TestMCP23017DriverStart(t *testing.T) {
@@ -220,7 +220,7 @@ func TestMCP23017DriverWriteGPIONoAutoDir(t *testing.T) {
 	// * write OLAT (manipulate val, write reg, write val)
 	// arrange
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
-	mcp.mvpBehav.autoIODirOff = true
+	mcp.mcpBehav.autoIODirOff = true
 	for bitState := 0; bitState <= 1; bitState++ {
 		adaptor.written = []byte{} // reset writes of Start() and former test
 		// arrange some values
@@ -362,7 +362,7 @@ func TestMCP23017DriverReadGPIONoAutoDir(t *testing.T) {
 	// * read GPIO (write reg, read val)
 	// arrange
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
-	mcp.mvpBehav.autoIODirOff = true
+	mcp.mcpBehav.autoIODirOff = true
 	for bitState := 0; bitState <= 1; bitState++ {
 		adaptor.written = []byte{} // reset writes of Start() and former test
 		// arrange some values

--- a/drivers/i2c/mcp23017_driver_test.go
+++ b/drivers/i2c/mcp23017_driver_test.go
@@ -277,15 +277,13 @@ func TestMCP23017DriverPinMode(t *testing.T) {
 		// arrange some values
 		testPort := "A"
 		testPin := uint8(7)
-		wantReg := uint8(0x00)    // IODIRA
-		returnRead := uint8(0xFF) // emulate all ports are inputs
-		/*
-			wantRegVal := returnRead & 0x7F // bit 7 reset, all other untouched
-			if bitState == 1 {
-				returnRead = 0x00              // emulate all ports are outputs
-				wantRegVal = returnRead | 0x80 // bit 7 set, all other untouched
-			}
-		*/
+		wantReg := uint8(0x00)          // IODIRA
+		returnRead := uint8(0xFF)       // emulate all ports are inputs
+		wantRegVal := returnRead & 0x7F // bit 7 reset, all other untouched
+		if bitState == 1 {
+			returnRead = 0x00              // emulate all ports are outputs
+			wantRegVal = returnRead | 0x80 // bit 7 set, all other untouched
+		}
 		// arrange reads
 		numCallsRead := 0
 		adaptor.i2cReadImpl = func(b []byte) (int, error) {
@@ -300,9 +298,7 @@ func TestMCP23017DriverPinMode(t *testing.T) {
 		gobottest.Assert(t, len(adaptor.written), 3)
 		gobottest.Assert(t, adaptor.written[0], wantReg)
 		gobottest.Assert(t, adaptor.written[1], wantReg)
-		/* TODO this line cause an exception now after switch to #569
 		gobottest.Assert(t, adaptor.written[2], wantRegVal)
-		*/
 		gobottest.Assert(t, numCallsRead, 1)
 	}
 }
@@ -335,14 +331,12 @@ func TestMCP23017DriverSetPullUp(t *testing.T) {
 		testPort := "A"
 		wantReg := uint8(0x0C) // GPPUA
 		testPin := uint8(5)
-		returnRead := uint8(0xFF) // emulate all I's with pull up
-		/*
-			wantSetVal := returnRead & 0xDF // bit 5 cleared, all other unchanged
-			if bitState == 1 {
-				returnRead = uint8(0x00)       // emulate all I's without pull up
-				wantSetVal = returnRead | 0x20 // bit 5 set, all other unchanged
-			}
-		*/
+		returnRead := uint8(0xFF)       // emulate all I's with pull up
+		wantSetVal := returnRead & 0xDF // bit 5 cleared, all other unchanged
+		if bitState == 1 {
+			returnRead = uint8(0x00)       // emulate all I's without pull up
+			wantSetVal = returnRead | 0x20 // bit 5 set, all other unchanged
+		}
 		// arrange reads
 		numCallsRead := 0
 		adaptor.i2cReadImpl = func(b []byte) (int, error) {
@@ -357,9 +351,7 @@ func TestMCP23017DriverSetPullUp(t *testing.T) {
 		gobottest.Assert(t, len(adaptor.written), 3)
 		gobottest.Assert(t, adaptor.written[0], wantReg)
 		gobottest.Assert(t, adaptor.written[1], wantReg)
-		/* TODO this line cause an exception now after switch to #569
 		gobottest.Assert(t, adaptor.written[2], wantSetVal)
-		*/
 		gobottest.Assert(t, numCallsRead, 1)
 	}
 }
@@ -392,14 +384,12 @@ func TestMCP23017DriverSetGPIOPolarity(t *testing.T) {
 		testPort := "B"
 		wantReg := uint8(0x03) // IPOLB
 		testPin := uint8(6)
-		returnRead := uint8(0xFF) // emulate all I's negotiated
-		/*
-			wantSetVal := returnRead & 0xBF // bit 6 cleared, all other unchanged
-			if bitState == 1 {
-				returnRead = uint8(0x00)       // emulate all I's not negotiated
-				wantSetVal = returnRead | 0x40 // bit 6 set, all other unchanged
-			}
-		*/
+		returnRead := uint8(0xFF)       // emulate all I's negotiated
+		wantSetVal := returnRead & 0xBF // bit 6 cleared, all other unchanged
+		if bitState == 1 {
+			returnRead = uint8(0x00)       // emulate all I's not negotiated
+			wantSetVal = returnRead | 0x40 // bit 6 set, all other unchanged
+		}
 		// arrange reads
 		numCallsRead := 0
 		adaptor.i2cReadImpl = func(b []byte) (int, error) {
@@ -414,9 +404,7 @@ func TestMCP23017DriverSetGPIOPolarity(t *testing.T) {
 		gobottest.Assert(t, len(adaptor.written), 3)
 		gobottest.Assert(t, adaptor.written[0], wantReg)
 		gobottest.Assert(t, adaptor.written[1], wantReg)
-		/* TODO this line cause an exception now after switch to #569
 		gobottest.Assert(t, adaptor.written[2], wantSetVal)
-		*/
 		gobottest.Assert(t, numCallsRead, 1)
 	}
 }
@@ -508,10 +496,6 @@ func TestMCP23017Driver_read(t *testing.T) {
 	gobottest.Assert(t, err, errors.New("read error"))
 
 	// read
-	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
-	port = mcp.getPort("A")
-	_, err = mcp.read(port.IODIR)
-	gobottest.Assert(t, err, ErrNotEnoughBytes)
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
 	port = mcp.getPort("A")
 	adaptor.i2cReadImpl = func(b []byte) (int, error) {

--- a/drivers/i2c/mcp23017_driver_test.go
+++ b/drivers/i2c/mcp23017_driver_test.go
@@ -12,17 +12,17 @@ import (
 )
 
 var _ gobot.Driver = (*MCP23017Driver)(nil)
-var (
-	pinValPort = map[string]interface{}{
-		"pin":  uint8(7),
-		"val":  uint8(0),
-		"port": "A",
-	}
-	pinPort = map[string]interface{}{
-		"pin":  uint8(7),
-		"port": "A",
-	}
-)
+
+var pinValPort = map[string]interface{}{
+	"pin":  uint8(7),
+	"val":  uint8(0),
+	"port": "A",
+}
+
+var pinPort = map[string]interface{}{
+	"pin":  uint8(7),
+	"port": "A",
+}
 
 func initTestMCP23017Driver(b uint8) (driver *MCP23017Driver) {
 	driver, _ = initTestMCP23017DriverWithStubbedAdaptor(b)
@@ -82,18 +82,14 @@ func TestNewMCP23017DriverIntpol(t *testing.T) {
 
 func TestMCP23017DriverStart(t *testing.T) {
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
+
 	gobottest.Assert(t, mcp.Start(), nil)
+
 	adaptor.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
 	err := mcp.Start()
 	gobottest.Assert(t, err, errors.New("write error"))
-}
-
-func TestMCP23017StartConnectError(t *testing.T) {
-	d, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
-	adaptor.Testi2cConnectErr(true)
-	gobottest.Assert(t, d.Start(), errors.New("Invalid i2c connection"))
 }
 
 func TestMCP23017DriverHalt(t *testing.T) {
@@ -104,6 +100,7 @@ func TestMCP23017DriverHalt(t *testing.T) {
 func TestMCP23017DriverCommandsWriteGPIO(t *testing.T) {
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
 	gobottest.Assert(t, mcp.Start(), nil)
+
 	adaptor.i2cReadImpl = func(b []byte) (int, error) {
 		return len(b), nil
 	}
@@ -117,6 +114,7 @@ func TestMCP23017DriverCommandsWriteGPIO(t *testing.T) {
 func TestMCP23017DriverCommandsReadGPIO(t *testing.T) {
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
 	gobottest.Assert(t, mcp.Start(), nil)
+
 	adaptor.i2cReadImpl = func(b []byte) (int, error) {
 		return len(b), nil
 	}
@@ -127,6 +125,7 @@ func TestMCP23017DriverCommandsReadGPIO(t *testing.T) {
 func TestMCP23017DriverWriteGPIO(t *testing.T) {
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
 	gobottest.Assert(t, mcp.Start(), nil)
+
 	adaptor.i2cReadImpl = func(b []byte) (int, error) {
 		return len(b), nil
 	}
@@ -140,6 +139,7 @@ func TestMCP23017DriverWriteGPIO(t *testing.T) {
 func TestMCP23017DriverCommandsWriteGPIOErrIODIR(t *testing.T) {
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
 	gobottest.Assert(t, mcp.Start(), nil)
+
 	adaptor.i2cReadImpl = func(b []byte) (int, error) {
 		return len(b), nil
 	}
@@ -153,6 +153,7 @@ func TestMCP23017DriverCommandsWriteGPIOErrIODIR(t *testing.T) {
 func TestMCP23017DriverCommandsWriteGPIOErrOLAT(t *testing.T) {
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
 	gobottest.Assert(t, mcp.Start(), nil)
+
 	adaptor.i2cReadImpl = func(b []byte) (int, error) {
 		return len(b), nil
 	}
@@ -171,11 +172,13 @@ func TestMCP23017DriverCommandsWriteGPIOErrOLAT(t *testing.T) {
 func TestMCP23017DriverReadGPIO(t *testing.T) {
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
 	gobottest.Assert(t, mcp.Start(), nil)
+
 	adaptor.i2cReadImpl = func(b []byte) (int, error) {
 		return len(b), nil
 	}
 	val, _ := mcp.ReadGPIO(7, "A")
 	gobottest.Assert(t, val, uint8(0))
+
 	// read error
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
 	gobottest.Assert(t, mcp.Start(), nil)
@@ -185,6 +188,7 @@ func TestMCP23017DriverReadGPIO(t *testing.T) {
 	}
 	_, err := mcp.ReadGPIO(7, "A")
 	gobottest.Assert(t, err, errors.New("read error"))
+
 	// empty value from read
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
 	gobottest.Assert(t, mcp.Start(), nil)
@@ -194,6 +198,33 @@ func TestMCP23017DriverReadGPIO(t *testing.T) {
 	}
 	_, err = mcp.ReadGPIO(7, "A")
 	gobottest.Assert(t, err, errors.New("Read came back with no data"))
+}
+
+func TestMCP23017DriverPinMode(t *testing.T) {
+	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
+	gobottest.Assert(t, mcp.Start(), nil)
+
+	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+		return len(b), nil
+	}
+	adaptor.i2cWriteImpl = func([]byte) (int, error) {
+		return 0, nil
+	}
+	err := mcp.PinMode(7, 0, "A")
+	gobottest.Assert(t, err, nil)
+
+	// write error
+	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
+	gobottest.Assert(t, mcp.Start(), nil)
+
+	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+		return len(b), nil
+	}
+	adaptor.i2cWriteImpl = func([]byte) (int, error) {
+		return 0, errors.New("write error")
+	}
+	err = mcp.PinMode(7, 0, "A")
+	gobottest.Assert(t, err, errors.New("write error"))
 }
 
 func TestMCP23017DriverSetPullUp(t *testing.T) {
@@ -208,6 +239,7 @@ func TestMCP23017DriverSetPullUp(t *testing.T) {
 	}
 	err := mcp.SetPullUp(7, 0, "A")
 	gobottest.Assert(t, err, nil)
+
 	// write error
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
 	gobottest.Assert(t, mcp.Start(), nil)
@@ -234,6 +266,7 @@ func TestMCP23017DriverSetGPIOPolarity(t *testing.T) {
 	}
 	err := mcp.SetGPIOPolarity(7, 0, "A")
 	gobottest.Assert(t, err, nil)
+
 	// write error
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
 	gobottest.Assert(t, mcp.Start(), nil)
@@ -246,12 +279,14 @@ func TestMCP23017DriverSetGPIOPolarity(t *testing.T) {
 	}
 	err = mcp.SetGPIOPolarity(7, 0, "A")
 	gobottest.Assert(t, err, errors.New("write error"))
+
 }
 
 func TestMCP23017DriverWrite(t *testing.T) {
 	// clear bit
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
 	gobottest.Assert(t, mcp.Start(), nil)
+
 	port := mcp.getPort("A")
 	adaptor.i2cReadImpl = func(b []byte) (int, error) {
 		return len(b), nil
@@ -261,9 +296,11 @@ func TestMCP23017DriverWrite(t *testing.T) {
 	}
 	err := mcp.write(port.IODIR, uint8(7), 0)
 	gobottest.Assert(t, err, nil)
+
 	// set bit
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
 	gobottest.Assert(t, mcp.Start(), nil)
+
 	port = mcp.getPort("B")
 	adaptor.i2cReadImpl = func(b []byte) (int, error) {
 		return len(b), nil
@@ -273,6 +310,7 @@ func TestMCP23017DriverWrite(t *testing.T) {
 	}
 	err = mcp.write(port.IODIR, uint8(7), 1)
 	gobottest.Assert(t, err, nil)
+
 	// write error
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
 	gobottest.Assert(t, mcp.Start(), nil)
@@ -285,6 +323,17 @@ func TestMCP23017DriverWrite(t *testing.T) {
 	}
 	err = mcp.write(port.IODIR, uint8(7), 0)
 	gobottest.Assert(t, err, errors.New("write error"))
+
+	// read error
+	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
+	gobottest.Assert(t, mcp.Start(), nil)
+
+	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+		return len(b), errors.New("read error")
+	}
+	err = mcp.write(port.IODIR, uint8(7), 0)
+	gobottest.Assert(t, err, errors.New("read error"))
+
 	//debug
 	debug = true
 	log.SetOutput(ioutil.Discard)
@@ -312,6 +361,7 @@ func TestMCP23017DriverReadPort(t *testing.T) {
 	}
 	val, _ := mcp.read(port.IODIR)
 	gobottest.Assert(t, val, uint8(255))
+
 	// read error
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
 	gobottest.Assert(t, mcp.Start(), nil)
@@ -319,19 +369,35 @@ func TestMCP23017DriverReadPort(t *testing.T) {
 	adaptor.i2cReadImpl = func(b []byte) (int, error) {
 		return len(b), errors.New("read error")
 	}
+
 	val, err := mcp.read(port.IODIR)
 	gobottest.Assert(t, val, uint8(0))
 	gobottest.Assert(t, err, errors.New("read error"))
+
+	// read
+	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
+	gobottest.Assert(t, mcp.Start(), nil)
+
+	port = mcp.getPort("A")
+	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+		return 0, nil
+	}
+	_, err = mcp.read(port.IODIR)
+	gobottest.Assert(t, err, errors.New("Read was unable to get 1 bytes for register: 0x0\n"))
+
 	// debug
 	debug = true
 	log.SetOutput(ioutil.Discard)
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
 	gobottest.Assert(t, mcp.Start(), nil)
+
 	port = mcp.getPort("A")
+
 	adaptor.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{255})
 		return 1, nil
 	}
+
 	val, _ = mcp.read(port.IODIR)
 	gobottest.Assert(t, val, uint8(255))
 	debug = false
@@ -344,16 +410,19 @@ func TestMCP23017DriverGetPort(t *testing.T) {
 	expectedPort := getBank(0).PortA
 	actualPort := mcp.getPort("A")
 	gobottest.Assert(t, expectedPort, actualPort)
+
 	// port B
 	mcp = initTestMCP23017Driver(0)
 	expectedPort = getBank(0).PortB
 	actualPort = mcp.getPort("B")
 	gobottest.Assert(t, expectedPort, actualPort)
+
 	// default
 	mcp = initTestMCP23017Driver(0)
 	expectedPort = getBank(0).PortA
 	actualPort = mcp.getPort("")
 	gobottest.Assert(t, expectedPort, actualPort)
+
 	// port A bank 1
 	mcp = initTestMCP23017Driver(1)
 	expectedPort = getBank(1).PortA

--- a/drivers/i2c/mcp23017_driver_test.go
+++ b/drivers/i2c/mcp23017_driver_test.go
@@ -109,10 +109,7 @@ func TestMCP23017DriverHalt(t *testing.T) {
 
 func TestMCP23017DriverCommandsWriteGPIO(t *testing.T) {
 	// arrange
-	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
-		return len(b), nil
-	}
+	mcp, _ := initTestMCP23017DriverWithStubbedAdaptor(0)
 	// act
 	result := mcp.Command("WriteGPIO")(pinValPort)
 	// assert
@@ -121,10 +118,7 @@ func TestMCP23017DriverCommandsWriteGPIO(t *testing.T) {
 
 func TestMCP23017DriverCommandsReadGPIO(t *testing.T) {
 	// arrange
-	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
-		return len(b), nil
-	}
+	mcp, _ := initTestMCP23017DriverWithStubbedAdaptor(0)
 	// act
 	result := mcp.Command("ReadGPIO")(pinPort)
 	// assert
@@ -180,9 +174,6 @@ func TestMCP23017DriverWriteGPIO(t *testing.T) {
 func TestMCP23017DriverCommandsWriteGPIOErrIODIR(t *testing.T) {
 	// arrange
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
-		return len(b), nil
-	}
 	adaptor.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
@@ -195,9 +186,6 @@ func TestMCP23017DriverCommandsWriteGPIOErrIODIR(t *testing.T) {
 func TestMCP23017DriverCommandsWriteGPIOErrOLAT(t *testing.T) {
 	// arrange
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
-		return len(b), nil
-	}
 	numCalls := 1
 	adaptor.i2cWriteImpl = func([]byte) (int, error) {
 		if numCalls == 2 {
@@ -306,9 +294,6 @@ func TestMCP23017DriverPinMode(t *testing.T) {
 func TestMCP23017DriverPinModeErr(t *testing.T) {
 	// arrange
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
-		return len(b), nil
-	}
 	adaptor.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
@@ -359,9 +344,6 @@ func TestMCP23017DriverSetPullUp(t *testing.T) {
 func TestMCP23017DriverSetPullUpErr(t *testing.T) {
 	// arrange
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
-		return len(b), nil
-	}
 	adaptor.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
@@ -412,9 +394,6 @@ func TestMCP23017DriverSetGPIOPolarity(t *testing.T) {
 func TestMCP23017DriverSetGPIOPolarityErr(t *testing.T) {
 	// arrange
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
-		return len(b), nil
-	}
 	adaptor.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
@@ -434,26 +413,17 @@ func TestMCP23017Driver_write(t *testing.T) {
 	// clear bit
 	mcp, adaptor := initTestMCP23017DriverWithStubbedAdaptor(0)
 	port := mcp.getPort("A")
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
-		return len(b), nil
-	}
 	err := mcp.write(port.IODIR, uint8(7), 0)
 	gobottest.Assert(t, err, nil)
 
 	// set bit
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
 	port = mcp.getPort("B")
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
-		return len(b), nil
-	}
 	err = mcp.write(port.IODIR, uint8(7), 1)
 	gobottest.Assert(t, err, nil)
 
 	// write error
 	mcp, adaptor = initTestMCP23017DriverWithStubbedAdaptor(0)
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
-		return len(b), nil
-	}
 	adaptor.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
@@ -530,16 +500,4 @@ func TestMCP23017Driver_getPort(t *testing.T) {
 	expectedPort = getBank(1).PortA
 	actualPort = mcp.getPort("")
 	gobottest.Assert(t, expectedPort, actualPort)
-}
-
-func Test_setBit(t *testing.T) {
-	var expectedVal uint8 = 129
-	actualVal := setBit(1, 7)
-	gobottest.Assert(t, expectedVal, actualVal)
-}
-
-func Test_clearBit(t *testing.T) {
-	var expectedVal uint8
-	actualVal := clearBit(128, 7)
-	gobottest.Assert(t, expectedVal, actualVal)
 }


### PR DESCRIPTION
Fix the #810 
* make SetPullUp() working again
* make SetGPIOPolarity() working again
* heavy improvement of unit tests
* re-add the PinMode feature
* introduce speed optimizations for common use cases (speedup each read/write up to 50% by default, additional speedup by new flag possible)
* limit access to some internal variables
* don't panic on With-calls allow simpler wrapping of drivers
* introduce type "bitState" to make the usage of setting/resetting bits in a given register or value more explicit
* move setBit() and clearBit() to common usage to i2c.go