### PR TITLE
BUGFIX: new pwm behaviour of tinkerboard

### DIFF
--- a/platforms/tinkerboard/README.md
+++ b/platforms/tinkerboard/README.md
@@ -14,15 +14,43 @@ You would normally install Go and Gobot on your workstation. Once installed, cro
 go get -d -u gobot.io/x/gobot/...
 ```
 
-### Enabling GPIO pins
+### System access and configuration basics
 
-To enable use of the Tinker Board GPIO pins, you need to perform the following steps as a one-time configuration. Once your Tinker Board has been configured, you do not need to do so again.
+Some configuration steps are needed to enable drivers and simplify the interaction with your Tinker Board. Once your Tinker Board has been configured, you do not need to do so again.
 
 Note that these configuration steps must be performed on the Tinker Board itself. The easiest is to login to the Tinker Board via SSH (option "-4" is used to force IPv4, which is needed for some versions of TinkerOS):
 
 ```
 ssh -4 linaro@192.168.1.xxx
 ```
+
+### Enabling hardware drivers
+
+Not all drivers are enabled by default. You can have a look at the configuration file, to find out what is enabled at your system:
+
+```
+cat /boot/config.txt
+```
+
+This file can be modified by "vi" or "nano", it is self explanatory:
+
+```
+sudo vi /boot/config.txt
+```
+
+Newer versions of Tinker Board provide an user interface for configuration with:
+
+```
+sudo tinker-config
+```
+
+After configuration was changed, an reboot is necessary.
+
+```
+sudo reboot
+```
+
+### Enabling GPIO pins
 
 #### Create a group "gpio"
 
@@ -62,14 +90,6 @@ SUBSYSTEM=="gpio", KERNEL=="gpio*", ACTION=="add", PROGRAM="/bin/sh -c 'chown ro
 Press the "Esc" key, then press the ":" key and then the "q" key, and then press the "Enter" key. This should save your file. After rebooting your Tinker Board, you should be able to run your Gobot code that uses GPIO.
 
 ### Enabling I2C
-
-To enable use of the Tinker Board I2C, you need to perform the following steps as a one-time configuration. Once your Tinker Board has been configured, you do not need to do so again.
-
-Note that these configuration steps must be performed on the Tinker Board itself. The easiest is to login to the Tinker Board via SSH:
-
-```
-ssh linaro@192.168.1.xxx
-```
 
 #### Create a group "i2c"
 
@@ -127,9 +147,106 @@ Compile your Gobot program on your workstation like this:
 $ GOARM=7 GOARCH=arm GOOS=linux go build examples/tinkerboard_blink.go
 ```
 
-Once you have compiled your code, you can you can upload your program and execute it on the Tinkerboard from your workstation using the `scp` and `ssh` commands like this:
+Once you have compiled your code, you can upload your program and execute it on the Tinkerboard from your workstation using the `scp` and `ssh` commands like this:
 
 ```bash
 $ scp tinkerboard_blink linaro@192.168.1.xxx:/home/linaro/
 $ ssh -t linaro@192.168.1.xxx "./tinkerboard_blink"
 ```
