### PR TITLE
Feature/i2c readblockdata

### DIFF
--- a/drivers/i2c/helpers_test.go
+++ b/drivers/i2c/helpers_test.go
@@ -68,41 +68,33 @@ func (t *i2cTestAdaptor) ReadByte() (val byte, err error) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 	bytes := []byte{0}
-	bytesRead, err := t.i2cReadImpl(bytes)
-	if err != nil {
-		return 0, err
-	}
-	if bytesRead != 1 {
-		return 0, fmt.Errorf("Buffer underrun")
+	if err = t.readBytes(bytes); err != nil {
+		return
 	}
 	val = bytes[0]
 	return
 }
 
 func (t *i2cTestAdaptor) ReadByteData(reg uint8) (val uint8, err error) {
-	if err = t.WriteByte(reg); err != nil {
-		return
-	}
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-	bytes := []byte{0}
-	bytesRead, err := t.i2cReadImpl(bytes)
-	if err != nil {
-		return 0, err
+	if err = t.writeBytes([]byte{reg}); err != nil {
+		return
 	}
-	if bytesRead != 1 {
-		return 0, fmt.Errorf("Buffer underrun")
+	bytes := []byte{0}
+	if err = t.readBytes(bytes); err != nil {
+		return
 	}
 	val = bytes[0]
 	return
 }
 
 func (t *i2cTestAdaptor) ReadWordData(reg uint8) (val uint16, err error) {
-	if err = t.WriteByte(reg); err != nil {
-		return
-	}
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
+	if err = t.writeBytes([]byte{reg}); err != nil {
+		return
+	}
 	bytes := []byte{0, 0}
 	bytesRead, err := t.i2cReadImpl(bytes)
 	if err != nil {
@@ -115,45 +107,50 @@ func (t *i2cTestAdaptor) ReadWordData(reg uint8) (val uint16, err error) {
 	return (uint16(high) << 8) | uint16(low), err
 }
 
-func (t *i2cTestAdaptor) WriteByte(val byte) (err error) {
+func (t *i2cTestAdaptor) ReadBlockData(reg uint8, b []byte) (err error) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-	t.written = append(t.written, val)
-	bytes := []byte{val}
-	_, err = t.i2cWriteImpl(bytes)
-	return
+	if err = t.writeBytes([]byte{reg}); err != nil {
+		return
+	}
+	return t.readBytes(b)
+}
+
+func (t *i2cTestAdaptor) WriteByte(val byte) error {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	return t.writeBytes([]byte{val})
 }
 
 func (t *i2cTestAdaptor) WriteByteData(reg uint8, val uint8) (err error) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-	t.written = append(t.written, reg)
-	t.written = append(t.written, val)
-	bytes := []byte{val}
-	_, err = t.i2cWriteImpl(bytes)
-	return
+	bytes := []byte{reg, val}
+
+	return t.writeBytes(bytes)
 }
 
-func (t *i2cTestAdaptor) WriteWordData(reg uint8, val uint16) (err error) {
+func (t *i2cTestAdaptor) WriteWordData(reg uint8, val uint16) error {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-	t.written = append(t.written, reg)
 	low := uint8(val & 0xff)
 	high := uint8((val >> 8) & 0xff)
-	t.written = append(t.written, low)
-	t.written = append(t.written, high)
-	bytes := []byte{low, high}
-	_, err = t.i2cWriteImpl(bytes)
-	return
+	bytes := []byte{reg, low, high}
+
+	return t.writeBytes(bytes)
 }
 
-func (t *i2cTestAdaptor) WriteBlockData(reg uint8, b []byte) (err error) {
+func (t *i2cTestAdaptor) WriteBlockData(reg uint8, b []byte) error {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-	t.written = append(t.written, reg)
-	t.written = append(t.written, b...)
-	_, err = t.i2cWriteImpl(b)
-	return
+	if len(b) > 32 {
+		b = b[:32]
+	}
+	buf := make([]byte, len(b)+1)
+	copy(buf[1:], b)
+	buf[0] = reg
+
+	return t.writeBytes(buf)
 }
 
 func (t *i2cTestAdaptor) GetConnection( /* address */ int /* bus */, int) (connection Connection, err error) {
@@ -182,4 +179,25 @@ func newI2cTestAdaptor() *i2cTestAdaptor {
 			return 0, nil
 		},
 	}
+}
+
+func (t *i2cTestAdaptor) readBytes(b []byte) error {
+	n, err := t.i2cReadImpl(b)
+	if err != nil {
+		return err
+	}
+	if n != len(b) {
+		return fmt.Errorf("Read %v bytes from device by i2c helpers, expected %v", n, len(b))
+	}
+	return nil
+}
+
+func (t *i2cTestAdaptor) writeBytes(b []byte) error {
+	t.written = append(t.written, b...)
+	// evaluation of count can be done in test
+	_, err := t.i2cWriteImpl(b)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/drivers/i2c/i2c.go
+++ b/drivers/i2c/i2c.go
@@ -33,14 +33,56 @@ const (
 	set            = 0x01
 )
 
+// I2cOperations represents the i2c methods according to I2C/SMBus specification.
+// Some functions are not in the interface yet:
+// * Process Call (WriteWordDataReadWordData)
+// * Block Write - Block Read (WriteBlockDataReadBlockData)
+// * Host Notify - WriteWordData() can be used instead
+//
+// see: https://docs.kernel.org/i2c/smbus-protocol.html#key-to-symbols
+//
+// S: Start condition; Sr: Repeated start condition, used to switch from write to read mode.
+// P: Stop condition; Rd/Wr (1 bit): Read/Write bit. Rd equals 1, Wr equals 0.
+// A, NA (1 bit): Acknowledge (ACK) and Not Acknowledge (NACK) bit
+// Addr (7 bits): I2C 7 bit address. (10 bit I2C address not yet supported by gobot).
+// Comm (8 bits): Command byte, a data byte which often selects a register on the device.
+// Data (8 bits): A plain data byte. DataLow and DataHigh represent the low and high byte of a 16 bit word.
+// Count (8 bits): A data byte containing the length of a block operation.
+// [..]: Data sent by I2C device, as opposed to data sent by the host adapter.
+//
 type I2cOperations interface {
 	io.ReadWriteCloser
+
+	// ReadByte must be implemented as the sequence:
+	// "S Addr Rd [A] [Data] NA P"
 	ReadByte() (val byte, err error)
+
+	// ReadByteData must be implemented as the sequence:
+	// "S Addr Wr [A] Comm [A] Sr Addr Rd [A] [Data] NA P"
 	ReadByteData(reg uint8) (val uint8, err error)
+
+	// ReadWordData must be implemented as the sequence:
+	// "S Addr Wr [A] Comm [A] Sr Addr Rd [A] [DataLow] A [DataHigh] NA P"
 	ReadWordData(reg uint8) (val uint16, err error)
+
+	// ReadBlockData must be implemented as the sequence:
+	// "S Addr Wr [A] Comm [A] Sr Addr Rd [A] [Count] A [Data] A [Data] A ... A [Data] NA P"
+	ReadBlockData(reg uint8, b []byte) (err error)
+
+	// WriteByte must be implemented as the sequence:
+	// "S Addr Wr [A] Data [A] P"
 	WriteByte(val byte) (err error)
+
+	// WriteByteData must be implemented as the sequence:
+	// "S Addr Wr [A] Comm [A] Data [A] P"
 	WriteByteData(reg uint8, val uint8) (err error)
+
+	// WriteWordData must be implemented as the sequence:
+	// "S Addr Wr [A] Comm [A] DataLow [A] DataHigh [A] P"
 	WriteWordData(reg uint8, val uint16) (err error)
+
+	// WriteBlockData must be implemented as the sequence:
+	// "S Addr Wr [A] Comm [A] Count [A] Data [A] Data [A] ... [A] Data [A] P"
 	WriteBlockData(reg uint8, b []byte) (err error)
 }
 
@@ -144,6 +186,17 @@ func (c *i2cConnection) ReadWordData(reg uint8) (val uint16, err error) {
 		return 0, err
 	}
 	return c.bus.ReadWordData(reg)
+}
+
+// ReadBlockData reads a block of bytes from a register on the i2c device.
+func (c *i2cConnection) ReadBlockData(reg uint8, b []byte) (err error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if err := c.bus.SetAddress(c.address); err != nil {
+		return err
+	}
+	return c.bus.ReadBlockData(reg, b)
 }
 
 // WriteByte writes a single byte to the i2c device.

--- a/platforms/firmata/firmata_adaptor_test.go
+++ b/platforms/firmata/firmata_adaptor_test.go
@@ -7,24 +7,21 @@ import (
 	"io"
 	"strings"
 	"testing"
-	"time"
 
 	"gobot.io/x/gobot"
 	"gobot.io/x/gobot/drivers/aio"
 	"gobot.io/x/gobot/drivers/gpio"
-	"gobot.io/x/gobot/drivers/i2c"
 	"gobot.io/x/gobot/gobottest"
 	"gobot.io/x/gobot/platforms/firmata/client"
 )
 
-// make sure that this Adaptor fullfills all the required interfaces
+// make sure that this Adaptor fulfills all required analog and digital interfaces
 var _ gobot.Adaptor = (*Adaptor)(nil)
 var _ gpio.DigitalReader = (*Adaptor)(nil)
 var _ gpio.DigitalWriter = (*Adaptor)(nil)
 var _ aio.AnalogReader = (*Adaptor)(nil)
 var _ gpio.PwmWriter = (*Adaptor)(nil)
 var _ gpio.ServoWriter = (*Adaptor)(nil)
-var _ i2c.Connector = (*Adaptor)(nil)
 var _ FirmataAdaptor = (*Adaptor)(nil)
 
 type readWriteCloser struct{}
@@ -67,10 +64,10 @@ func newMockFirmataBoard() *mockFirmataBoard {
 	m.pins[1].Value = 1
 	m.pins[15].Value = 133
 
-	m.AddEvent("I2cReply")
 	return m
 }
 
+// setup mock for GPIO, PWM and servo tests
 func (mockFirmataBoard) Connect(io.ReadWriteCloser) error { return nil }
 func (m mockFirmataBoard) Disconnect() error {
 	return m.disconnectError
@@ -83,11 +80,13 @@ func (mockFirmataBoard) SetPinMode(int, int) error       { return nil }
 func (mockFirmataBoard) ReportAnalog(int, int) error     { return nil }
 func (mockFirmataBoard) ReportDigital(int, int) error    { return nil }
 func (mockFirmataBoard) DigitalWrite(int, int) error     { return nil }
-func (mockFirmataBoard) I2cRead(int, int) error          { return nil }
-func (mockFirmataBoard) I2cWrite(int, []byte) error      { return nil }
-func (mockFirmataBoard) I2cConfig(int) error             { return nil }
 func (mockFirmataBoard) ServoConfig(int, int, int) error { return nil }
-func (mockFirmataBoard) WriteSysex(data []byte) error    { return nil }
+func (mockFirmataBoard) WriteSysex([]byte) error         { return nil }
+
+// i2c functions unused in this test scenarios
+func (mockFirmataBoard) I2cRead(int, int) error     { return nil }
+func (mockFirmataBoard) I2cWrite(int, []byte) error { return nil }
+func (mockFirmataBoard) I2cConfig(int) error        { return nil }
 
 func initTestAdaptor() *Adaptor {
 	a := NewAdaptor("/dev/null")
@@ -99,8 +98,8 @@ func initTestAdaptor() *Adaptor {
 	return a
 }
 
-func TestAdaptor(t *testing.T) {
-	a := initTestAdaptor()
+func TestNewAdaptor(t *testing.T) {
+	a := NewAdaptor("/dev/null")
 	gobottest.Assert(t, a.Port(), "/dev/null")
 }
 
@@ -202,130 +201,6 @@ func TestAdaptorAnalogReadBadPin(t *testing.T) {
 	gobottest.Refute(t, err, nil)
 }
 
-func TestAdaptorI2cStart(t *testing.T) {
-	a := initTestAdaptor()
-	i2c, err := a.GetConnection(0, 0)
-	gobottest.Assert(t, err, nil)
-	gobottest.Refute(t, i2c, nil)
-	gobottest.Assert(t, i2c.Close(), nil)
-}
-
-func TestAdaptorI2cRead(t *testing.T) {
-	a := initTestAdaptor()
-	i := []byte{100}
-	i2cReply := client.I2cReply{Data: i}
-	go func() {
-		<-time.After(10 * time.Millisecond)
-		a.Board.Publish(a.Board.Event("I2cReply"), i2cReply)
-	}()
-
-	con, err := a.GetConnection(0, 0)
-	gobottest.Assert(t, err, nil)
-
-	response := []byte{12}
-	_, err = con.Read(response)
-	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, response, i)
-}
-
-func TestAdaptorI2cReadByte(t *testing.T) {
-	a := initTestAdaptor()
-	i := []byte{100}
-	i2cReply := client.I2cReply{Data: i}
-	go func() {
-		<-time.After(10 * time.Millisecond)
-		a.Board.Publish(a.Board.Event("I2cReply"), i2cReply)
-	}()
-
-	con, err := a.GetConnection(0, 0)
-	gobottest.Assert(t, err, nil)
-
-	var val byte
-	val, err = con.ReadByte()
-	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, val, uint8(100))
-}
-
-func TestAdaptorI2cReadByteData(t *testing.T) {
-	a := initTestAdaptor()
-	i := []byte{100}
-	i2cReply := client.I2cReply{Data: i}
-	go func() {
-		<-time.After(10 * time.Millisecond)
-		a.Board.Publish(a.Board.Event("I2cReply"), i2cReply)
-	}()
-
-	con, err := a.GetConnection(0, 0)
-	gobottest.Assert(t, err, nil)
-
-	var val byte
-	val, err = con.ReadByteData(0x01)
-	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, val, uint8(100))
-}
-
-func TestAdaptorI2cReadWordData(t *testing.T) {
-	a := initTestAdaptor()
-	i := []byte{100}
-	i2cReply := client.I2cReply{Data: i}
-	go func() {
-		<-time.After(10 * time.Millisecond)
-		a.Board.Publish(a.Board.Event("I2cReply"), i2cReply)
-	}()
-
-	con, err := a.GetConnection(0, 0)
-	gobottest.Assert(t, err, nil)
-
-	var val uint16
-	val, err = con.ReadWordData(0x01)
-	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, val, uint16(100))
-}
-
-func TestAdaptorI2cWrite(t *testing.T) {
-	a := initTestAdaptor()
-	con, err := a.GetConnection(0, 0)
-	gobottest.Assert(t, err, nil)
-	written, _ := con.Write([]byte{0x00, 0x01})
-	gobottest.Assert(t, written, 2)
-}
-
-func TestAdaptorI2cWrite20bytes(t *testing.T) {
-	a := initTestAdaptor()
-	con, err := a.GetConnection(0, 0)
-	gobottest.Assert(t, err, nil)
-	written, _ := con.Write([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19})
-	gobottest.Assert(t, written, 20)
-}
-
-func TestAdaptorI2cWriteByte(t *testing.T) {
-	a := initTestAdaptor()
-	con, err := a.GetConnection(0, 0)
-	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, con.WriteByte(0x00), nil)
-}
-
-func TestAdaptorI2cWriteByteData(t *testing.T) {
-	a := initTestAdaptor()
-	con, err := a.GetConnection(0, 0)
-	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, con.WriteByteData(0x00, 0x02), nil)
-}
-
-func TestAdaptorI2cWriteWordData(t *testing.T) {
-	a := initTestAdaptor()
-	con, err := a.GetConnection(0, 0)
-	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, con.WriteWordData(0x00, 0x02), nil)
-}
-
-func TestAdaptorI2cWriteBlockData(t *testing.T) {
-	a := initTestAdaptor()
-	con, err := a.GetConnection(0, 0)
-	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, con.WriteBlockData(0x00, []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19}), nil)
-}
-
 func TestServoConfig(t *testing.T) {
 	a := initTestAdaptor()
 	err := a.ServoConfig("9", 0, 0)
@@ -334,15 +209,4 @@ func TestServoConfig(t *testing.T) {
 	// test atoi error
 	err = a.ServoConfig("a", 0, 0)
 	gobottest.Assert(t, true, strings.Contains(fmt.Sprintf("%v", err), "invalid syntax"))
-}
-
-func TestDefaultBus(t *testing.T) {
-	a := initTestAdaptor()
-	gobottest.Assert(t, a.GetDefaultBus(), 0)
-}
-
-func TestGetConnectionInvalidBus(t *testing.T) {
-	a := initTestAdaptor()
-	_, err := a.GetConnection(0x01, 99)
-	gobottest.Assert(t, err, errors.New("Invalid bus number 99, only 0 is supported"))
 }

--- a/platforms/firmata/firmata_i2c.go
+++ b/platforms/firmata/firmata_i2c.go
@@ -1,13 +1,17 @@
 package firmata
 
 import (
-	//	"gobot.io/x/gobot/drivers/i2c"
+	"fmt"
+	"sync"
+
 	"gobot.io/x/gobot/platforms/firmata/client"
 )
 
+// firmataI2cConnection implements the interface i2c.I2cOperations
 type firmataI2cConnection struct {
 	address int
 	adaptor *Adaptor
+	mtx     sync.Mutex
 }
 
 // NewFirmataI2cConnection creates an I2C connection to an I2C device at
@@ -19,6 +23,163 @@ func NewFirmataI2cConnection(adaptor *Adaptor, address int) (connection *firmata
 // Read tries to read a full buffer from the i2c device.
 // Returns an empty array if the response from the board has timed out.
 func (c *firmataI2cConnection) Read(b []byte) (read int, err error) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	return c.readInternal(b)
+}
+
+// Write writes the buffer content in data to the i2c device.
+func (c *firmataI2cConnection) Write(data []byte) (written int, err error) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	return c.writeInternal(data)
+}
+
+// Close do nothing than return nil.
+func (c *firmataI2cConnection) Close() error {
+	return nil
+}
+
+// ReadByte reads one byte from the i2c device.
+func (c *firmataI2cConnection) ReadByte() (byte, error) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	buf := []byte{0}
+	if err := c.readAndCheckCount(buf); err != nil {
+		return 0, err
+	}
+	return buf[0], nil
+}
+
+// ReadByteData reads one byte of the given register address from the i2c device.
+// TODO: implement the specification, because some devices will not work with this
+//       current:  "S Addr Wr [A] Comm [A] P S Addr Rd [A] [Data] NA P"
+//       required: "S Addr Wr [A] Comm [A] S Addr Rd [A] [Data] NA P"
+func (c *firmataI2cConnection) ReadByteData(reg uint8) (uint8, error) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	if err := c.writeAndCheckCount([]byte{reg}); err != nil {
+		return 0, err
+	}
+
+	buf := []byte{0}
+	if err := c.readAndCheckCount(buf); err != nil {
+		return 0, err
+	}
+	return buf[0], nil
+}
+
+// ReadWordData reads two bytes of the given register address from the i2c device.
+// TODO: implement the specification, because some devices will not work with this
+//       current:  "S Addr Wr [A] Comm [A] P S Addr Rd [A] [DataLow] A [DataHigh] NA P"
+//       required: "S Addr Wr [A] Comm [A] S Addr Rd [A] [DataLow] A [DataHigh] NA P"
+func (c *firmataI2cConnection) ReadWordData(reg uint8) (uint16, error) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	if err := c.writeAndCheckCount([]byte{reg}); err != nil {
+		return uint16(0), err
+	}
+
+	buf := []byte{0, 0}
+	if err := c.readAndCheckCount(buf); err != nil {
+		return uint16(0), err
+	}
+	low, high := buf[0], buf[1]
+	return (uint16(high) << 8) | uint16(low), nil
+}
+
+// ReadBlockData reads a block of maximum 32 bytes from the given register address of the i2c device.
+// TODO: implement the specification, because some devices will not work with this
+//       current:  "S Addr Wr [A] Comm [A] P S Addr Rd [A] [Count] A [Data] A [Data] A ... A [Data] NA P"
+//       required: "S Addr Wr [A] Comm [A] S Addr Rd [A] [Count] A [Data] A [Data] A ... A [Data] NA P"
+func (c *firmataI2cConnection) ReadBlockData(reg uint8, data []byte) error {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	if err := c.writeAndCheckCount([]byte{reg}); err != nil {
+		return err
+	}
+
+	if len(data) > 32 {
+		data = data[:32]
+	}
+	return c.readAndCheckCount(data)
+}
+
+// WriteByte writes one byte to the i2c device.
+func (c *firmataI2cConnection) WriteByte(val byte) error {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	buf := []byte{val}
+	return c.writeAndCheckCount(buf)
+}
+
+// WriteByteData writes one byte to the given register address of the i2c device.
+func (c *firmataI2cConnection) WriteByteData(reg uint8, val byte) error {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	buf := []byte{reg, val}
+	return c.writeAndCheckCount(buf)
+}
+
+// WriteWordData writes two bytes to the given register address of the i2c device.
+func (c *firmataI2cConnection) WriteWordData(reg uint8, val uint16) error {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	low := uint8(val & 0xff)
+	high := uint8((val >> 8) & 0xff)
+	buf := []byte{reg, low, high}
+	return c.writeAndCheckCount(buf)
+}
+
+// WriteBlockData writes a block of maximum 32 bytes to the given register address of the i2c device.
+func (c *firmataI2cConnection) WriteBlockData(reg uint8, data []byte) error {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	if len(data) > 32 {
+		data = data[:32]
+	}
+
+	buf := make([]byte, len(data)+1)
+	copy(buf[1:], data)
+	buf[0] = reg
+	return c.writeAndCheckCount(buf)
+}
+
+func (c *firmataI2cConnection) readAndCheckCount(buf []byte) error {
+	countRead, err := c.readInternal(buf)
+	if err != nil {
+		return err
+	}
+	expectedCount := len(buf)
+	if countRead != expectedCount {
+		return fmt.Errorf("Firmata i2c read %d bytes, expected %d bytes", countRead, expectedCount)
+	}
+	return nil
+}
+
+func (c *firmataI2cConnection) writeAndCheckCount(buf []byte) error {
+	countWritten, err := c.writeInternal(buf)
+	if err != nil {
+		return err
+	}
+	expectedCount := len(buf)
+	if countWritten != expectedCount {
+		return fmt.Errorf("Firmata i2c write %d bytes, expected %d bytes", countWritten, expectedCount)
+	}
+	return nil
+}
+
+func (c *firmataI2cConnection) readInternal(b []byte) (read int, err error) {
 	ret := make(chan []byte)
 
 	if err = c.adaptor.Board.I2cRead(c.address, len(b)); err != nil {
@@ -37,7 +198,7 @@ func (c *firmataI2cConnection) Read(b []byte) (read int, err error) {
 	return
 }
 
-func (c *firmataI2cConnection) Write(data []byte) (written int, err error) {
+func (c *firmataI2cConnection) writeInternal(data []byte) (written int, err error) {
 	var chunk []byte
 	for len(data) >= 16 {
 		chunk, data = data[:16], data[16:]
@@ -51,72 +212,5 @@ func (c *firmataI2cConnection) Write(data []byte) (written int, err error) {
 		err = c.adaptor.Board.I2cWrite(c.address, data[:])
 		written += len(data)
 	}
-	return
-}
-
-func (c *firmataI2cConnection) Close() error {
-	return nil
-}
-
-func (c *firmataI2cConnection) ReadByte() (val byte, err error) {
-	buf := []byte{0}
-	if _, err = c.Read(buf); err != nil {
-		return
-	}
-	val = buf[0]
-	return
-}
-
-func (c *firmataI2cConnection) ReadByteData(reg uint8) (val uint8, err error) {
-	if err = c.WriteByte(reg); err != nil {
-		return
-	}
-	return c.ReadByte()
-}
-
-func (c *firmataI2cConnection) ReadWordData(reg uint8) (val uint16, err error) {
-	if err = c.WriteByte(reg); err != nil {
-		return
-	}
-
-	buf := []byte{0, 0}
-	if _, err = c.Read(buf); err != nil {
-		return
-	}
-	low, high := buf[0], buf[1]
-
-	val = (uint16(high) << 8) | uint16(low)
-	return
-}
-
-func (c *firmataI2cConnection) WriteByte(val byte) (err error) {
-	buf := []byte{val}
-	_, err = c.Write(buf)
-	return
-}
-
-func (c *firmataI2cConnection) WriteByteData(reg uint8, val byte) (err error) {
-	buf := []byte{reg, val}
-	_, err = c.Write(buf)
-	return
-}
-
-func (c *firmataI2cConnection) WriteWordData(reg uint8, val uint16) (err error) {
-	low := uint8(val & 0xff)
-	high := uint8((val >> 8) & 0xff)
-	buf := []byte{reg, low, high}
-	_, err = c.Write(buf)
-	return
-}
-
-func (c *firmataI2cConnection) WriteBlockData(reg uint8, data []byte) (err error) {
-	if len(data) > 32 {
-		data = data[:32]
-	}
-
-	buf := make([]byte, len(data)+1)
-	copy(buf[:1], data)
-	buf[0] = reg
-	_, err = c.Write(buf)
 	return
 }

--- a/platforms/firmata/firmata_i2c_test.go
+++ b/platforms/firmata/firmata_i2c_test.go
@@ -1,0 +1,248 @@
+package firmata
+
+import (
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/drivers/i2c"
+	"gobot.io/x/gobot/gobottest"
+	"gobot.io/x/gobot/platforms/firmata/client"
+)
+
+// make sure that this Adaptor fulfills all required I2C interfaces
+var _ i2c.Connector = (*Adaptor)(nil)
+
+type i2cMockFirmataBoard struct {
+	gobot.Eventer
+	i2cDataForRead []byte
+	numBytesToRead int
+	i2cWritten     []byte
+	i2cWriteImpl   func([]byte) (int, error)
+}
+
+// setup mock for i2c tests
+func (t *i2cMockFirmataBoard) I2cRead(address int, numBytes int) error {
+	t.numBytesToRead = numBytes
+	i2cReply := client.I2cReply{Data: t.i2cDataForRead}
+	go func() {
+		<-time.After(10 * time.Millisecond)
+		t.Publish(t.Event("I2cReply"), i2cReply)
+	}()
+	return nil
+}
+func (t *i2cMockFirmataBoard) I2cWrite(address int, data []byte) error {
+	t.i2cWritten = append(t.i2cWritten, data...)
+	return nil
+}
+func (i2cMockFirmataBoard) I2cConfig(int) error { return nil }
+
+// GPIO, PWM and servo functions unused in this test scenarios
+func (i2cMockFirmataBoard) Connect(io.ReadWriteCloser) error { return nil }
+func (i2cMockFirmataBoard) Disconnect() error                { return nil }
+func (i2cMockFirmataBoard) Pins() []client.Pin               { return nil }
+func (i2cMockFirmataBoard) AnalogWrite(int, int) error       { return nil }
+func (i2cMockFirmataBoard) SetPinMode(int, int) error        { return nil }
+func (i2cMockFirmataBoard) ReportAnalog(int, int) error      { return nil }
+func (i2cMockFirmataBoard) ReportDigital(int, int) error     { return nil }
+func (i2cMockFirmataBoard) DigitalWrite(int, int) error      { return nil }
+func (i2cMockFirmataBoard) ServoConfig(int, int, int) error  { return nil }
+
+// WriteSysex of the client implementation not tested here
+func (i2cMockFirmataBoard) WriteSysex([]byte) error { return nil }
+
+func newI2cMockFirmataBoard() *i2cMockFirmataBoard {
+	m := &i2cMockFirmataBoard{
+		Eventer: gobot.NewEventer(),
+	}
+	m.AddEvent("I2cReply")
+	return m
+}
+
+func initTestTestAdaptorWithI2cConnection() (i2c.Connection, *i2cMockFirmataBoard) {
+	a := NewAdaptor()
+	a.Board = newI2cMockFirmataBoard()
+	con, err := a.GetConnection(0, 0)
+	if err != nil {
+		panic(err)
+	}
+	return con, a.Board.(*i2cMockFirmataBoard)
+}
+
+func TestClose(t *testing.T) {
+	i2c, _ := initTestTestAdaptorWithI2cConnection()
+	gobottest.Assert(t, i2c.Close(), nil)
+}
+
+func TestRead(t *testing.T) {
+	// arrange
+	con, brd := initTestTestAdaptorWithI2cConnection()
+	brd.i2cDataForRead = []byte{111}
+	buf := []byte{0}
+	// act
+	countRead, err := con.Read(buf)
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, countRead, 1)
+	gobottest.Assert(t, brd.numBytesToRead, 1)
+	gobottest.Assert(t, buf, brd.i2cDataForRead)
+	gobottest.Assert(t, len(brd.i2cWritten), 0)
+}
+
+func TestReadByte(t *testing.T) {
+	// arrange
+	con, brd := initTestTestAdaptorWithI2cConnection()
+	brd.i2cDataForRead = []byte{222}
+	// act
+	val, err := con.ReadByte()
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, brd.numBytesToRead, 1)
+	gobottest.Assert(t, val, brd.i2cDataForRead[0])
+	gobottest.Assert(t, len(brd.i2cWritten), 0)
+}
+
+func TestReadByteData(t *testing.T) {
+	// arrange
+	con, brd := initTestTestAdaptorWithI2cConnection()
+	brd.i2cDataForRead = []byte{100}
+	reg := uint8(0x01)
+	// act
+	val, err := con.ReadByteData(reg)
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, brd.numBytesToRead, 1)
+	gobottest.Assert(t, val, brd.i2cDataForRead[0])
+	gobottest.Assert(t, len(brd.i2cWritten), 1)
+	gobottest.Assert(t, brd.i2cWritten[0], reg)
+}
+
+func TestReadWordData(t *testing.T) {
+	// arrange
+	con, brd := initTestTestAdaptorWithI2cConnection()
+	lsb := uint8(0x11)
+	msb := uint8(0xff)
+	brd.i2cDataForRead = []byte{lsb, msb}
+	reg := uint8(0x22)
+	// act
+	val, err := con.ReadWordData(reg)
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, brd.numBytesToRead, 2)
+	gobottest.Assert(t, val, uint16(lsb)|uint16(msb)<<8)
+	gobottest.Assert(t, len(brd.i2cWritten), 1)
+	gobottest.Assert(t, brd.i2cWritten[0], reg)
+}
+
+func TestReadBlockData(t *testing.T) {
+	// arrange
+	con, brd := initTestTestAdaptorWithI2cConnection()
+	brd.i2cDataForRead = []byte{50, 40, 30, 20, 10}
+	reg := uint8(0x33)
+	buf := []byte{1, 2, 3, 4, 5}
+	// act
+	err := con.ReadBlockData(reg, buf)
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, brd.numBytesToRead, 5)
+	gobottest.Assert(t, buf, brd.i2cDataForRead)
+	gobottest.Assert(t, len(brd.i2cWritten), 1)
+	gobottest.Assert(t, brd.i2cWritten[0], reg)
+}
+
+func TestWrite(t *testing.T) {
+	// arrange
+	con, brd := initTestTestAdaptorWithI2cConnection()
+	want := []byte{0x00, 0x01}
+	wantLen := len(want)
+	// act
+	written, err := con.Write(want)
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, written, wantLen)
+	gobottest.Assert(t, brd.i2cWritten, want)
+}
+
+func TestWrite20bytes(t *testing.T) {
+	// arrange
+	con, brd := initTestTestAdaptorWithI2cConnection()
+	want := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19}
+	wantLen := len(want)
+	// act
+	written, err := con.Write(want)
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, written, wantLen)
+	gobottest.Assert(t, brd.i2cWritten, want)
+}
+
+func TestWriteByte(t *testing.T) {
+	// arrange
+	con, brd := initTestTestAdaptorWithI2cConnection()
+	want := uint8(0x11)
+	// act
+	err := con.WriteByte(want)
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, len(brd.i2cWritten), 1)
+	gobottest.Assert(t, brd.i2cWritten[0], want)
+}
+
+func TestWriteByteData(t *testing.T) {
+	// arrange
+	con, brd := initTestTestAdaptorWithI2cConnection()
+	reg := uint8(0x12)
+	val := uint8(0x22)
+	// act
+	err := con.WriteByteData(reg, val)
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, len(brd.i2cWritten), 2)
+	gobottest.Assert(t, brd.i2cWritten[0], reg)
+	gobottest.Assert(t, brd.i2cWritten[1], val)
+}
+
+func TestWriteWordData(t *testing.T) {
+	// arrange
+	con, brd := initTestTestAdaptorWithI2cConnection()
+	reg := uint8(0x13)
+	val := uint16(0x8002)
+	// act
+	err := con.WriteWordData(reg, val)
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, len(brd.i2cWritten), 3)
+	gobottest.Assert(t, brd.i2cWritten[0], reg)
+	gobottest.Assert(t, brd.i2cWritten[1], uint8(val&0x00FF))
+	gobottest.Assert(t, brd.i2cWritten[2], uint8(val>>8))
+}
+
+func TestWriteBlockData(t *testing.T) {
+	// arrange
+	con, brd := initTestTestAdaptorWithI2cConnection()
+	reg := uint8(0x14)
+	val := []byte{}
+	// we prepare more than 32 bytes, because the call has to drop it
+	for i := uint8(0); i < 40; i++ {
+		val = append(val, i)
+	}
+	// act
+	err := con.WriteBlockData(reg, val)
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, len(brd.i2cWritten), 33)
+	gobottest.Assert(t, brd.i2cWritten[0], reg)
+	gobottest.Assert(t, brd.i2cWritten[1:], val[0:32])
+}
+
+func TestDefaultBus(t *testing.T) {
+	a := NewAdaptor()
+	gobottest.Assert(t, a.GetDefaultBus(), 0)
+}
+
+func TestGetConnectionInvalidBus(t *testing.T) {
+	a := NewAdaptor()
+	_, err := a.GetConnection(0x01, 99)
+	gobottest.Assert(t, err, errors.New("Invalid bus number 99, only 0 is supported"))
+}


### PR DESCRIPTION
This is for issue #832 
* add ReadBlockData for i2c, sysfs, digispark, firmata
* split test file for i2c test in firmata (just like digispark)
* FIX: Read*Data() for digispark
* FIX: WriteBlockData for digispark, firmata and helpers_test (only the first data byte was used)
* FIX: interruption of write_register-read_data possible in digispark, fixed by introduce mutex
* add tests
* use new function for suitable devices
  * HMC5883L will be done together with #831
  * TH02, will be done together with #841 
  * MPU6050, will be done together with #838 
  * MPL1115A2, will be done with #843 
  * L3GD20H, will be done together with #844 
  * CCS811, will be done with #846 
  * BMxy8z, will be done with #847 
  * ADXL345, will be done with #851 