### PR TITLE
Feature/adafruit1109 2x16lcd 5keys

### DIFF
--- a/drivers/gpio/hd44780_driver_test.go
+++ b/drivers/gpio/hd44780_driver_test.go
@@ -157,10 +157,10 @@ func TestHD44780DriverSetCursor(t *testing.T) {
 func TestHD44780DriverSetCursorInvalid(t *testing.T) {
 	d := initTestHD44780Driver()
 	d.Start()
-	gobottest.Assert(t, d.SetCursor(-1, 3), errors.New("Invalid position value"))
-	gobottest.Assert(t, d.SetCursor(2, 3), errors.New("Invalid position value"))
-	gobottest.Assert(t, d.SetCursor(0, -1), errors.New("Invalid position value"))
-	gobottest.Assert(t, d.SetCursor(0, 16), errors.New("Invalid position value"))
+	gobottest.Assert(t, d.SetCursor(-1, 3), errors.New("Invalid position value (-1, 3), range (1, 15)"))
+	gobottest.Assert(t, d.SetCursor(2, 3), errors.New("Invalid position value (2, 3), range (1, 15)"))
+	gobottest.Assert(t, d.SetCursor(0, -1), errors.New("Invalid position value (0, -1), range (1, 15)"))
+	gobottest.Assert(t, d.SetCursor(0, 16), errors.New("Invalid position value (0, 16), range (1, 15)"))
 }
 
 func TestHD44780DriverDisplayOn(t *testing.T) {

--- a/drivers/i2c/README.md
+++ b/drivers/i2c/README.md
@@ -12,6 +12,7 @@ go get -d -u gobot.io/x/gobot/...
 ## Hardware Support
 Gobot has a extensible system for connecting to hardware devices. The following i2c devices are currently supported:
 
+- Adafruit 2x16 RGB-LCD with 5 keys
 - Adafruit Motor Hat
 - ADS1015 Analog to Digital Converter
 - ADS1115 Analog to Digital Converter

--- a/drivers/i2c/adafruit1109_driver.go
+++ b/drivers/i2c/adafruit1109_driver.go
@@ -1,0 +1,265 @@
+package i2c
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/drivers/gpio"
+)
+
+const adafruit1109Debug = false
+
+type adafruit1109PortPin struct {
+	port string
+	pin  uint8
+}
+
+// have to implement DigitalWriter, DigitalReader interface
+type Adafruit1109Driver struct {
+	name string
+	*MCP23017Driver
+	redPin    adafruit1109PortPin
+	greenPin  adafruit1109PortPin
+	bluePin   adafruit1109PortPin
+	selectPin adafruit1109PortPin
+	upPin     adafruit1109PortPin
+	downPin   adafruit1109PortPin
+	leftPin   adafruit1109PortPin
+	rightPin  adafruit1109PortPin
+	rwPin     adafruit1109PortPin
+	rsPin     adafruit1109PortPin
+	enPin     adafruit1109PortPin
+	dataPinD4 adafruit1109PortPin
+	dataPinD5 adafruit1109PortPin
+	dataPinD6 adafruit1109PortPin
+	dataPinD7 adafruit1109PortPin
+	*gpio.HD44780Driver
+}
+
+// Adafruit1109Driver is a driver for the 2x16 LCD display with RGB backlit and 5 keys from adafruit, designed for Pi.
+// The display is driven by the HD44780, and all is connected by i2c port expander MCP23017.
+// https://www.adafruit.com/product/1109
+//
+// Because both are already implemented in gobot, we creates a wrapper for using existing implementation.
+// So, for the documentation of the parameters, have a look at this drivers.
+//
+// Tests are done with a tinkerboard.
+func NewAdafruit1109Driver(a Connector, options ...func(Config)) *Adafruit1109Driver {
+	options = append(options, WithMCP23017AutoIODirOff(1))
+	mcp := NewMCP23017Driver(a, options...)
+	m := &Adafruit1109Driver{
+		name:           gobot.DefaultName("Adafruit1109"),
+		MCP23017Driver: mcp,
+		redPin:         adafruit1109PortPin{"A", 6},
+		greenPin:       adafruit1109PortPin{"A", 7},
+		bluePin:        adafruit1109PortPin{"B", 0},
+		selectPin:      adafruit1109PortPin{"A", 0},
+		upPin:          adafruit1109PortPin{"A", 3},
+		downPin:        adafruit1109PortPin{"A", 2},
+		leftPin:        adafruit1109PortPin{"A", 4},
+		rightPin:       adafruit1109PortPin{"A", 1},
+		rwPin:          adafruit1109PortPin{"B", 6},
+		rsPin:          adafruit1109PortPin{"B", 7},
+		enPin:          adafruit1109PortPin{"B", 5},
+		dataPinD4:      adafruit1109PortPin{"B", 4},
+		dataPinD5:      adafruit1109PortPin{"B", 3},
+		dataPinD6:      adafruit1109PortPin{"B", 2},
+		dataPinD7:      adafruit1109PortPin{"B", 1},
+	}
+	// mapping for HD44780 to MCP23017 port and IO, 4-Bit data
+	dataPins := gpio.HD44780DataPin{
+		D4: m.dataPinD4.String(),
+		D5: m.dataPinD5.String(),
+		D6: m.dataPinD6.String(),
+		D7: m.dataPinD7.String(),
+	}
+
+	//rwPin := "B_6" not mapped in HD44780 driver
+	// at test initialization, there seems rows and columns be switched
+	// but inside the driver the row is used as row and col as column
+	rows := 2
+	columns := 16
+	lcd := gpio.NewHD44780Driver(m, columns, rows, gpio.HD44780_4BITMODE, m.rsPin.String(), m.enPin.String(), dataPins)
+	lcd.SetRWPin(m.rwPin.String())
+	m.HD44780Driver = lcd
+	return m
+}
+
+// gobot.Connection interface
+func (m *Adafruit1109Driver) Name() string {
+	return fmt.Sprintf("%s_%s_%s", m.name, m.MCP23017Driver.Name(), m.HD44780Driver.Name())
+}
+func (m *Adafruit1109Driver) SetName(n string) { m.name = n }
+
+// gobot.Device interface
+func (m *Adafruit1109Driver) Connection() gobot.Connection { return m.MCP23017Driver.Connection() }
+func (m *Adafruit1109Driver) Halt() (err error)            { return m.MCP23017Driver.Halt() }
+
+func (m *Adafruit1109Driver) Start() (err error) {
+	if adafruit1109Debug {
+		log.Printf("## MCP.Start ##")
+	}
+	if err = m.MCP23017Driver.Start(); err != nil {
+		return err
+	}
+
+	// set all to output (inputs will be set by initButton)
+	for pin := uint8(0); pin <= 7; pin++ {
+		if err := m.PinMode(pin, 0, "A"); err != nil {
+			return err
+		}
+		if err := m.PinMode(pin, 0, "B"); err != nil {
+			return err
+		}
+	}
+
+	// button pins are inputs, has inverse logic and needs pull up
+	if err := m.adafruit1109InitButton(m.selectPin); err != nil {
+		return err
+	}
+	if err := m.adafruit1109InitButton(m.upPin); err != nil {
+		return err
+	}
+	if err := m.adafruit1109InitButton(m.downPin); err != nil {
+		return err
+	}
+	if err := m.adafruit1109InitButton(m.leftPin); err != nil {
+		return err
+	}
+	if err := m.adafruit1109InitButton(m.rightPin); err != nil {
+		return err
+	}
+
+	// lets start with neutral background
+	if err = m.SetRGB(true, true, true); err != nil {
+		return err
+	}
+	// set rw pin to write
+	if err := m.writePin(m.rwPin, 0x00); err != nil {
+		return err
+	}
+	if adafruit1109Debug {
+		log.Printf("## HD.Start ##")
+	}
+	return m.HD44780Driver.Start()
+}
+
+// DigitalWriter interface
+// This is called by HD44780 driver to set one gpio output. We redirect the call to the i2c driver MCP23017.
+// The given id is the same as defined in dataPins and has the syntax "<port>_<pin>".
+func (m *Adafruit1109Driver) DigitalWrite(id string, val byte) (err error) {
+	portio := adafruit1109ParseId(id)
+	return m.writePin(portio, val)
+}
+
+// DigitalReader interface
+// This is called by HD44780 driver to read one gpio input. We redirect the call to the i2c driver MCP23017.
+// The given id is the same as defined in dataPins and has the syntax "<port>_<pin>".
+func (m *Adafruit1109Driver) DigitalRead(id string) (val int, err error) {
+	portio := adafruit1109ParseId(id)
+	uval, err := m.readPin(portio)
+	if err != nil {
+		return 0, err
+	}
+	return int(uval), err
+}
+
+// Connector interface, haven't found any adaptor which implements this with more content
+func (m *Adafruit1109Driver) Connect() (err error)  { return }
+func (m *Adafruit1109Driver) Finalize() (err error) { return }
+
+// SetRGB sets the Red Green Blue value of backlit.
+// The MCP23017 variant don't support PWM and have inverted logic
+func (m *Adafruit1109Driver) SetRGB(r, g, b bool) error {
+	if adafruit1109Debug {
+		log.Printf("## SetRGB %t, %t, %t ##", r, g, b)
+	}
+	rio := m.redPin
+	gio := m.greenPin
+	bio := m.bluePin
+	rval := uint8(0x1)
+	gval := uint8(0x1)
+	bval := uint8(0x1)
+	if r {
+		rval = 0x00
+	}
+	if g {
+		gval = 0x00
+	}
+	if b {
+		bval = 0x00
+	}
+
+	if err := m.writePin(rio, rval); err != nil {
+		return err
+	}
+
+	if err := m.writePin(gio, gval); err != nil {
+		return err
+	}
+
+	if err := m.writePin(bio, bval); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Adafruit1109Driver) SelectButton() (uint8, error) {
+	return m.readPin(m.selectPin)
+}
+
+func (m *Adafruit1109Driver) UpButton() (uint8, error) {
+	return m.readPin(m.upPin)
+}
+
+func (m *Adafruit1109Driver) DownButton() (uint8, error) {
+	return m.readPin(m.downPin)
+}
+
+func (m *Adafruit1109Driver) LeftButton() (uint8, error) {
+	return m.readPin(m.leftPin)
+}
+
+func (m *Adafruit1109Driver) RightButton() (uint8, error) {
+	return m.readPin(m.rightPin)
+}
+
+func (m *Adafruit1109Driver) writePin(ap adafruit1109PortPin, val uint8) (err error) {
+	return m.WriteGPIO(ap.pin, val, ap.port)
+}
+
+func (m *Adafruit1109Driver) readPin(ap adafruit1109PortPin) (uint8, error) {
+	return m.ReadGPIO(ap.pin, ap.port)
+}
+
+func (ap *adafruit1109PortPin) String() string {
+	return fmt.Sprintf("%s_%d", ap.port, ap.pin)
+}
+
+func adafruit1109ParseId(id string) adafruit1109PortPin {
+	items := strings.Split(id, "_")
+	io := uint8(0)
+	if io64, err := strconv.ParseUint(items[1], 10, 32); err == nil {
+		io = uint8(io64)
+	}
+	return adafruit1109PortPin{port: items[0], pin: io}
+}
+
+func (m *Adafruit1109Driver) adafruit1109InitButton(p adafruit1109PortPin) error {
+	// make an input
+	if err := m.PinMode(p.pin, 1, p.port); err != nil {
+		return err
+	}
+	// add pull up resistors
+	if err := m.SetPullUp(p.pin, 1, p.port); err != nil {
+		return err
+	}
+	// invert polarity
+	if err := m.SetGPIOPolarity(p.pin, 1, p.port); err != nil {
+		return err
+	}
+	return nil
+}

--- a/drivers/i2c/adafruit1109_driver_test.go
+++ b/drivers/i2c/adafruit1109_driver_test.go
@@ -1,0 +1,51 @@
+package i2c
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"gobot.io/x/gobot/gobottest"
+)
+
+func initTestAdafruit1109DriverWithStubbedAdaptor() (*Adafruit1109Driver, *i2cTestAdaptor) {
+	adaptor := newI2cTestAdaptor()
+	return NewAdafruit1109Driver(adaptor), adaptor
+}
+
+func TestAdafruit1109DriverStart(t *testing.T) {
+	ada, _ := initTestAdafruit1109DriverWithStubbedAdaptor()
+	gobottest.Assert(t, ada.Start(), nil)
+}
+
+func TestAdafruit1109DriverStartWriteErr(t *testing.T) {
+	d, adaptor := initTestAdafruit1109DriverWithStubbedAdaptor()
+	adaptor.i2cWriteImpl = func([]byte) (int, error) {
+		return 0, errors.New("write error")
+	}
+	gobottest.Assert(t, d.Start(), errors.New("write error"))
+}
+
+func TestAdafruit1109DriverStartReadErr(t *testing.T) {
+	d, adaptor := initTestAdafruit1109DriverWithStubbedAdaptor()
+	adaptor.i2cReadImpl = func([]byte) (int, error) {
+		return 0, errors.New("read error")
+	}
+	gobottest.Assert(t, d.Start(), errors.New("read error"))
+}
+
+func TestAdafruit1109Driver_parseId(t *testing.T) {
+	// arrange
+	ports := []string{"A", "B"}
+	for _, port := range ports {
+		for pin := uint8(0); pin <= 7; pin++ {
+			id := fmt.Sprintf("%s_%d", port, pin)
+			t.Run(id, func(t *testing.T) {
+				// act
+				got := adafruit1109ParseId(id)
+				// assert
+				gobottest.Assert(t, got, adafruit1109PortPin{port, pin})
+			})
+		}
+	}
+}