+
+## Troubleshooting
+
+### PWM
+
+#### Investigate state
+```
+$ ls /sys/class/pwm/
+pwmchip0  pwmchip1
+
+```
+pwmchip0 and pwmchip1 seems to be not usable (unknown, which functionality make use of that, maybe fan?)
+
+#### Activate
+When there is no pwm2, pwm3, this can be activated.
+Open the file /boot/config.txt and add lines/remove comment sign and adjust:
+
+intf:pwm2=on
+intf:pwm3=on
+
+Then save the file, close and reboot.
+
+After reboot check the state:
+```
+$ ls /sys/class/pwm/
+pwmchip0  pwmchip1  pwmchip2  pwmchip3
+
+```
+pwmchip2: the pin 33 is usable
+pwmchip3: the pin 32 is usable
+
+When only one pwm was enabled it will be always "pwmchip2". In this case, the activated pin can be found by investigating the symbolic link of the device:
+```
+# ls -la /sys/class/pwm/
+total 0
+drwxr-xr-x  2 root root 0 Apr 24 14:11 .
+drwxr-xr-x 66 root root 0 Apr 24 14:09 ..
+lrwxrwxrwx  1 root root 0 Apr 24 14:09 pwmchip0 -> ../../devices/platform/ff680000.pwm/pwm/pwmchip0
+lrwxrwxrwx  1 root root 0 Apr 24 14:09 pwmchip1 -> ../../devices/platform/ff680010.pwm/pwm/pwmchip1
+lrwxrwxrwx  1 root root 0 Apr 24 14:09 pwmchip2 -> ../../devices/platform/ff680030.pwm/pwm/pwmchip2
+```
+
+ff680020 => pwm2, pin33
+ff680030 => pwm3, pin32
+
+#### Test
+For example only pwm3 was activated to use pin32. Connect an oscilloscope or at least a meter to the pin 32.
+
+switch to root user by "su -"
+
+investigate state:
+```
+# ls -la /sys/class/pwm/pwmchip2/
+total 0
+drwxr-xr-x 3 root root    0 Apr 24 14:17 .
+drwxr-xr-x 3 root root    0 Apr 24 14:17 ..
+lrwxrwxrwx 1 root root    0 Apr 24 14:17 device -> ../../../ff680030.pwm
+--w------- 1 root root 4096 Apr 24 14:17 export
+-r--r--r-- 1 root root 4096 Apr 24 14:17 npwm
+drwxr-xr-x 2 root root    0 Apr 24 14:17 power
+lrwxrwxrwx 1 root root    0 Apr 24 14:17 subsystem -> ../../../../../class/pwm
+-rw-r--r-- 1 root root 4096 Apr 24 14:17 uevent
+--w------- 1 root root 4096 Apr 24 14:17 unexport
+```
+#### Creating pwm0
+`echo 0 > /sys/class/pwm/pwmchip2/enable`
+investigate result:
+```
+# ls /sys/class/pwm/pwmchip2/
+device	export	npwm  power  pwm0  subsystem  uevent  unexport
+# ls /sys/class/pwm/pwmchip2/pwm0/
+capture  duty_cycle  enable  period  polarity  power  uevent
+# cat /sys/class/pwm/pwmchip2/pwm0/period 
+0
+# cat /sys/class/pwm/pwmchip2/pwm0/duty_cycle 
+0
+# cat /sys/class/pwm/pwmchip2/pwm0/enable 
+0
+# cat /sys/class/pwm/pwmchip2/pwm0/polarity 
+inversed
+```
+#### Initialization
+Note: Before writing the period all other write actions will cause an error "-bash: echo: write error: Invalid argument"
+```
+echo 10000000 > /sys/class/pwm/pwmchip2/pwm0/period # this is a frequency divider for 1GHz (1000 will produce a frequency of 1MHz, 1000000 will cause a frequency of 1kHz, her we got 100Hz)
+echo "normal" > /sys/class/pwm/pwmchip2/pwm0/polarity
+echo 3000000 > /sys/class/pwm/pwmchip2/pwm0/duty_cycle # this means 30%
+echo 1  > /sys/class/pwm/pwmchip2/pwm0/enable
+
+```
+Now we should measure a value of around 1V with the meter, because the basis value is 3.3V and 30% leads to 1V.
+
+Try to inverse the sequence:
+`echo "inversed" > /sys/class/pwm/pwmchip2/pwm0/polarity`
+Now we should measure a value of around 2.3V with the meter, which is the difference of 1V to 3.3V.
+
+If we have attached an oscilloscope we can play around with the values for period and duty_cycle and see what happen.

