### PR TITLE
test: make some tests less fragile

### DIFF
--- a/platforms/firmata/client/client_test.go
+++ b/platforms/firmata/client/client_test.go
@@ -462,7 +462,7 @@ func TestProcessSysexData(t *testing.T) {
 
 	select {
 	case <-sem:
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(250 * time.Millisecond):
 		t.Errorf("SysexResponse was not published")
 	}
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -10,16 +10,16 @@ import (
 
 func TestEvery(t *testing.T) {
 	i := 0
-	begin := time.Now().UnixNano()
-	sem := make(chan int64, 1)
+	begin := time.Now()
+	sem := make(chan time.Time, 1)
 	Every(2*time.Millisecond, func() {
 		i++
 		if i == 2 {
-			sem <- time.Now().UnixNano()
+			sem <- time.Now()
 		}
 	})
-	end := <-sem
-	if end-begin < 4000000 {
+	<-sem
+	if time.Since(begin) < 4*time.Millisecond {
 		t.Error("Test should have taken at least 4 milliseconds")
 	}
 }
@@ -34,12 +34,12 @@ func TestEveryWhenStopped(t *testing.T) {
 	select {
 	case <-sem:
 		done.Stop()
-	case <-time.After(60 * time.Millisecond):
+	case <-time.After(70 * time.Millisecond):
 		t.Errorf("Every was not called")
 	}
 
 	select {
-	case <-time.After(60 * time.Millisecond):
+	case <-time.After(70 * time.Millisecond):
 	case <-sem:
 		t.Error("Every should have stopped")
 	}
@@ -49,14 +49,14 @@ func TestAfter(t *testing.T) {
 	i := 0
 	sem := make(chan bool)
 
-	After(1*time.Millisecond, func() {
+	After(10*time.Millisecond, func() {
 		i++
 		sem <- true
 	})
 
 	select {
 	case <-sem:
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(30 * time.Millisecond):
 		t.Errorf("After was not called")
 	}
 


### PR DESCRIPTION
A few tests appear to be a bit fragile due to timing difference on the CI machines. This PR attempts to remedy that a bit.