### PR TITLE
Document fields for tello.FlightData

### DIFF
--- a/platforms/dji/tello/driver.go
+++ b/platforms/dji/tello/driver.go
@@ -133,42 +133,45 @@ const (
 	VideoBitRate4M VideoBitRate = 5
 )
 
-// FlightData packet returned by the Tello
+// FlightData packet returned by the Tello.
+//
+// The meaning of some fields is not documented. If you learned more, please, contribute.
+// See https://github.com/hybridgroup/gobot/issues/798.
 type FlightData struct {
 	BatteryLow               bool
 	BatteryLower             bool
-	BatteryPercentage        int8
-	BatteryState             bool
+	BatteryPercentage        int8 // How much battery left [in %].
 	CameraState              int8
-	DownVisualState          bool
 	DroneBatteryLeft         int16
 	DroneFlyTimeLeft         int16
-	DroneHover               bool
+	DroneHover               bool // If the drone is in the air and not moving.
 	EmOpen                   bool
-	Flying                   bool
-	OnGround                 bool
-	EastSpeed                int16
+	Flying                   bool  // If the drone is currently in the air.
+	OnGround                 bool  // If the drone is currently on the ground.
+	EastSpeed                int16 // Movement speed towards East [in cm/s]. Negative if moving west.
 	ElectricalMachineryState int16
 	FactoryMode              bool
 	FlyMode                  int8
-	FlyTime                  int16
+	FlyTime                  int16 // How long since take off [in s/10].
 	FrontIn                  bool
 	FrontLSC                 bool
 	FrontOut                 bool
 	GravityState             bool
-	VerticalSpeed            int16
-	Height                   int16
-	ImuCalibrationState      int8
-	ImuState                 bool
-	LightStrength            int8
-	NorthSpeed               int16
-	OutageRecording          bool
-	PowerState               bool
-	PressureState            bool
-	SmartVideoExitMode       int16
-	TemperatureHigh          bool
+	VerticalSpeed            int16 // Movement speed up [in cm/s].
+	Height                   int16 // The height [in decimeters].
+	ImuCalibrationState      int8  // The IMU calibration step (when doing IMU calibration).
+	NorthSpeed               int16 // Movement speed towards North [in cm/s]. Negative if moving South.
 	ThrowFlyTimer            int8
-	WindState                bool
+
+	// Warnings:
+	DownVisualState bool // If the ground is visible by the down camera.
+	BatteryState    bool // If there is an issue with battery.
+	ImuState        bool // If drone needs IMU (Inertial Measurement Unit) calibration.
+	OutageRecording bool // If there is an issue with video recording.
+	PowerState      bool // If there is an issue with power supply.
+	PressureState   bool // If there is an issue with air pressure.
+	TemperatureHigh bool // If drone is overheating.
+	WindState       bool // If the wind is too strong.
 }
 
 // WifiData packet returned by the Tello


### PR DESCRIPTION
1. Document some of the fields in tello.FlightData description of which I found in my old notes.
2. Drop LightStrength and SmartVideoExitMode. These fields are always zero in the current implementation.

Closes #798