--- a/platforms/tinkerboard/adaptor.go
+++ b/platforms/tinkerboard/adaptor.go
@@ -1,8 +1,8 @@
 package tinkerboard
 
 import (
-	"errors"
 	"fmt"
+	"log"
 	"sync"
 
 	multierror "github.com/hashicorp/go-multierror"
@@ -11,17 +11,25 @@ import (
 	"gobot.io/x/gobot/sysfs"
 )
 
-type sysfsPin struct {
-	pin    int
-	pwmPin int
+const debug = false
+
+const (
+	pwmNormal        = "normal"
+	pwmInverted      = "inversed"
+	pwmPeriodDefault = 10000000 // 10ms = 100Hz
+)
+
+type pwmPinDefinition struct {
+	channel   int
+	dir       string
+	dirRegexp string
 }
 
 // Adaptor represents a Gobot Adaptor for the ASUS Tinker Board
 type Adaptor struct {
 	name        string
-	pinmap      map[string]sysfsPin
-	digitalPins map[int]*sysfs.DigitalPin
-	pwmPins     map[int]*sysfs.PWMPin
+	digitalPins map[string]*sysfs.DigitalPin
+	pwmPins     map[string]*sysfs.PWMPin
 	i2cBuses    [5]i2c.I2cDevice
 	mutex       *sync.Mutex
 }
@@ -98,9 +106,12 @@ func (c *Adaptor) DigitalWrite(pin string, val byte) (err error) {
 	return sysfsPin.Write(int(val))
 }
 
-// PwmWrite writes a PWM signal to the specified pin
+// PwmWrite writes a PWM signal to the specified pin.
 func (c *Adaptor) PwmWrite(pin string, val byte) (err error) {
-	pwmPin, err := c.PWMPin(pin)
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	pwmPin, err := c.pwmPin(pin)
 	if err != nil {
 		return
 	}
@@ -109,29 +120,49 @@ func (c *Adaptor) PwmWrite(pin string, val byte) (err error) {
 		return err
 	}
 	duty := gobot.FromScale(float64(val), 0, 255.0)
+	if debug {
+		log.Printf("Tinkerboard PwmWrite - raw: %d, period: %d, duty: %.2f %%", val, period, duty*100)
+	}
 	return pwmPin.SetDutyCycle(uint32(float64(period) * duty))
 }
 
-// TODO: take into account the actual period setting, not just assume default
-const pwmPeriod = 10000000
-
-// ServoWrite writes a servo signal to the specified pin
+// ServoWrite writes a servo signal to the specified pin.
 func (c *Adaptor) ServoWrite(pin string, angle byte) (err error) {
-	pwmPin, err := c.PWMPin(pin)
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	pwmPin, err := c.pwmPin(pin)
 	if err != nil {
 		return
+	}
+	period, err := pwmPin.Period()
+	if err != nil {
+		return err
 	}
 
 	// 0.5 ms => -90
 	// 1.5 ms =>   0
 	// 2.0 ms =>  90
-	const minDuty = 100 * 0.0005 * pwmPeriod
-	const maxDuty = 100 * 0.0020 * pwmPeriod
+	minDuty := 100 * 0.0005 * float64(period)
+	maxDuty := 100 * 0.0020 * float64(period)
 	duty := uint32(gobot.ToScale(gobot.FromScale(float64(angle), 0, 180), minDuty, maxDuty))
 	return pwmPin.SetDutyCycle(duty)
 }
 
-// DigitalPin returns matched digitalPin for specified values
+// SetPeriod adjusts the period of the specified PWM pin.
+// If duty cycle is already set, also this value will be adjusted in the same ratio.
+func (c *Adaptor) SetPeriod(pin string, period uint32) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	pwmPin, err := c.pwmPin(pin)
+	if err != nil {
+		return err
+	}
+	return setPeriod(pwmPin, period)
+}
+
+// DigitalPin returns matched digitalPin for specified values.
 func (c *Adaptor) DigitalPin(pin string, dir string) (sysfsPin sysfs.DigitalPinner, err error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
@@ -142,59 +173,30 @@ func (c *Adaptor) DigitalPin(pin string, dir string) (sysfsPin sysfs.DigitalPinn
 		return
 	}
 
-	if c.digitalPins[i] == nil {
-		c.digitalPins[i] = sysfs.NewDigitalPin(i)
-		if err = c.digitalPins[i].Export(); err != nil {
+	if c.digitalPins[pin] == nil {
+		c.digitalPins[pin] = sysfs.NewDigitalPin(i)
+		if err = c.digitalPins[pin].Export(); err != nil {
 			return
 		}
 	}
 
-	if err = c.digitalPins[i].Direction(dir); err != nil {
+	if err = c.digitalPins[pin].Direction(dir); err != nil {
 		return
 	}
 
-	return c.digitalPins[i], nil
+	return c.digitalPins[pin], nil
 }
 
-// PWMPin returns matched pwmPin for specified pin number
+// PWMPin initializes the pin for PWM and returns matched pwmPin for specified pin number.
+// It implements the PWMPinnerProvider interface.
 func (c *Adaptor) PWMPin(pin string) (sysfsPin sysfs.PWMPinner, err error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	i, err := c.translatePwmPin(pin)
-	if err != nil {
-		return nil, err
-	}
-	if i == -1 {
-		return nil, errors.New("Not a PWM pin")
-	}
-
-	if c.pwmPins[i] == nil {
-		newPin := sysfs.NewPWMPin(i)
-		if err = newPin.Export(); err != nil {
-			return
-		}
-		// Make sure pwm is disabled when setting polarity
-		if err = newPin.Enable(false); err != nil {
-			return
-		}
-		if err = newPin.InvertPolarity(false); err != nil {
-			return
-		}
-		if err = newPin.Enable(true); err != nil {
-			return
-		}
-		if err = newPin.SetPeriod(10000000); err != nil {
-			return
-		}
-		c.pwmPins[i] = newPin
-	}
-
-	sysfsPin = c.pwmPins[i]
-	return
+	return c.pwmPin(pin)
 }
 
-// GetConnection returns a connection to a device on a specified bus.
+// GetConnection returns a connection to a device on a specified i2c bus.
 // Valid bus number is [0..4] which corresponds to /dev/i2c-0 through /dev/i2c-4.
 // We don't support "/dev/i2c-6 DesignWare HDMI".
 func (c *Adaptor) GetConnection(address int, bus int) (connection i2c.Connection, err error) {
@@ -210,31 +212,135 @@ func (c *Adaptor) GetConnection(address int, bus int) (connection i2c.Connection
 	return i2c.NewConnection(c.i2cBuses[bus], address), err
 }
 
-// GetDefaultBus returns the default i2c bus for this platform
+// GetDefaultBus returns the default i2c bus for this platform.
 func (c *Adaptor) GetDefaultBus() int {
 	return 1
 }
 
-func (c *Adaptor) setPins() {
-	c.digitalPins = make(map[int]*sysfs.DigitalPin)
-	c.pwmPins = make(map[int]*sysfs.PWMPin)
-	c.pinmap = fixedPins
+// pwmPin initializes the pin for PWM and returns matched pwmPin for specified pin number.
+func (c *Adaptor) pwmPin(pin string) (sysfsPin sysfs.PWMPinner, err error) {
+	var pwmPinData pwmPinDefinition
+	if pwmPinData, err = c.translatePwmPin(pin); err != nil {
+		return
+	}
+
+	if c.pwmPins[pin] == nil {
+		var path string
+		if path, err = pwmPinData.findDir(); err != nil {
+			return
+		}
+		newPin := sysfs.NewPWMPin(pwmPinData.channel)
+		newPin.Path = path
+		if err = newPin.Export(); err != nil {
+			return
+		}
+		// Make sure pwm is disabled before change anything
+		if err = newPin.Enable(false); err != nil {
+			return
+		}
+		if err = setPeriod(newPin, pwmPeriodDefault); err != nil {
+			return
+		}
+		if err = newPin.SetPolarity(pwmNormal); err != nil {
+			return
+		}
+		if err = newPin.Enable(true); err != nil {
+			return
+		}
+		if debug {
+			log.Printf("New PWMPin created for %s\n", pin)
+		}
+		c.pwmPins[pin] = newPin
+	}
+
+	return c.pwmPins[pin], nil
 }
 
-func (c *Adaptor) translatePin(pin string) (i int, err error) {
-	if val, ok := c.pinmap[pin]; ok {
-		i = val.pin
+// setPeriod adjusts the PWM period of the given pin.
+// If duty cycle is already set, also this value will be adjusted in the same ratio.
+// The order in which the values are written must be observed, otherwise an error occur "write error: Invalid argument".
+func setPeriod(pwmPin sysfs.PWMPinner, period uint32) error {
+	var errorBase = fmt.Sprintf("tinkerboard.setPeriod(%v, %d) failed", pwmPin, period)
+	oldDuty, err := pwmPin.DutyCycle()
+	if err != nil {
+		return fmt.Errorf("%s with '%v'", errorBase, err)
+	}
+
+	if oldDuty == 0 {
+		if err := pwmPin.SetPeriod(period); err != nil {
+			log.Println(1, period)
+			return fmt.Errorf("%s with '%v'", errorBase, err)
+		}
 	} else {
-		err = errors.New("Not a valid pin")
+		// adjust duty cycle in the same ratio
+		oldPeriod, err := pwmPin.Period()
+		if err != nil {
+			return fmt.Errorf("%s with '%v'", errorBase, err)
+		}
+		duty := uint32(uint64(oldDuty) * uint64(period) / uint64(oldPeriod))
+		if debug {
+			log.Printf("oldPeriod: %d, oldDuty: %d, new period: %d, new duty: %d", oldPeriod, oldDuty, period, duty)
+		}
+
+		// the order depends on value (duty must not be bigger than period in any situation)
+		if duty > oldPeriod {
+			if err := pwmPin.SetPeriod(period); err != nil {
+				log.Println(2, period)
+				return fmt.Errorf("%s with '%v'", errorBase, err)
+			}
+			if err := pwmPin.SetDutyCycle(uint32(duty)); err != nil {
+				log.Println(2, duty)
+				return fmt.Errorf("%s with '%v'", errorBase, err)
+			}
+		} else {
+			if err := pwmPin.SetDutyCycle(uint32(duty)); err != nil {
+				log.Println(3, duty)
+				return fmt.Errorf("%s with '%v'", errorBase, err)
+			}
+			if err := pwmPin.SetPeriod(period); err != nil {
+				log.Println(3, period)
+				return fmt.Errorf("%s with '%v'", errorBase, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (c *Adaptor) setPins() {
+	c.digitalPins = make(map[string]*sysfs.DigitalPin)
+	c.pwmPins = make(map[string]*sysfs.PWMPin)
+}
+
+func (c *Adaptor) translatePin(pin string) (sysfsPinNo int, err error) {
+	sysfsPinNo, ok := gpioPinDefinitions[pin]
+	if !ok {
+		err = fmt.Errorf("Not a valid pin")
 	}
 	return
 }
 
-func (c *Adaptor) translatePwmPin(pin string) (i int, err error) {
-	if val, ok := c.pinmap[pin]; ok {
-		i = val.pwmPin
-	} else {
-		err = errors.New("Not a valid pin")
+func (c *Adaptor) translatePwmPin(pin string) (pwmPin pwmPinDefinition, err error) {
+	var ok bool
+	if pwmPin, ok = pwmPinDefinitions[pin]; !ok {
+		err = fmt.Errorf("Not a valid PWM pin")
 	}
+	return
+}
+
+func (p pwmPinDefinition) findDir() (dir string, err error) {
+	items, _ := sysfs.Find(p.dir, p.dirRegexp)
+	if items == nil || len(items) == 0 {
+		return "", fmt.Errorf("No path found for PWM directory pattern, '%s' in path '%s'. See README.md for activation.", p.dirRegexp, p.dir)
+	}
+
+	dir = items[0]
+	info, err := sysfs.Stat(dir)
+	if err != nil {
+		return "", fmt.Errorf("Error (%v) on access '%s'.", err, dir)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("The item '%s' is not a directory, which is not expected.", dir)
+	}
+
 	return
 }

--- a/platforms/tinkerboard/pin_map.go
+++ b/platforms/tinkerboard/pin_map.go
@@ -1,116 +1,39 @@
 package tinkerboard
 
-var fixedPins = map[string]sysfsPin{
-	"7": {
-		pin:    17, // GPIO0_C1_CLKOUT
-		pwmPin: -1,
-	},
-	"10": {
-		pin:    160, // GPIO5_B0_UART1RX
-		pwmPin: -1,
-	},
-	"8": {
-		pin:    161, // GPIO5_B1_UART1TX
-		pwmPin: -1,
-	},
-	"16": {
-		pin:    162, // GPIO5_B2_UART1CTSN
-		pwmPin: -1,
-	},
-	"18": {
-		pin:    163, // GPIO5_B3_UART1RTSN
-		pwmPin: -1,
-	},
-	"11": {
-		pin:    164, // GPIO5_B4_SPI0CLK_UART4CTSN
-		pwmPin: -1,
-	},
-	"29": {
-		pin:    165, // GPIO5_B5_SPI0CSN_UART4RTSN
-		pwmPin: -1,
-	},
-	"13": {
-		pin:    166, // GPIO5_B6_SPI0_TXD_UART4TX
-		pwmPin: -1,
-	},
-	"15": {
-		pin:    167, // GPIO5_B7_SPI0_RXD_UART4RX
-		pwmPin: -1,
-	},
-	"31": {
-		pin:    168, // GPIO5_C0_SPI0CSN1
-		pwmPin: -1,
-	},
-	"22": {
-		pin:    171, // GPIO5_C3
-		pwmPin: -1,
-	},
-	"12": {
-		pin:    184, // GPIO6_A0_PCM/I2S_CLK
-		pwmPin: -1,
-	},
-	"35": {
-		pin:    185, // GPIO6_A1_PCM/I2S_FS
-		pwmPin: -1,
-	},
-	"38": {
-		pin:    187, // GPIO6_A3_PCM/I2S_SDI
-		pwmPin: -1,
-	},
-	"40": {
-		pin:    188, // GPIO6_A4_PCM/I2S_SDO
-		pwmPin: -1,
-	},
-	"36": {
-		pin:    223, // GPIO7_A7_UART3RX
-		pwmPin: -1,
-	},
-	"37": {
-		pin:    224, // GPIO7_B0_UART3TX
-		pwmPin: -1,
-	},
-	"27": {
-		pin:    233, // GPIO7_C1_I2C4_SDA
-		pwmPin: -1,
-	},
-	"28": {
-		pin:    234, // GPIO7_C2_I2C_SCL
-		pwmPin: -1,
-	},
-	"33": {
-		pin:    238, // GPIO7_C6_UART2RX_PWM2
-		pwmPin: 0,
-	},
-	"32": {
-		pin:    239, // GPIO7_C7_UART2TX_PWM3
-		pwmPin: 1,
-	},
-	"26": {
-		pin:    251, // GPIO8_A3_SPI2CSN1
-		pwmPin: -1,
-	},
-	"3": {
-		pin:    252, // GPIO8_A4_I2C1_SDA
-		pwmPin: -1,
-	},
-	"5": {
-		pin:    253, // GPIO8_A5_I2C1_SCL
-		pwmPin: -1,
-	},
-	"23": {
-		pin:    254, // GPIO8_A6_SPI2CLK
-		pwmPin: -1,
-	},
-	"24": {
-		pin:    255, // GPIO8_A7_SPI2CSN0
-		pwmPin: -1,
-	},
-	"21": {
-		pin:    256, // GPIO8_B0_SPI2RXD
-		pwmPin: -1,
-	},
-	"19": {
-		pin:    257, // GPIO8_B1_SPI2TXD
-		pwmPin: -1,
-	},
+var gpioPinDefinitions = map[string]int{
+	"7":  17,  // GPIO0_C1_CLKOUT
+	"10": 160, // GPIO5_B0_UART1RX
+	"8":  161, // GPIO5_B1_UART1TX
+	"16": 162, // GPIO5_B2_UART1CTSN
+	"18": 163, // GPIO5_B3_UART1RTSN
+	"11": 164, // GPIO5_B4_SPI0CLK_UART4CTSN
+	"29": 165, // GPIO5_B5_SPI0CSN_UART4RTSN
+	"13": 166, // GPIO5_B6_SPI0_TXD_UART4TX
+	"15": 167, // GPIO5_B7_SPI0_RXD_UART4RX
+	"31": 168, // GPIO5_C0_SPI0CSN1
+	"22": 171, // GPIO5_C3
+	"12": 184, // GPIO6_A0_PCM/I2S_CLK
+	"35": 185, // GPIO6_A1_PCM/I2S_FS
+	"38": 187, // GPIO6_A3_PCM/I2S_SDI
+	"40": 188, // GPIO6_A4_PCM/I2S_SDO
+	"36": 223, // GPIO7_A7_UART3RX
+	"37": 224, // GPIO7_B0_UART3TX
+	"27": 233, // GPIO7_C1_I2C4_SDA
+	"28": 234, // GPIO7_C2_I2C_SCL
+	"33": 238, // GPIO7_C6_UART2RX_PWM2
+	"32": 239, // GPIO7_C7_UART2TX_PWM3
+	"26": 251, // GPIO8_A3_SPI2CSN1
+	"3":  252, // GPIO8_A4_I2C1_SDA
+	"5":  253, // GPIO8_A5_I2C1_SCL
+	"23": 254, // GPIO8_A6_SPI2CLK
+	"24": 255, // GPIO8_A7_SPI2CSN0
+	"21": 256, // GPIO8_B0_SPI2RXD
+	"19": 257, // GPIO8_B1_SPI2TXD
+}
+
+var pwmPinDefinitions = map[string]pwmPinDefinition{
+	// GPIO7_C6_UART2RX_PWM2
+	"33": pwmPinDefinition{dir: "/sys/devices/platform/ff680020.pwm/pwm/", dirRegexp: "pwmchip2$", channel: 0},
+	// GPIO7_C7_UART2TX_PWM3
+	"32": pwmPinDefinition{dir: "/sys/devices/platform/ff680030.pwm/pwm/", dirRegexp: "pwmchip[2|3]$", channel: 0},
 }


### PR DESCRIPTION
* fix #818 path issue similar to implementation in [beaglebone adaptor](https://github.com/hybridgroup/gobot/blob/release/platforms/beaglebone/beaglebone_adaptor.go). Introduce sysfs.Find() to avoid func in struct.
* fix #818 function order problems in PWMPin().
* fix #818 naming problem with "inverted" by introducing sysfs.SetPolarity()
* read period to use in ServoWrite() - TODO resolved.
* implement SetPeriod()  to ensure automatic adjustment of duty cycle.
* expand error messages in sysfs.pwm_pin.go for better trouble shooting, some other improvements
* adjust tests