### PR TITLE
BUGFIX/Improvement: th02 i2c driver - wrong register usage for heater

### DIFF
--- a/drivers/i2c/helpers_test.go
+++ b/drivers/i2c/helpers_test.go
@@ -179,8 +179,8 @@ func newI2cTestAdaptor() *i2cTestAdaptor {
 		i2cReadImpl: func(b []byte) (int, error) {
 			return len(b), nil
 		},
-		i2cWriteImpl: func([]byte) (int, error) {
-			return 0, nil
+		i2cWriteImpl: func(b []byte) (int, error) {
+			return len(b), nil
 		},
 	}
 }


### PR DESCRIPTION
This PR fix #841 

In addition:
* add "WithTH02FastMode"
* add set heater independent of measurement
* add mutex to prevent interruption of write-read sequences
* make waitForReady() not so greedy
* tests heavily improved
* i2c.Driver used as base, which let us more focus on important tests