### PR TITLE
BUGFIX: examples and Makefile for examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-.PHONY: test race cover robeaux examples test_with_coverage fmt_check
+# include also examples in other than ./examples folder
+ALL_EXAMPLES := $(shell grep -l -r --include "*.go" 'build example' ./)
+# prevent examples with joystick (sdl2) and gocv (opencv) dependencies
+EXAMPLES := $(shell grep -L 'joystick' $$(grep -L 'gocv' $(ALL_EXAMPLES)))
+
+.PHONY: test race cover robeaux test_with_coverage fmt_check examples $(EXAMPLES)
 
 # opencv platform currently skipped to prevent install of preconditions
 including_except := $(shell go list ./... | grep -v platforms/opencv)
@@ -37,9 +42,7 @@ endif
 	rm -rf node_modules/ ; \
 	go fmt ./robeaux/robeaux.go ; \
 
-EXAMPLES := $(shell ls examples/*.go | sed -e 's/examples\///')
+examples: $(EXAMPLES)
 
-examples:
-	for example in $(EXAMPLES) ; do \
-		go build -o /tmp/$$example examples/$$example ; \
-	done ; \
+$(EXAMPLES):
+	go build -o /tmp/gobot_examples/$@ ./$@

--- a/examples/ble_firmata_curie_imu.go
+++ b/examples/ble_firmata_curie_imu.go
@@ -25,7 +25,8 @@ import (
 )
 
 func main() {
-	firmataAdaptor := firmata.NewBLEAdaptor(os.Args[1])
+	var bleAdaptor interface{} = firmata.NewBLEAdaptor(os.Args[1])
+	firmataAdaptor := bleAdaptor.(*firmata.Adaptor)
 	led := gpio.NewLedDriver(firmataAdaptor, "13")
 	imu := curie.NewIMUDriver(firmataAdaptor)
 

--- a/examples/firmata_gpio_max7219.go
+++ b/examples/firmata_gpio_max7219.go
@@ -57,7 +57,7 @@ func main() {
 	}
 
 	robot := gobot.NewRobot("Max7219Bot",
-		[]gobot.Connection{esp8266},
+		[]gobot.Connection{firmataAdaptor},
 		[]gobot.Device{max},
 		work,
 	)

--- a/examples/firmata_ssd1306.go
+++ b/examples/firmata_ssd1306.go
@@ -15,9 +15,11 @@ import (
 )
 
 func main() {
-
+	width := 128
+	height := 64
 	r := firmata.NewAdaptor(os.Args[1])
-	oled := i2c.NewSSD1306Driver(r, i2c.WithAddress(0x3c))
+	oled := i2c.NewSSD1306Driver(r, i2c.WithAddress(0x3c),
+		i2c.WithSSD1306DisplayWidth(width), i2c.WithSSD1306DisplayHeight(height))
 
 	stage := false
 
@@ -27,8 +29,8 @@ func main() {
 			fmt.Println("displaying")
 			oled.Clear()
 			if stage {
-				for x := 0; x < oled.Buffer.Width; x += 5 {
-					for y := 0; y < oled.Buffer.Height; y++ {
+				for x := 0; x < width; x += 5 {
+					for y := 0; y < height; y++ {
 						oled.Set(x, y, 1)
 					}
 				}

--- a/examples/firmata_tm1638.go
+++ b/examples/firmata_tm1638.go
@@ -25,10 +25,10 @@ func main() {
 
 	// Even thought the modules are connected among them, they are independent (not chained)
 	modules := make([]*gpio.TM1638Driver, 4)
-	modules[0] = gpio.NewTM1638Driver(esp8266, "9", "8", "7")
-	modules[1] = gpio.NewTM1638Driver(esp8266, "9", "8", "6")
-	modules[2] = gpio.NewTM1638Driver(esp8266, "9", "8", "5")
-	modules[3] = gpio.NewTM1638Driver(esp8266, "9", "8", "4")
+	modules[0] = gpio.NewTM1638Driver(firmataAdaptor, "9", "8", "7")
+	modules[1] = gpio.NewTM1638Driver(firmataAdaptor, "9", "8", "6")
+	modules[2] = gpio.NewTM1638Driver(firmataAdaptor, "9", "8", "5")
+	modules[3] = gpio.NewTM1638Driver(firmataAdaptor, "9", "8", "4")
 
 	var ledInt byte
 	var color byte

--- a/platforms/dexter/gopigo3/driver.go
+++ b/platforms/dexter/gopigo3/driver.go
@@ -325,7 +325,13 @@ func (g *Driver) SetServo(srvo Servo, us uint16) error {
 }
 
 // ServoWrite writes an angle (0-180) to the given servo (servo 1 or servo 2).
-func (g *Driver) ServoWrite(srvo Servo, angle byte) error {
+// Must implement the ServoWriter interface of gpio package.
+func (g *Driver) ServoWrite(port string, angle byte) error {
+	srvo := SERVO_1 // default for unknown ports
+	if port == "2" || port == "SERVO_2" {
+		srvo = SERVO_2
+	}
+
 	pulseWidthRange := 1850
 	if angle > 180 {
 		angle = 180

--- a/platforms/dexter/gopigo3/driver_test.go
+++ b/platforms/dexter/gopigo3/driver_test.go
@@ -176,7 +176,7 @@ func TestDigitalRead(t *testing.T) {
 
 func TestServoWrite(t *testing.T) {
 	d := initTestDriver()
-	err := d.ServoWrite(SERVO_1, 0x7F)
+	err := d.ServoWrite("SERVO_1", 0x7F)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
this is related to #852 

* now all examples build successfully (joystick and opencv not tested)
* gopigo3/driver.go must implement the ServoWriter interface of gpio package