### PR TITLE
BUGFIX/Improvement: mpu6050 wrong initialize

### DIFF
--- a/drivers/i2c/mpu6050_driver.go
+++ b/drivers/i2c/mpu6050_driver.go
@@ -3,49 +3,121 @@ package i2c
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"log"
 	"time"
-
-	"gobot.io/x/gobot"
 )
 
-const mpu6050Address = 0x68
+const (
+	mpu6050Debug                = false
+	mpu6050DefaultAddress       = 0x68
+	mpu6050EarthStandardGravity = 9.80665 // [m/s²] standard gravity (pole: 9.834,  equator: 9.764)
+)
 
-const MPU6050_RA_ACCEL_XOUT_H = 0x3B
-const MPU6050_RA_PWR_MGMT_1 = 0x6B
-const MPU6050_PWR1_CLKSEL_BIT = 2
-const MPU6050_PWR1_CLKSEL_LENGTH = 3
-const MPU6050_CLOCK_PLL_XGYRO = 0x01
-const MPU6050_GYRO_FS_250 = 0x00
-const MPU6050_RA_GYRO_CONFIG = 0x1B
-const MPU6050_GCONFIG_FS_SEL_LENGTH = 2
-const MPU6050_GCONFIG_FS_SEL_BIT = 4
-const MPU6050_RA_ACCEL_CONFIG = 0x1C
-const MPU6050_ACONFIG_AFS_SEL_BIT = 4
-const MPU6050_ACONFIG_AFS_SEL_LENGTH = 2
-const MPU6050_ACCEL_FS_2 = 0x00
-const MPU6050_PWR1_SLEEP_BIT = 6
-const MPU6050_PWR1_ENABLE_BIT = 0
+type MPU6050DlpfConfig uint8
+type MPU6050FrameSyncConfig uint8
+type MPU6050GyroFsConfig uint8
+type MPU6050AccelFsConfig uint8
+type MPU6050Pwr1ClockConfig uint8
 
