### PR TITLE
TESTFIX: stabilize firmata tests

### DIFF
--- a/platforms/firmata/client/client_test.go
+++ b/platforms/firmata/client/client_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"log"
 	"sync"
 	"testing"
 	"time"
@@ -9,7 +10,39 @@ import (
 	"gobot.io/x/gobot/gobottest"
 )
 
-type readWriteCloser struct{}
+const semPublishWait = 10 * time.Millisecond
+
+type readWriteCloser struct {
+	id string
+}
+
+var testWriteData = bytes.Buffer{}
+var writeDataMutex sync.Mutex
+
+// do not set this data directly, use always addTestReadData()
+var testReadDataMap = make(map[string][]byte)
+var rwDataMapMutex sync.Mutex
+
+// arduino uno r3 protocol response "2.3"
+var testDataProtocolResponse = []byte{249, 2, 3}
+
+// arduino uno r3 firmware response "StandardFirmata.ino"
+var testDataFirmwareResponse = []byte{240, 121, 2, 3, 83, 0, 116, 0, 97, 0, 110, 0, 100, 0, 97,
+	0, 114, 0, 100, 0, 70, 0, 105, 0, 114, 0, 109, 0, 97, 0, 116, 0, 97, 0, 46,
+	0, 105, 0, 110, 0, 111, 0, 247}
+
+// arduino uno r3 capabilities response
+var testDataCapabilitiesResponse = []byte{240, 108, 127, 127, 0, 1, 1, 1, 4, 14, 127, 0, 1, 1, 1, 3,
+	8, 4, 14, 127, 0, 1, 1, 1, 4, 14, 127, 0, 1, 1, 1, 3, 8, 4, 14, 127, 0, 1,
+	1, 1, 3, 8, 4, 14, 127, 0, 1, 1, 1, 4, 14, 127, 0, 1, 1, 1, 4, 14, 127, 0,
+	1, 1, 1, 3, 8, 4, 14, 127, 0, 1, 1, 1, 3, 8, 4, 14, 127, 0, 1, 1, 1, 3, 8,
+	4, 14, 127, 0, 1, 1, 1, 4, 14, 127, 0, 1, 1, 1, 4, 14, 127, 0, 1, 1, 1, 2,
+	10, 127, 0, 1, 1, 1, 2, 10, 127, 0, 1, 1, 1, 2, 10, 127, 0, 1, 1, 1, 2, 10,
+	127, 0, 1, 1, 1, 2, 10, 6, 1, 127, 0, 1, 1, 1, 2, 10, 6, 1, 127, 247}
+
+// arduino uno r3 analog mapping response
+var testDataAnalogMappingResponse = []byte{240, 106, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,
+	127, 127, 127, 127, 0, 1, 2, 3, 4, 5, 247}
 
 func (readWriteCloser) Write(p []byte) (int, error) {
 	writeDataMutex.Lock()
@@ -17,30 +50,37 @@ func (readWriteCloser) Write(p []byte) (int, error) {
 	return testWriteData.Write(p)
 }
 
-var clientMutex sync.Mutex
-var writeDataMutex sync.Mutex
-var readDataMutex sync.Mutex
-var testReadData = []byte{}
-var testWriteData = bytes.Buffer{}
+func (rwc readWriteCloser) addTestReadData(d []byte) {
+	// concurrent read/change of map is not allowed
+	rwDataMapMutex.Lock()
+	defer rwDataMapMutex.Unlock()
 
-func SetTestReadData(d []byte) {
-	readDataMutex.Lock()
-	defer readDataMutex.Unlock()
-	testReadData = d
-	return
+	data, ok := testReadDataMap[rwc.id]
+	if !ok {
+		data = []byte{}
+	}
+
+	data = append(data, d...)
+	testReadDataMap[rwc.id] = data
 }
 
-func (readWriteCloser) Read(b []byte) (int, error) {
-	readDataMutex.Lock()
-	defer readDataMutex.Unlock()
+func (rwc readWriteCloser) Read(b []byte) (int, error) {
+	// concurrent change of map is not allowed
+	rwDataMapMutex.Lock()
+	defer rwDataMapMutex.Unlock()
 
-	size := len(b)
-	if len(testReadData) < size {
-		size = len(testReadData)
+	data, ok := testReadDataMap[rwc.id]
+	if !ok {
+		// there was no content stored before to read
+		log.Printf("no content stored in %s", rwc.id)
+		return 0, nil
 	}
-	copy(b, []byte(testReadData)[:size])
-	testReadData = testReadData[size:]
-
+	size := len(b)
+	if len(data) < size {
+		size = len(data)
+	}
+	copy(b, []byte(data)[:size])
+	testReadDataMap[rwc.id] = data[size:]
 	return size, nil
 }
 
@@ -48,86 +88,45 @@ func (readWriteCloser) Close() error {
 	return nil
 }
 
-func testProtocolResponse() []byte {
-	// arduino uno r3 protocol response "2.3"
-	return []byte{249, 2, 3}
-}
-
-func testFirmwareResponse() []byte {
-	// arduino uno r3 firmware response "StandardFirmata.ino"
-	return []byte{240, 121, 2, 3, 83, 0, 116, 0, 97, 0, 110, 0, 100, 0, 97,
-		0, 114, 0, 100, 0, 70, 0, 105, 0, 114, 0, 109, 0, 97, 0, 116, 0, 97, 0, 46,
-		0, 105, 0, 110, 0, 111, 0, 247}
-}
-
-func testCapabilitiesResponse() []byte {
-	// arduino uno r3 capabilities response
-	return []byte{240, 108, 127, 127, 0, 1, 1, 1, 4, 14, 127, 0, 1, 1, 1, 3,
-		8, 4, 14, 127, 0, 1, 1, 1, 4, 14, 127, 0, 1, 1, 1, 3, 8, 4, 14, 127, 0, 1,
-		1, 1, 3, 8, 4, 14, 127, 0, 1, 1, 1, 4, 14, 127, 0, 1, 1, 1, 4, 14, 127, 0,
-		1, 1, 1, 3, 8, 4, 14, 127, 0, 1, 1, 1, 3, 8, 4, 14, 127, 0, 1, 1, 1, 3, 8,
-		4, 14, 127, 0, 1, 1, 1, 4, 14, 127, 0, 1, 1, 1, 4, 14, 127, 0, 1, 1, 1, 2,
-		10, 127, 0, 1, 1, 1, 2, 10, 127, 0, 1, 1, 1, 2, 10, 127, 0, 1, 1, 1, 2, 10,
-		127, 0, 1, 1, 1, 2, 10, 6, 1, 127, 0, 1, 1, 1, 2, 10, 6, 1, 127, 247}
-}
-
-func testAnalogMappingResponse() []byte {
-	// arduino uno r3 analog mapping response
-	return []byte{240, 106, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,
-		127, 127, 127, 127, 0, 1, 2, 3, 4, 5, 247}
-}
-
-func initTestFirmata() *Client {
+func initTestFirmataWithReadWriteCloser(name string, data ...[]byte) (*Client, readWriteCloser) {
 	b := New()
-	b.connection = readWriteCloser{}
+	rwc := readWriteCloser{id: name}
+	b.connection = rwc
 
-	for _, f := range []func() []byte{
-		testProtocolResponse,
-		testFirmwareResponse,
-		testCapabilitiesResponse,
-		testAnalogMappingResponse,
-	} {
-		SetTestReadData(f())
+	for _, d := range data {
+		rwc.addTestReadData(d)
 		b.process()
 	}
 
-	return b
+	b.setConnected(true)
+	return b, rwc
 }
 
 func TestPins(t *testing.T) {
-	b := initTestFirmata()
-	b.setConnected(true)
-
+	b, _ := initTestFirmataWithReadWriteCloser(t.Name(), testDataCapabilitiesResponse, testDataAnalogMappingResponse)
 	gobottest.Assert(t, len(b.Pins()), 20)
 	gobottest.Assert(t, len(b.analogPins), 6)
 }
 
-func TestReportVersion(t *testing.T) {
-	b := initTestFirmata()
-	b.setConnected(true)
-	//test if functions executes
+func TestProtocolVersionQuery(t *testing.T) {
+	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
 	gobottest.Assert(t, b.ProtocolVersionQuery(), nil)
 }
 
-func TestQueryFirmware(t *testing.T) {
-	b := initTestFirmata()
-	b.setConnected(true)
-	//test if functions executes
+func TestFirmwareQuery(t *testing.T) {
+	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
 	gobottest.Assert(t, b.FirmwareQuery(), nil)
 }
 
-func TestQueryPinState(t *testing.T) {
-	b := initTestFirmata()
-	b.setConnected(true)
-	//test if functions executes
+func TestPinStateQuery(t *testing.T) {
+	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
 	gobottest.Assert(t, b.PinStateQuery(1), nil)
 }
 
 func TestProcessProtocolVersion(t *testing.T) {
 	sem := make(chan bool)
-	b := initTestFirmata()
-	b.setConnected(true)
-	SetTestReadData([]byte{249, 2, 3})
+	b, rwc := initTestFirmataWithReadWriteCloser(t.Name())
+	rwc.addTestReadData(testDataProtocolResponse)
 
 	b.Once(b.Event("ProtocolVersion"), func(data interface{}) {
 		gobottest.Assert(t, data, "2.3")
@@ -138,16 +137,15 @@ func TestProcessProtocolVersion(t *testing.T) {
 
 	select {
 	case <-sem:
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(semPublishWait):
 		t.Errorf("ProtocolVersion was not published")
 	}
 }
 
 func TestProcessAnalogRead0(t *testing.T) {
 	sem := make(chan bool)
-	b := initTestFirmata()
-	b.setConnected(true)
-	SetTestReadData([]byte{0xE0, 0x23, 0x05})
+	b, rwc := initTestFirmataWithReadWriteCloser(t.Name(), testDataCapabilitiesResponse, testDataAnalogMappingResponse)
+	rwc.addTestReadData([]byte{0xE0, 0x23, 0x05})
 
 	b.Once(b.Event("AnalogRead0"), func(data interface{}) {
 		gobottest.Assert(t, data, 675)
@@ -158,16 +156,15 @@ func TestProcessAnalogRead0(t *testing.T) {
 
 	select {
 	case <-sem:
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(semPublishWait):
 		t.Errorf("AnalogRead0 was not published")
 	}
 }
 
 func TestProcessAnalogRead1(t *testing.T) {
 	sem := make(chan bool)
-	b := initTestFirmata()
-	b.setConnected(true)
-	SetTestReadData([]byte{0xE1, 0x23, 0x06})
+	b, rwc := initTestFirmataWithReadWriteCloser(t.Name(), testDataCapabilitiesResponse, testDataAnalogMappingResponse)
+	rwc.addTestReadData([]byte{0xE1, 0x23, 0x06})
 
 	b.Once(b.Event("AnalogRead1"), func(data interface{}) {
 		gobottest.Assert(t, data, 803)
@@ -178,17 +175,16 @@ func TestProcessAnalogRead1(t *testing.T) {
 
 	select {
 	case <-sem:
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(semPublishWait):
 		t.Errorf("AnalogRead1 was not published")
 	}
 }
 
 func TestProcessDigitalRead2(t *testing.T) {
 	sem := make(chan bool)
-	b := initTestFirmata()
-	b.setConnected(true)
+	b, rwc := initTestFirmataWithReadWriteCloser(t.Name(), testDataCapabilitiesResponse)
 	b.pins[2].Mode = Input
-	SetTestReadData([]byte{0x90, 0x04, 0x00})
+	rwc.addTestReadData([]byte{0x90, 0x04, 0x00})
 
 	b.Once(b.Event("DigitalRead2"), func(data interface{}) {
 		gobottest.Assert(t, data, 1)
@@ -199,17 +195,16 @@ func TestProcessDigitalRead2(t *testing.T) {
 
 	select {
 	case <-sem:
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(semPublishWait):
 		t.Errorf("DigitalRead2 was not published")
 	}
 }
 
 func TestProcessDigitalRead4(t *testing.T) {
 	sem := make(chan bool)
-	b := initTestFirmata()
-	b.setConnected(true)
+	b, rwc := initTestFirmataWithReadWriteCloser(t.Name(), testDataCapabilitiesResponse)
 	b.pins[4].Mode = Input
-	SetTestReadData([]byte{0x90, 0x16, 0x00})
+	rwc.addTestReadData([]byte{0x90, 0x16, 0x00})
 
 	b.Once(b.Event("DigitalRead4"), func(data interface{}) {
 		gobottest.Assert(t, data, 1)
@@ -220,41 +215,36 @@ func TestProcessDigitalRead4(t *testing.T) {
 
 	select {
 	case <-sem:
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(semPublishWait):
 		t.Errorf("DigitalRead4 was not published")
 	}
 }
 
 func TestDigitalWrite(t *testing.T) {
-	b := initTestFirmata()
-	b.setConnected(true)
+	b, _ := initTestFirmataWithReadWriteCloser(t.Name(), testDataCapabilitiesResponse)
 	gobottest.Assert(t, b.DigitalWrite(13, 0), nil)
 }
 
 func TestSetPinMode(t *testing.T) {
-	b := initTestFirmata()
-	b.setConnected(true)
+	b, _ := initTestFirmataWithReadWriteCloser(t.Name(), testDataCapabilitiesResponse)
 	gobottest.Assert(t, b.SetPinMode(13, Output), nil)
 }
 
 func TestAnalogWrite(t *testing.T) {
-	b := initTestFirmata()
-	b.setConnected(true)
+	b, _ := initTestFirmataWithReadWriteCloser(t.Name(), testDataCapabilitiesResponse)
 	gobottest.Assert(t, b.AnalogWrite(0, 128), nil)
 }
 
 func TestReportAnalog(t *testing.T) {
-	b := initTestFirmata()
-	b.setConnected(true)
+	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
 	gobottest.Assert(t, b.ReportAnalog(0, 1), nil)
 	gobottest.Assert(t, b.ReportAnalog(0, 0), nil)
 }
 
 func TestProcessPinState13(t *testing.T) {
 	sem := make(chan bool)
-	b := initTestFirmata()
-	b.setConnected(true)
-	SetTestReadData([]byte{240, 110, 13, 1, 1, 247})
+	b, rwc := initTestFirmataWithReadWriteCloser(t.Name(), testDataCapabilitiesResponse, testDataAnalogMappingResponse)
+	rwc.addTestReadData([]byte{240, 110, 13, 1, 1, 247})
 
 	b.Once(b.Event("PinState13"), func(data interface{}) {
 		gobottest.Assert(t, data, Pin{[]int{0, 1, 4}, 1, 0, 1, 127})
@@ -265,40 +255,35 @@ func TestProcessPinState13(t *testing.T) {
 
 	select {
 	case <-sem:
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(semPublishWait):
 		t.Errorf("PinState13 was not published")
 	}
 }
 
 func TestI2cConfig(t *testing.T) {
-	b := initTestFirmata()
-	b.setConnected(true)
+	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
 	gobottest.Assert(t, b.I2cConfig(100), nil)
 }
 
 func TestI2cWrite(t *testing.T) {
-	b := initTestFirmata()
-	b.setConnected(true)
+	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
 	gobottest.Assert(t, b.I2cWrite(0x00, []byte{0x01, 0x02}), nil)
 }
 
 func TestI2cRead(t *testing.T) {
-	b := initTestFirmata()
-	b.setConnected(true)
+	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
 	gobottest.Assert(t, b.I2cRead(0x00, 10), nil)
 }
 
 func TestWriteSysex(t *testing.T) {
-	b := initTestFirmata()
-	b.setConnected(true)
+	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
 	gobottest.Assert(t, b.WriteSysex([]byte{0x01, 0x02}), nil)
 }
 
 func TestProcessI2cReply(t *testing.T) {
 	sem := make(chan bool)
-	b := initTestFirmata()
-	b.setConnected(true)
-	SetTestReadData([]byte{240, 119, 9, 0, 0, 0, 24, 1, 1, 0, 26, 1, 247})
+	b, rwc := initTestFirmataWithReadWriteCloser(t.Name())
+	rwc.addTestReadData([]byte{240, 119, 9, 0, 0, 0, 24, 1, 1, 0, 26, 1, 247})
 
 	b.Once(b.Event("I2cReply"), func(data interface{}) {
 		gobottest.Assert(t, data, I2cReply{
@@ -313,18 +298,15 @@ func TestProcessI2cReply(t *testing.T) {
 
 	select {
 	case <-sem:
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(semPublishWait):
 		t.Errorf("I2cReply was not published")
 	}
 }
 
 func TestProcessFirmwareQuery(t *testing.T) {
 	sem := make(chan bool)
-	b := initTestFirmata()
-	b.setConnected(true)
-	SetTestReadData([]byte{240, 121, 2, 3, 83, 0, 116, 0, 97, 0, 110, 0, 100, 0, 97,
-		0, 114, 0, 100, 0, 70, 0, 105, 0, 114, 0, 109, 0, 97, 0, 116, 0, 97, 0, 46,
-		0, 105, 0, 110, 0, 111, 0, 247})
+	b, rwc := initTestFirmataWithReadWriteCloser(t.Name())
+	rwc.addTestReadData(testDataFirmwareResponse)
 
 	b.Once(b.Event("FirmwareQuery"), func(data interface{}) {
 		gobottest.Assert(t, data, "StandardFirmata.ino")
@@ -335,16 +317,15 @@ func TestProcessFirmwareQuery(t *testing.T) {
 
 	select {
 	case <-sem:
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(semPublishWait):
 		t.Errorf("FirmwareQuery was not published")
 	}
 }
 
 func TestProcessStringData(t *testing.T) {
 	sem := make(chan bool)
-	b := initTestFirmata()
-	b.setConnected(true)
-	SetTestReadData(append([]byte{240, 0x71}, append([]byte("Hello Firmata!"), 247)...))
+	b, rwc := initTestFirmataWithReadWriteCloser(t.Name())
+	rwc.addTestReadData(append([]byte{240, 0x71}, append([]byte("Hello Firmata!"), 247)...))
 
 	b.Once(b.Event("StringData"), func(data interface{}) {
 		gobottest.Assert(t, data, "Hello Firmata!")
@@ -355,55 +336,34 @@ func TestProcessStringData(t *testing.T) {
 
 	select {
 	case <-sem:
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(semPublishWait):
 		t.Errorf("StringData was not published")
 	}
 }
 
 func TestConnect(t *testing.T) {
-	b := New()
+	b, rwc := initTestFirmataWithReadWriteCloser(t.Name())
+	b.setConnected(false)
 
-	var responseMutex sync.Mutex
-	responseMutex.Lock()
-	response := testProtocolResponse()
-	responseMutex.Unlock()
+	rwc.addTestReadData(testDataProtocolResponse)
 
 	b.Once(b.Event("ProtocolVersion"), func(data interface{}) {
-		responseMutex.Lock()
-		response = testFirmwareResponse()
-		responseMutex.Unlock()
+		rwc.addTestReadData(testDataFirmwareResponse)
 	})
 
 	b.Once(b.Event("FirmwareQuery"), func(data interface{}) {
-		responseMutex.Lock()
-		response = testCapabilitiesResponse()
-		responseMutex.Unlock()
+		rwc.addTestReadData(testDataCapabilitiesResponse)
 	})
 
 	b.Once(b.Event("CapabilityQuery"), func(data interface{}) {
-		responseMutex.Lock()
-		response = testAnalogMappingResponse()
-		responseMutex.Unlock()
+		rwc.addTestReadData(testDataAnalogMappingResponse)
 	})
 
 	b.Once(b.Event("AnalogMappingQuery"), func(data interface{}) {
-		responseMutex.Lock()
-		response = testProtocolResponse()
-		responseMutex.Unlock()
+		rwc.addTestReadData(testDataProtocolResponse)
 	})
 
-	go func() {
-		for {
-			responseMutex.Lock()
-			readDataMutex.Lock()
-			testReadData = append(testReadData, response...)
-			readDataMutex.Unlock()
-			responseMutex.Unlock()
-			time.Sleep(100 * time.Millisecond)
-		}
-	}()
-
-	gobottest.Assert(t, b.Connect(readWriteCloser{}), nil)
+	gobottest.Assert(t, b.Connect(rwc), nil)
 	time.Sleep(150 * time.Millisecond)
 	gobottest.Assert(t, b.Disconnect(), nil)
 }
@@ -449,9 +409,8 @@ func TestServoConfig(t *testing.T) {
 
 func TestProcessSysexData(t *testing.T) {
 	sem := make(chan bool)
-	b := initTestFirmata()
-	b.setConnected(true)
-	SetTestReadData([]byte{240, 17, 1, 2, 3, 247})
+	b, rwc := initTestFirmataWithReadWriteCloser(t.Name())
+	rwc.addTestReadData([]byte{240, 17, 1, 2, 3, 247})
 
 	b.Once("SysexResponse", func(data interface{}) {
 		gobottest.Assert(t, data, []byte{240, 17, 1, 2, 3, 247})
@@ -462,7 +421,7 @@ func TestProcessSysexData(t *testing.T) {
 
 	select {
 	case <-sem:
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(semPublishWait):
 		t.Errorf("SysexResponse was not published")
 	}
 }


### PR DESCRIPTION
this tests often fail, see also #849 :
* TestProcessSysexData, client_test.go:466: SysexResponse was not published OR panic: test timed out after 10m0s
* TestConnect

root causes are:
* read/write access to one resource from different tests (which run in parallel): "testReadData"
* initialization with more than needed data
* used mutexs can lock each other