### PR TITLE
dji/tello: fix the issue about Halt method

### DIFF
--- a/platforms/dji/tello/driver.go
+++ b/platforms/dji/tello/driver.go
@@ -334,18 +334,23 @@ func (d *Driver) Start() error {
 // Halt stops the driver.
 func (d *Driver) Halt() (err error) {
 	// send a landing command when we disconnect, and give it 500ms to be received before we shutdown
-	d.Land()
+	if d.cmdConn != nil {
+		d.Land()
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	if d.cmdConn != nil {
+		d.cmdConn.Close()
+	}
+
+	if d.videoConn != nil {
+		d.videoConn.Close()
+	}
 	readerCount := atomic.LoadInt32(&d.doneChReaderCount)
 	for i := 0; i < int(readerCount); i++ {
 		d.doneCh <- struct{}{}
 	}
 
-	time.Sleep(500 * time.Millisecond)
-
-	d.cmdConn.Close()
-	if d.videoConn != nil {
-		d.videoConn.Close()
-	}
 	return
 }
 

--- a/platforms/dji/tello/driver_test.go
+++ b/platforms/dji/tello/driver_test.go
@@ -151,17 +151,29 @@ func TestHaltShouldTerminateAllTheRelatedGoroutines(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(3)
+
+	d.addDoneChReaderCount(1)
 	go func() {
+		defer d.addDoneChReaderCount(-1)
+
 		<-d.doneCh
 		wg.Done()
 		fmt.Println("Done routine 1.")
 	}()
+
+	d.addDoneChReaderCount(1)
 	go func() {
+		defer d.addDoneChReaderCount(-1)
+
 		<-d.doneCh
 		wg.Done()
 		fmt.Println("Done routine 2.")
 	}()
+
+	d.addDoneChReaderCount(1)
 	go func() {
+		defer d.addDoneChReaderCount(-1)
+
 		<-d.doneCh
 		wg.Done()
 		fmt.Println("Done routine 3.")
@@ -169,6 +181,8 @@ func TestHaltShouldTerminateAllTheRelatedGoroutines(t *testing.T) {
 
 	d.Halt()
 	wg.Wait()
+
+	gobottest.Assert(t, d.doneChReaderCount, int32(0))
 }
 
 func TestHaltNotWaitForeverWhenCalledMultipleTimes(t *testing.T) {

--- a/platforms/dji/tello/driver_test.go
+++ b/platforms/dji/tello/driver_test.go
@@ -154,27 +154,24 @@ func TestHaltShouldTerminateAllTheRelatedGoroutines(t *testing.T) {
 
 	d.addDoneChReaderCount(1)
 	go func() {
-		defer d.addDoneChReaderCount(-1)
-
 		<-d.doneCh
+		d.addDoneChReaderCount(-1)
 		wg.Done()
 		fmt.Println("Done routine 1.")
 	}()
 
 	d.addDoneChReaderCount(1)
 	go func() {
-		defer d.addDoneChReaderCount(-1)
-
 		<-d.doneCh
+		d.addDoneChReaderCount(-1)
 		wg.Done()
 		fmt.Println("Done routine 2.")
 	}()
 
 	d.addDoneChReaderCount(1)
 	go func() {
-		defer d.addDoneChReaderCount(-1)
-
 		<-d.doneCh
+		d.addDoneChReaderCount(-1)
 		wg.Done()
 		fmt.Println("Done routine 3.")
 	}()


### PR DESCRIPTION
This PR is intended to fix the issue: [Dji Tello Halt does not terminate all the related goroutines and may wait forever when it is called multiple times #793](https://github.com/hybridgroup/gobot/issues/793).

This PR contains consecutive four commits.