-type ThreeDData struct {
-	X int16
-	Y int16
-	Z int16
+const (
+	mpu6050Reg_GeneralConfig   = 0x1A // external frame synchronization and digital low pass filter
+	mpu6050Reg_GyroConfig      = 0x1B // self test and full scale range
+	mpu6050Reg_AccelConfig     = 0x1C // self test and full scale range
+	mpu6050Reg_AccelXoutH      = 0x3B // first data register
+	mpu6050Reg_SignalPathReset = 0x68
+	mpu6050Reg_PwrMgmt1        = 0x6B
+
+	MPU6050General_Dlpf260Hz MPU6050DlpfConfig = 0x00
+	MPU6050General_Dlpf184Hz MPU6050DlpfConfig = 0x01
+	MPU6050General_Dlpf94Hz  MPU6050DlpfConfig = 0x02
+	MPU6050General_Dlpf44Hz  MPU6050DlpfConfig = 0x03
+	MPU6050General_Dlpf21Hz  MPU6050DlpfConfig = 0x04
+	MPU6050General_Dlpf10Hz  MPU6050DlpfConfig = 0x05
+	MPU6050General_Dlpf5Hz   MPU6050DlpfConfig = 0x06
+
+	MPU6050General_FrameSyncDisabled MPU6050FrameSyncConfig = 0x00
+	MPU6050General_FrameSyncTemp     MPU6050FrameSyncConfig = 0x01
+	MPU6050General_FrameSyncGyroX    MPU6050FrameSyncConfig = 0x02
+	MPU6050General_FrameSyncGyroY    MPU6050FrameSyncConfig = 0x03
+	MPU6050General_FrameSyncGyroZ    MPU6050FrameSyncConfig = 0x04
+	MPU6050General_FrameSyncAccelX   MPU6050FrameSyncConfig = 0x05
+	MPU6050General_FrameSyncAccelY   MPU6050FrameSyncConfig = 0x06
+	MPU6050General_FrameSyncAccelZ   MPU6050FrameSyncConfig = 0x07
+
+	MPU6050Gyro_FsSel250dps  MPU6050GyroFsConfig = 0x00 // +/- 250 °/s
+	MPU6050Gyro_FsSel500dps  MPU6050GyroFsConfig = 0x01 // +/- 500 °/s
+	MPU6050Gyro_FsSel1000dps MPU6050GyroFsConfig = 0x02 // +/- 1000 °/s
+	MPU6050Gyro_FsSel2000dps MPU6050GyroFsConfig = 0x03 // +/- 2000 °/s
+
+	MPU6050Accel_AFsSel2g  MPU6050AccelFsConfig = 0x00 // +/- 2 g
+	MPU6050Accel_AFsSel4g  MPU6050AccelFsConfig = 0x01 // +/- 4 g
+	MPU6050Accel_AFsSel8g  MPU6050AccelFsConfig = 0x02 // +/- 8 g
+	MPU6050Accel_AFsSel16g MPU6050AccelFsConfig = 0x03 // +/- 16 g
+
+	mpu6050SignalReset_TempBit  = 0x01
+	mpu6050SignalReset_AccelBit = 0x02
+	mpu6050SignalReset_GyroBit  = 0x04
+
+	MPU6050Pwr1_ClockIntern8G  MPU6050Pwr1ClockConfig = 0x00 // internal 8GHz
+	MPU6050Pwr1_ClockPllXGyro  MPU6050Pwr1ClockConfig = 0x01 // PLL with X axis gyroscope reference
+	MPU6050Pwr1_ClockPllYGyro  MPU6050Pwr1ClockConfig = 0x02 // PLL with Y axis gyroscope reference
+	MPU6050Pwr1_ClockPllZGyro  MPU6050Pwr1ClockConfig = 0x03 // PLL with Z axis gyroscope reference
+	MPU6050Pwr1_ClockPllExt32K MPU6050Pwr1ClockConfig = 0x04 // PLL with external 32.768kHz reference
+	MPU6050Pwr1_ClockPllExt19M MPU6050Pwr1ClockConfig = 0x05 // PLL with external 19.2MHz reference
+	MPU6050Pwr1_ClockStop      MPU6050Pwr1ClockConfig = 0x07 // Stops the clock and keeps the timing generator in reset
+
+	mpu6050Pwr1_SleepOnBit     = 0x40 // put into low power sleep mode
+	mpu6050Pwr1_DeviceResetBit = 0x80
+)
+
+type MPU6050ThreeDData struct {
+	X float64
+	Y float64
+	Z float64
 }
 
-// MPU6050Driver is a new Gobot Driver for an MPU6050 I2C Accelerometer/Gyroscope.
+// MPU6050Driver is a Gobot Driver for an MPU6050 I2C Accelerometer/Gyroscope/Temperature sensor.
+//
+// This driver was tested with Tinkerboard & Digispark adaptor and a MPU6050 breakout board GY-521,
+// available from various distributors.
+//
+// datasheet:
+// https://product.tdk.com/system/files/dam/doc/product/sensor/mortion-inertial/imu/data_sheet/mpu-6000-datasheet1.pdf
+//
+// reference implementations:
+// * https://github.com/adafruit/Adafruit_CircuitPython_MPU6050
+// * https://github.com/ElectronicCats/mpu6050
 type MPU6050Driver struct {
-	name       string
-	connector  Connector
-	connection Connection
-	Config
-	interval      time.Duration
-	Accelerometer ThreeDData
-	Gyroscope     ThreeDData
-	Temperature   int16
-	gobot.Eventer
+	*Driver
+	Accelerometer MPU6050ThreeDData
+	Gyroscope     MPU6050ThreeDData
+	Temperature   float64
+	dlpf          MPU6050DlpfConfig
+	frameSync     MPU6050FrameSyncConfig
+	accelFs       MPU6050AccelFsConfig
+	gyroFs        MPU6050GyroFsConfig
+	clock         MPU6050Pwr1ClockConfig
+	gravity       float64 // set to 1.0 leads to [g]
 }
 
-// NewMPU6050Driver creates a new Gobot Driver for an MPU6050 I2C Accelerometer/Gyroscope.
+// mpu6050AccelGain in 1/g
+var mpu6050AccelGain = map[MPU6050AccelFsConfig]uint16{
+	MPU6050Accel_AFsSel2g:  16384,
+	MPU6050Accel_AFsSel4g:  8192,
+	MPU6050Accel_AFsSel8g:  4096,
+	MPU6050Accel_AFsSel16g: 2028,
+}
+
+// mpu6050GyroGain in s/°
+var mpu6050GyroGain = map[MPU6050GyroFsConfig]float64{
+	MPU6050Gyro_FsSel250dps:  131.0,
+	MPU6050Gyro_FsSel500dps:  65.5,
+	MPU6050Gyro_FsSel1000dps: 32.8,
+	MPU6050Gyro_FsSel2000dps: 16.4,
+}
+
+// NewMPU6050Driver creates a new Gobot Driver for an MPU6050 I2C Accelerometer/Gyroscope/Temperature sensor.
 //
 // Params:
 //		conn Connector - the Adaptor to use with this Driver
@@ -56,11 +128,15 @@ type MPU6050Driver struct {
 //
 func NewMPU6050Driver(a Connector, options ...func(Config)) *MPU6050Driver {
 	m := &MPU6050Driver{
-		name:      gobot.DefaultName("MPU6050"),
-		connector: a,
-		Config:    NewConfig(),
-		Eventer:   gobot.NewEventer(),
+		Driver:    NewDriver(a, "MPU6050", mpu6050DefaultAddress),
+		dlpf:      MPU6050General_Dlpf260Hz,
+		frameSync: MPU6050General_FrameSyncDisabled,
+		accelFs:   MPU6050Accel_AFsSel2g,
+		gyroFs:    MPU6050Gyro_FsSel250dps,
+		clock:     MPU6050Pwr1_ClockPllXGyro,
+		gravity:   mpu6050EarthStandardGravity,
 	}
+	m.afterStart = m.initialize
 
 	for _, option := range options {
 		option(m)
@@ -70,95 +146,172 @@ func NewMPU6050Driver(a Connector, options ...func(Config)) *MPU6050Driver {
 	return m
 }
 
-// Name returns the name of the device.
-func (h *MPU6050Driver) Name() string { return h.name }
-
-// SetName sets the name of the device.
-func (h *MPU6050Driver) SetName(n string) { h.name = n }
-
-// Connection returns the connection for the device.
-func (h *MPU6050Driver) Connection() gobot.Connection { return h.connector.(gobot.Connection) }
-
-// Start writes initialization bytes to sensor
-func (h *MPU6050Driver) Start() (err error) {
-	if err := h.initialize(); err != nil {
-		return err
+// WithMPU6050DigitalFilter option sets the digital low pass filter bandwidth frequency.
+// Valid settings are of type "MPU6050DlpfConfig"
+func WithMPU6050DigitalFilter(val MPU6050DlpfConfig) func(Config) {
+	return func(c Config) {
+		if d, ok := c.(*MPU6050Driver); ok {
+			d.dlpf = val
+		} else if mpu6050Debug {
+			log.Printf("Trying to set digital low pass filter for non-MPU6050Driver %v", c)
+		}
 	}
-
-	return
 }
 
-// Halt returns true if devices is halted successfully
-func (h *MPU6050Driver) Halt() (err error) { return }
+// WithMPU6050FrameSync option sets the external frame synchronization.
+// Valid settings are of type "MPU6050FrameSyncConfig"
+func WithMPU6050FrameSync(val MPU6050FrameSyncConfig) func(Config) {
+	return func(c Config) {
+		if d, ok := c.(*MPU6050Driver); ok {
+			d.frameSync = val
+		} else if mpu6050Debug {
+			log.Printf("Trying to set external frame synchronization for non-MPU6050Driver %v", c)
+		}
+	}
+}
+
+// WithMPU6050AccelFullScaleRange option sets the full scale range for the accelerometer.
+// Valid settings are of type "MPU6050AccelFsConfig"
+func WithMPU6050AccelFullScaleRange(val MPU6050AccelFsConfig) func(Config) {
+	return func(c Config) {
+		if d, ok := c.(*MPU6050Driver); ok {
+			d.accelFs = val
+		} else if mpu6050Debug {
+			log.Printf("Trying to set full scale range of accelerometer for non-MPU6050Driver %v", c)
+		}
+	}
+}
+
+// WithMPU6050GyroFullScaleRange option sets the full scale range for the gyroscope.
+// Valid settings are of type "MPU6050GyroFsConfig"
+func WithMPU6050GyroFullScaleRange(val MPU6050GyroFsConfig) func(Config) {
+	return func(c Config) {
+		if d, ok := c.(*MPU6050Driver); ok {
+			d.gyroFs = val
+		} else if mpu6050Debug {
+			log.Printf("Trying to set full scale range of gyroscope for non-MPU6050Driver %v", c)
+		}
+	}
+}
+
+// WithMPU6050ClockSource option sets the clock source.
+// Valid settings are of type "MPU6050Pwr1ClockConfig"
+func WithMPU6050ClockSource(val MPU6050Pwr1ClockConfig) func(Config) {
+	return func(c Config) {
+		if d, ok := c.(*MPU6050Driver); ok {
+			d.clock = val
+		} else if mpu6050Debug {
+			log.Printf("Trying to set clock source for non-MPU6050Driver %v", c)
+		}
+	}
+}
+
+// WithMPU6050Gravity option sets the gravity in [m/s²/g].
+// Useful settings are "1.0" (to use unit "g") or a value between 9.834 (pole) and 9.764 (equator)
+func WithMPU6050Gravity(val float64) func(Config) {
+	return func(c Config) {
+		if d, ok := c.(*MPU6050Driver); ok {
+			d.gravity = val
+		} else if mpu6050Debug {
+			log.Printf("Trying to set gravity for non-MPU6050Driver %v", c)
+		}
+	}
+}
 
 // GetData fetches the latest data from the MPU6050
-func (h *MPU6050Driver) GetData() (err error) {
-	if _, err = h.connection.Write([]byte{MPU6050_RA_ACCEL_XOUT_H}); err != nil {
+func (m *MPU6050Driver) GetData() (err error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	data := make([]byte, 14)
+	err = m.connection.ReadBlockData(mpu6050Reg_AccelXoutH, data)
+	if err != nil {
 		return
 	}
 
-	data := make([]byte, 14)
-	_, err = h.connection.Read(data)
-	if err != nil {
-		return
+	var accel struct {
+		X int16
+		Y int16
+		Z int16
+	}
+	var temp int16
+	var gyro struct {
+		X int16
+		Y int16
+		Z int16
 	}
 
 	buf := bytes.NewBuffer(data)
-	binary.Read(buf, binary.BigEndian, &h.Accelerometer)
-	binary.Read(buf, binary.BigEndian, &h.Temperature)
-	binary.Read(buf, binary.BigEndian, &h.Gyroscope)
-	h.convertToCelsius()
+	binary.Read(buf, binary.BigEndian, &accel)
+	binary.Read(buf, binary.BigEndian, &temp)
+	binary.Read(buf, binary.BigEndian, &gyro)
+
+	ag := float64(mpu6050AccelGain[m.accelFs]) / m.gravity
+	m.Accelerometer.X = float64(accel.X) / ag
+	m.Accelerometer.Y = float64(accel.Y) / ag
+	m.Accelerometer.Z = float64(accel.Z) / ag
+
+	m.Temperature = float64(temp)/340 + 36.53
+
+	gg := mpu6050GyroGain[m.gyroFs]
+	m.Gyroscope.X = float64(gyro.X) / gg
+	m.Gyroscope.Y = float64(gyro.Y) / gg
+	m.Gyroscope.Z = float64(gyro.Z) / gg
+
 	return
 }
 
-func (h *MPU6050Driver) initialize() (err error) {
-	bus := h.GetBusOrDefault(h.connector.GetDefaultBus())
-	address := h.GetAddressOrDefault(mpu6050Address)
-
-	h.connection, err = h.connector.GetConnection(address, bus)
-	if err != nil {
-		return err
+func (m *MPU6050Driver) waitForReset() error {
+	wait := 100 * time.Millisecond
+	start := time.Now()
+	for {
+		if time.Since(start) > wait {
+			return fmt.Errorf("timeout on wait for reset is done")
+		}
+		if val, err := m.connection.ReadByteData(mpu6050Reg_PwrMgmt1); (val&mpu6050Pwr1_DeviceResetBit == 0) && (err == nil) {
+			return nil
+		}
+		time.Sleep(wait / 10)
 	}
-
-	// setClockSource
-	if _, err = h.connection.Write([]byte{MPU6050_RA_PWR_MGMT_1,
-		MPU6050_PWR1_CLKSEL_BIT,
-		MPU6050_PWR1_CLKSEL_LENGTH,
-		MPU6050_CLOCK_PLL_XGYRO}); err != nil {
-		return
-	}
-
-	// setFullScaleGyroRange
-	if _, err = h.connection.Write([]byte{MPU6050_RA_GYRO_CONFIG,
-		MPU6050_GCONFIG_FS_SEL_BIT,
-		MPU6050_GCONFIG_FS_SEL_LENGTH,
-		MPU6050_GYRO_FS_250}); err != nil {
-		return
-	}
-
-	// setFullScaleAccelRange
-	if _, err = h.connection.Write([]byte{MPU6050_RA_ACCEL_CONFIG,
-		MPU6050_ACONFIG_AFS_SEL_BIT,
-		MPU6050_ACONFIG_AFS_SEL_LENGTH,
-		MPU6050_ACCEL_FS_2}); err != nil {
-		return
-	}
-
-	// setSleepEnabled
-	if _, err = h.connection.Write([]byte{MPU6050_RA_PWR_MGMT_1,
-		MPU6050_PWR1_ENABLE_BIT,
-		0}); err != nil {
-		return
-	}
-
-	return nil
 }
 
-// The temperature sensor is -40 to +85 degrees Celsius.
-// It is a signed integer.
-// According to the datasheet:
-//   340 per degrees Celsius, -512 at 35 degrees.
-// At 0 degrees: -512 - (340 * 35) = -12412
-func (h *MPU6050Driver) convertToCelsius() {
-	h.Temperature = (h.Temperature + 12412) / 340
+func (m *MPU6050Driver) initialize() (err error) {
+	// reset device and wait for reset is finished
+	if err = m.connection.WriteByteData(mpu6050Reg_PwrMgmt1, mpu6050Pwr1_DeviceResetBit); err != nil {
+		return
+	}
+	if err = m.waitForReset(); err != nil {
+		return
+	}
+
+	// reset signal path register
+	reset := uint8(mpu6050SignalReset_TempBit | mpu6050SignalReset_AccelBit | mpu6050SignalReset_GyroBit)
+	if err = m.connection.WriteByteData(mpu6050Reg_SignalPathReset, reset); err != nil {
+		return
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	// configure digital filter bandwidth and external frame synchronization (bits 3...5 are used)
+	generalConf := uint8(m.dlpf) | uint8(m.frameSync)<<3
+	if err = m.connection.WriteByteData(mpu6050Reg_GeneralConfig, generalConf); err != nil {
+		return
+	}
+
+	// set full scale range of gyroscope (bits 3 and 4 are used)
+	if err = m.connection.WriteByteData(mpu6050Reg_GyroConfig, uint8(m.gyroFs)<<3); err != nil {
+		return
+	}
+
+	// set full scale range of accelerometer (bits 3 and 4 are used)
+	if err = m.connection.WriteByteData(mpu6050Reg_AccelConfig, uint8(m.accelFs)<<3); err != nil {
+		return
+	}
+
+	// set clock source and reset sleep
+	pwr1 := uint8(m.clock) & ^uint8(mpu6050Pwr1_SleepOnBit)
+	if err = m.connection.WriteByteData(mpu6050Reg_PwrMgmt1, pwr1); err != nil {
+		return
+	}
+
+	return
 }

--- a/drivers/i2c/mpu6050_driver_test.go
+++ b/drivers/i2c/mpu6050_driver_test.go
@@ -9,105 +9,183 @@ import (
 	"gobot.io/x/gobot/gobottest"
 )
 
-// ensure that MPU6050Driver fulfills Gobot Driver interface
+// this ensures that the implementation is based on i2c.Driver, which implements the gobot.Driver
+// and tests all implementations, so no further tests needed here for gobot.Driver interface
 var _ gobot.Driver = (*MPU6050Driver)(nil)
 
-// --------- HELPERS
-func initTestMPU6050Driver() (driver *MPU6050Driver) {
-	driver, _ = initTestMPU6050DriverWithStubbedAdaptor()
-	return
+func initTestMPU6050WithStubbedAdaptor() (*MPU6050Driver, *i2cTestAdaptor) {
+	a := newI2cTestAdaptor()
+	d := NewMPU6050Driver(a)
+	if err := d.Start(); err != nil {
+		panic(err)
+	}
+	return d, a
 }
-
-func initTestMPU6050DriverWithStubbedAdaptor() (*MPU6050Driver, *i2cTestAdaptor) {
-	adaptor := newI2cTestAdaptor()
-	return NewMPU6050Driver(adaptor), adaptor
-}
-
-// --------- TESTS
 
 func TestNewMPU6050Driver(t *testing.T) {
 	// Does it return a pointer to an instance of MPU6050Driver?
-	var bm interface{} = NewMPU6050Driver(newI2cTestAdaptor())
-	_, ok := bm.(*MPU6050Driver)
+	var di interface{} = NewMPU6050Driver(newI2cTestAdaptor())
+	d, ok := di.(*MPU6050Driver)
 	if !ok {
 		t.Errorf("NewMPU6050Driver() should have returned a *MPU6050Driver")
 	}
+	gobottest.Refute(t, d.Driver, nil)
+	gobottest.Assert(t, strings.HasPrefix(d.name, "MPU6050"), true)
+	gobottest.Assert(t, d.dlpf, MPU6050DlpfConfig(0x00))
+	gobottest.Assert(t, d.frameSync, MPU6050FrameSyncConfig(0x00))
+	gobottest.Assert(t, d.accelFs, MPU6050AccelFsConfig(0x00))
+	gobottest.Assert(t, d.gyroFs, MPU6050GyroFsConfig(0x00))
+	gobottest.Assert(t, d.clock, MPU6050Pwr1ClockConfig(0x01))
+	gobottest.Assert(t, d.gravity, 9.80665)
 }
 
-func TestMPU6050DriverName(t *testing.T) {
-	mpu := initTestMPU6050Driver()
-	gobottest.Refute(t, mpu.Connection(), nil)
-	gobottest.Assert(t, strings.HasPrefix(mpu.Name(), "MPU6050"), true)
+func TestMPU6050Options(t *testing.T) {
+	// This is a general test, that options are applied in constructor by using the common WithBus() option and
+	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".
+	d := NewMPU6050Driver(newI2cTestAdaptor(), WithBus(2), WithMPU6050DigitalFilter(0x06))
+	gobottest.Assert(t, d.GetBusOrDefault(1), 2)
+	gobottest.Assert(t, d.dlpf, MPU6050DlpfConfig(0x06))
 }
 
-func TestMPU6050DriverOptions(t *testing.T) {
-	mpu := NewMPU6050Driver(newI2cTestAdaptor(), WithBus(2))
-	gobottest.Assert(t, mpu.GetBusOrDefault(1), 2)
+func TestWithMPU6050FrameSync(t *testing.T) {
+	d := NewMPU6050Driver(newI2cTestAdaptor(), WithMPU6050FrameSync(0x07))
+	gobottest.Assert(t, d.frameSync, MPU6050FrameSyncConfig(0x07))
 }
 
-// Methods
-func TestMPU6050DriverStart(t *testing.T) {
-	mpu := initTestMPU6050Driver()
-
-	gobottest.Assert(t, mpu.Start(), nil)
+func TestWithMPU6050AccelFullScaleRange(t *testing.T) {
+	d := NewMPU6050Driver(newI2cTestAdaptor(), WithMPU6050AccelFullScaleRange(0x02))
+	gobottest.Assert(t, d.accelFs, MPU6050AccelFsConfig(0x02))
 }
 
-func TestMPU6050StartConnectError(t *testing.T) {
-	d, adaptor := initTestMPU6050DriverWithStubbedAdaptor()
-	adaptor.Testi2cConnectErr(true)
-	gobottest.Assert(t, d.Start(), errors.New("Invalid i2c connection"))
+func TestWithMPU6050GyroFullScaleRange(t *testing.T) {
+	d := NewMPU6050Driver(newI2cTestAdaptor(), WithMPU6050GyroFullScaleRange(0x03))
+	gobottest.Assert(t, d.gyroFs, MPU6050GyroFsConfig(0x03))
 }
 
-func TestMPU6050DriverStartWriteError(t *testing.T) {
-	mpu, adaptor := initTestMPU6050DriverWithStubbedAdaptor()
-	adaptor.i2cWriteImpl = func([]byte) (int, error) {
-		return 0, errors.New("write error")
+func TestWithMPU6050ClockSource(t *testing.T) {
+	d := NewMPU6050Driver(newI2cTestAdaptor(), WithMPU6050ClockSource(0x05))
+	gobottest.Assert(t, d.clock, MPU6050Pwr1ClockConfig(0x05))
+}
+
+func TestWithMPU6050Gravity(t *testing.T) {
+	d := NewMPU6050Driver(newI2cTestAdaptor(), WithMPU6050Gravity(1.0))
+	gobottest.Assert(t, d.gravity, 1.0)
+}
+
+func TestMPU6050GetData(t *testing.T) {
+	// sequence to read values
+	// * reset device and prepare config registers, see test for Start()
+	// * write first data register address (0x3B)
+	// * read 3 x 2 bytes acceleration.X, Y, Z data, little-endian (MSB, LSB)
+	// * read 2 bytes temperature data, little-endian (MSB, LSB)
+	// * read 3 x 2 bytes gyroscope.X, Y, Z data, little-endian (MSB, LSB)
+	// * scale
+	//    Acceleration: raw value / gain * standard gravity [m/s²]
+	//    Temperature:  raw value / 340 + 36.53 [°C]
+	//    Gyroscope:    raw value / gain [°/s]
+
+	// arrange
+	d, adaptor := initTestMPU6050WithStubbedAdaptor()
+	d.Start()
+
+	accData := []byte{0x00, 0x01, 0x02, 0x04, 0x08, 0x16}
+	tempData := []byte{0x32, 0x64}
+	gyroData := []byte{0x16, 0x08, 0x04, 0x02, 0x01, 0x00}
+
+	wantAccel := MPU6050ThreeDData{
+		X: 0x0001 / 16384.0 * d.gravity,
+		Y: 0x0204 / 16384.0 * d.gravity,
+		Z: 0x0816 / 16384.0 * d.gravity,
 	}
-	gobottest.Assert(t, mpu.Start(), errors.New("write error"))
-}
-
-func TestMPU6050DriverHalt(t *testing.T) {
-	mpu := initTestMPU6050Driver()
-
-	gobottest.Assert(t, mpu.Halt(), nil)
-}
-
-func TestMPU6050DriverReadData(t *testing.T) {
-	mpu, adaptor := initTestMPU6050DriverWithStubbedAdaptor()
+	wantGyro := MPU6050ThreeDData{
+		X: 0x1608 / 131.0,
+		Y: 0x0402 / 131.0,
+		Z: 0x0100 / 131.0,
+	}
+	wantTemp := float64(0x3264)/340 + 36.53
 
 	adaptor.i2cReadImpl = func(b []byte) (int, error) {
-		copy(b, []byte{0x00, 0x01, 0x02, 0x04})
-		return 4, nil
+		copy(b, append(append(accData, tempData...), gyroData...))
+		return len(b), nil
 	}
-	mpu.Start()
-	mpu.GetData()
-	gobottest.Assert(t, mpu.Temperature, int16(36))
+	// act
+	d.GetData()
+	// assert
+	gobottest.Assert(t, d.Accelerometer, wantAccel)
+	gobottest.Assert(t, d.Gyroscope, wantGyro)
+	gobottest.Assert(t, d.Temperature, wantTemp)
 }
 
-func TestMPU6050DriverGetDataReadError(t *testing.T) {
-	mpu, adaptor := initTestMPU6050DriverWithStubbedAdaptor()
-	mpu.Start()
+func TestMPU6050GetDataReadError(t *testing.T) {
+	d, adaptor := initTestMPU6050WithStubbedAdaptor()
+	d.Start()
 
 	adaptor.i2cReadImpl = func(b []byte) (int, error) {
 		return 0, errors.New("read error")
 	}
 
-	gobottest.Assert(t, mpu.GetData(), errors.New("read error"))
+	gobottest.Assert(t, d.GetData(), errors.New("read error"))
 }
 
-func TestMPU6050DriverGetDataWriteError(t *testing.T) {
-	mpu, adaptor := initTestMPU6050DriverWithStubbedAdaptor()
-	mpu.Start()
+func TestMPU6050GetDataWriteError(t *testing.T) {
+	d, adaptor := initTestMPU6050WithStubbedAdaptor()
+	d.Start()
 
 	adaptor.i2cWriteImpl = func(b []byte) (int, error) {
 		return 0, errors.New("write error")
 	}
 
-	gobottest.Assert(t, mpu.GetData(), errors.New("write error"))
+	gobottest.Assert(t, d.GetData(), errors.New("write error"))
 }
 
-func TestMPU6050DriverSetName(t *testing.T) {
-	mpu := initTestMPU6050Driver()
-	mpu.SetName("TESTME")
-	gobottest.Assert(t, mpu.Name(), "TESTME")
+func TestMPU6050_initialize(t *testing.T) {
+	// sequence for initialization the device on Start()
+	//          reset (according to data sheet)
+	// * write power management 1 register address (0x6B)
+	// * set device reset bit - write 0x80
+	// * read device reset bit until it becomes false (timeout 100 ms)
+	//   * write power management 1 register address (0x6B)
+	//   * read value
+	//   * wait some time before retry
+	// * write signal path reset register address (0x68)
+	// * reset all sensors - write 0x07
+	// * wait 100 ms
+	//               config
+	// * write general config register address (0x1A)
+	// * disable external sync and set filter bandwidth to 260 HZ - write 0x00
+	// * write gyroscope config register address (0x1B)
+	// * set full scale to 250 °/s - write 0x00
+	// * write accelerometer config register address (0x1C)
+	// * set full scale to 2 g - write 0x00
+	// * write power management 1 register address (0x6B)
+	// * set clock source to PLL with X and switch off sleep bit - write 0x01
+	// arrange
+	a := newI2cTestAdaptor()
+	d := NewMPU6050Driver(a)
+	readCallCounter := 0
+	a.i2cReadImpl = func(b []byte) (int, error) {
+		readCallCounter++
+		// emulate ready
+		b[0] = 0x00
+		return len(b), nil
+	}
+	// act, assert - initialize() must be called on Start()
+	err := d.Start()
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, readCallCounter, 1)
+	gobottest.Assert(t, len(a.written), 13)
+	gobottest.Assert(t, a.written[0], uint8(0x6B))
+	gobottest.Assert(t, a.written[1], uint8(0x80))
+	gobottest.Assert(t, a.written[2], uint8(0x6B))
+	gobottest.Assert(t, a.written[3], uint8(0x68))
+	gobottest.Assert(t, a.written[4], uint8(0x07))
+	gobottest.Assert(t, a.written[5], uint8(0x1A))
+	gobottest.Assert(t, a.written[6], uint8(0x00))
+	gobottest.Assert(t, a.written[7], uint8(0x1B))
+	gobottest.Assert(t, a.written[8], uint8(0x00))
+	gobottest.Assert(t, a.written[9], uint8(0x1C))
+	gobottest.Assert(t, a.written[10], uint8(0x00))
+	gobottest.Assert(t, a.written[11], uint8(0x6B))
+	gobottest.Assert(t, a.written[12], uint8(0x01))
 }


### PR DESCRIPTION
This is for issue #838 
* FIX: initialization sequence
* FIX: temperature resolution to float64
* FIX: Acceleration values now has unit [m²/s]
* FIX: Gyroscope values now has the unit [°/s]
* tests heavily improved
* some new constants introduced
* With-functions for full scale range (gain) and other values introduced
* 2c.Driver used as base, which let us more focus on important tests