--- a/examples/tinkerboard_adafruit1109_lcd_keys.go
+++ b/examples/tinkerboard_adafruit1109_lcd_keys.go
@@ -1,0 +1,120 @@
+// +build example
+//
+// Do not build by default.
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/drivers/i2c"
+	"gobot.io/x/gobot/platforms/tinkerboard"
+)
+
+func main() {
+	// * I2C1: 3 (SDA), 5 (SCL) --> connected to plate
+	board := tinkerboard.NewAdaptor()
+	ada := i2c.NewAdafruit1109Driver(board, i2c.WithBus(1))
+
+	work := func() {
+		// set a custom character
+		smiley := [8]byte{0, 0, 10, 0, 0, 17, 14, 0}
+		ada.CreateChar(0, smiley)
+
+		ada.Clear()
+		ada.SetRGB(true, false, false)
+		ada.Write("   Hello from   \n  Tinker Board ")
+		// add the custom character at the end of the string
+		ada.Write(string(byte(0)))
+
+		// after 1 sec. activate rotation
+		direction := 1
+		gobot.After(1*time.Second, func() {
+			ada.SetRGB(false, true, false)
+			gobot.Every(400*time.Millisecond, func() {
+				if direction == 1 {
+					ada.ScrollLeft()
+				}
+				if direction == 2 {
+					ada.ScrollRight()
+				}
+			})
+		})
+
+		// after 7 sec. activate play with the buttons
+		gobot.After(7*time.Second, func() {
+			direction = 0
+			time.Sleep(1 * time.Second)
+			ada.LeftToRight()
+			ada.Clear()
+			ada.SetRGB(false, false, true)
+			ada.Write("Try the buttons!")
+
+			gobot.Every(500*time.Millisecond, func() {
+				if val, err := ada.SelectButton(); err != nil {
+					fmt.Println(err)
+				} else {
+					if val != 0 {
+						ada.Clear()
+						ada.Write("-Select Button-\nclear the screen")
+						ada.Blink(false)
+						direction = 0
+					}
+				}
+				if val, err := ada.UpButton(); err != nil {
+					fmt.Println(err)
+				} else {
+					if val != 0 {
+						ada.Clear()
+						ada.Write("  -Up Button-   \nset RGB to white")
+						ada.Blink(false)
+						ada.SetRGB(true, true, true)
+						direction = 0
+					}
+				}
+				if val, err := ada.DownButton(); err != nil {
+					fmt.Println(err)
+				} else {
+					if val != 0 {
+						ada.Clear()
+						ada.Write(" -Down Button-  \nset blink on")
+						ada.Blink(true)
+						direction = 0
+					}
+				}
+				if val, err := ada.LeftButton(); err != nil {
+					fmt.Println(err)
+				} else {
+					if val != 0 {
+						ada.Clear()
+						ada.Write("   -Left Button-  \nrotate left")
+						ada.Blink(false)
+						direction = 1
+					}
+				}
+				if val, err := ada.RightButton(); err != nil {
+					fmt.Println(err)
+				} else {
+					if val != 0 {
+						ada.Clear()
+						ada.Write("   -Right Button-  \nrotate right")
+						ada.Blink(false)
+						direction = 2
+					}
+				}
+			})
+
+		})
+
+	}
+
+	robot := gobot.NewRobot("adaBot",
+		[]gobot.Connection{board},
+		[]gobot.Device{ada},
+		work,
+	)
+
+	robot.Start()
+}


### PR DESCRIPTION
Introduce a driver for Adafruit product 1109, a 2x16 LCD display with RGB backlit and 5 keys.
The display is driven by the HD44780, and all is connected by i2c port expander MCP23017.
Provides additional bugfix for concurrent writing in HD44780, according to #817 .
Provides stabilization for mcp23017 functions, against concurrent read-write.