### PR TITLE
BUGFIX: circleci new home path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,15 +15,17 @@ jobs:
 
       # For more information, please read https://github.com/CircleCI-Public/cimg-go/blob/main/README.md
 
-    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     steps:
       - checkout
       - run:
+          name: Debug version
+          command: go version
+      - run:
           name: Core and drivers tests
-          command: go test -v -cpu=2 -coverprofile=coverage.txt -covermode=atomic . ./drivers/...
+          command: go test -v -coverprofile=coverage.txt -covermode=atomic . ./drivers/...
       - run:
           name: Firmata tests
-          command: go test -v -cpu=2 ./platforms/firmata/...
+          command: go test -v ./platforms/firmata/...
       - run:
           name: Code coverage
           command: | 


### PR DESCRIPTION
this is part of #849 

On branch [circleci-editor/890/dev](https://github.com/hybridgroup/gobot/tree/circleci-editor/890/dev) firmata test still fails with "client_test.go:466: SysexResponse was not published". Because this seems to be a timing issue, it must possibly be fixed afterwards (e.g. by increasing the wait time).