### PR TITLE
Added support for Dualsense joystick (PlayStation 5)

### DIFF
--- a/examples/joystick_ps5.go
+++ b/examples/joystick_ps5.go
@@ -1,0 +1,140 @@
+//go:build example
+// +build example
+
+//
+// Do not build by default.
+
+package main
+
+import (
+	"fmt"
+
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/platforms/joystick"
+)
+
+func main() {
+	joystickAdaptor := joystick.NewAdaptor()
+	stick := joystick.NewDriver(joystickAdaptor, joystick.Dualsense)
+
+	work := func() {
+		stick.On(joystick.SquarePress, func(data interface{}) {
+			fmt.Println("square_press")
+		})
+		stick.On(joystick.SquareRelease, func(data interface{}) {
+			fmt.Println("square_release")
+		})
+		stick.On(joystick.TrianglePress, func(data interface{}) {
+			fmt.Println("triangle_press")
+		})
+		stick.On(joystick.TriangleRelease, func(data interface{}) {
+			fmt.Println("triangle_release")
+		})
+		stick.On(joystick.CirclePress, func(data interface{}) {
+			fmt.Println("circle_press")
+		})
+		stick.On(joystick.CircleRelease, func(data interface{}) {
+			fmt.Println("circle_release")
+		})
+		stick.On(joystick.XPress, func(data interface{}) {
+			fmt.Println("x_press")
+		})
+		stick.On(joystick.XRelease, func(data interface{}) {
+			fmt.Println("x_release")
+		})
+		stick.On(joystick.HomePress, func(data interface{}) {
+			fmt.Println("home_press")
+		})
+		stick.On(joystick.HomeRelease, func(data interface{}) {
+			fmt.Println("home_release")
+		})
+		stick.On(joystick.SharePress, func(data interface{}) {
+			fmt.Println("share_press")
+		})
+		stick.On(joystick.ShareRelease, func(data interface{}) {
+			fmt.Println("share_release")
+		})
+		stick.On(joystick.OptionsPress, func(data interface{}) {
+			fmt.Println("options_press")
+		})
+		stick.On(joystick.OptionsRelease, func(data interface{}) {
+			fmt.Println("options_release")
+		})
+		stick.On(joystick.L1Press, func(data interface{}) {
+			fmt.Println("l1_press")
+		})
+		stick.On(joystick.L1Release, func(data interface{}) {
+			fmt.Println("l1_release")
+		})
+		stick.On(joystick.L2Press, func(data interface{}) {
+			fmt.Println("l2_press")
+		})
+		stick.On(joystick.L2Release, func(data interface{}) {
+			fmt.Println("l2_release")
+		})
+		stick.On(joystick.R1Press, func(data interface{}) {
+			fmt.Println("r1_press")
+		})
+		stick.On(joystick.R1Release, func(data interface{}) {
+			fmt.Println("r1_release")
+		})
+		stick.On(joystick.R2Press, func(data interface{}) {
+			fmt.Println("r2_press")
+		})
+		stick.On(joystick.R2Release, func(data interface{}) {
+			fmt.Println("r2_release")
+		})
+
+		stick.On(joystick.UpPress, func(data interface{}) {
+			fmt.Println("up_press")
+		})
+		stick.On(joystick.UpRelease, func(data interface{}) {
+			fmt.Println("up_release")
+		})
+		stick.On(joystick.DownPress, func(data interface{}) {
+			fmt.Println("down_press")
+		})
+		stick.On(joystick.DownRelease, func(data interface{}) {
+			fmt.Println("down_release")
+		})
+		stick.On(joystick.RightPress, func(data interface{}) {
+			fmt.Println("right_press")
+		})
+		stick.On(joystick.RightRelease, func(data interface{}) {
+			fmt.Println("right_release")
+		})
+		stick.On(joystick.LeftPress, func(data interface{}) {
+			fmt.Println("left_press")
+		})
+		stick.On(joystick.LeftRelease, func(data interface{}) {
+			fmt.Println("left_release")
+		})
+
+		stick.On(joystick.LeftX, func(data interface{}) {
+			fmt.Println("left_x", data)
+		})
+		stick.On(joystick.LeftY, func(data interface{}) {
+			fmt.Println("left_y", data)
+		})
+		stick.On(joystick.RightX, func(data interface{}) {
+			fmt.Println("right_x", data)
+		})
+		stick.On(joystick.RightY, func(data interface{}) {
+			fmt.Println("right_y", data)
+		})
+		stick.On(joystick.L2, func(data interface{}) {
+			fmt.Println("L2", data)
+		})
+		stick.On(joystick.R2, func(data interface{}) {
+			fmt.Println("R2", data)
+		})
+	}
+
+	robot := gobot.NewRobot("joystickBot",
+		[]gobot.Connection{joystickAdaptor},
+		[]gobot.Device{stick},
+		work,
+	)
+
+	robot.Start()
+}

--- a/examples/joystick_ps5.go
+++ b/examples/joystick_ps5.go
@@ -48,11 +48,11 @@ func main() {
 		stick.On(joystick.HomeRelease, func(data interface{}) {
 			fmt.Println("home_release")
 		})
-		stick.On(joystick.SharePress, func(data interface{}) {
-			fmt.Println("share_press")
+		stick.On(joystick.CreatePress, func(data interface{}) {
+			fmt.Println("create_press")
 		})
-		stick.On(joystick.ShareRelease, func(data interface{}) {
-			fmt.Println("share_release")
+		stick.On(joystick.CreateRelease, func(data interface{}) {
+			fmt.Println("create_release")
 		})
 		stick.On(joystick.OptionsPress, func(data interface{}) {
 			fmt.Println("options_press")
@@ -66,23 +66,23 @@ func main() {
 		stick.On(joystick.L1Release, func(data interface{}) {
 			fmt.Println("l1_release")
 		})
-		stick.On(joystick.L2Press, func(data interface{}) {
-			fmt.Println("l2_press")
-		})
-		stick.On(joystick.L2Release, func(data interface{}) {
-			fmt.Println("l2_release")
-		})
 		stick.On(joystick.R1Press, func(data interface{}) {
 			fmt.Println("r1_press")
 		})
 		stick.On(joystick.R1Release, func(data interface{}) {
 			fmt.Println("r1_release")
 		})
-		stick.On(joystick.R2Press, func(data interface{}) {
-			fmt.Println("r2_press")
+		stick.On(joystick.PSPress, func(data interface{}) {
+			fmt.Println("ps_press")
 		})
-		stick.On(joystick.R2Release, func(data interface{}) {
-			fmt.Println("r2_release")
+		stick.On(joystick.PSRelease, func(data interface{}) {
+			fmt.Println("ps_release")
+		})
+		stick.On(joystick.TrackpadPress, func(data interface{}) {
+			fmt.Println("trackpad_press")
+		})
+		stick.On(joystick.TrackpadRelease, func(data interface{}) {
+			fmt.Println("trackpad_release")
 		})
 
 		stick.On(joystick.UpPress, func(data interface{}) {
@@ -110,24 +110,24 @@ func main() {
 			fmt.Println("left_release")
 		})
 
-		stick.On(joystick.LeftX, func(data interface{}) {
-			fmt.Println("left_x", data)
-		})
-		stick.On(joystick.LeftY, func(data interface{}) {
-			fmt.Println("left_y", data)
-		})
-		stick.On(joystick.RightX, func(data interface{}) {
-			fmt.Println("right_x", data)
-		})
-		stick.On(joystick.RightY, func(data interface{}) {
-			fmt.Println("right_y", data)
-		})
-		stick.On(joystick.L2, func(data interface{}) {
-			fmt.Println("L2", data)
-		})
-		stick.On(joystick.R2, func(data interface{}) {
-			fmt.Println("R2", data)
-		})
+		// stick.On(joystick.LeftX, func(data interface{}) {
+		// 	fmt.Println("left_x", data)
+		// })
+		// stick.On(joystick.LeftY, func(data interface{}) {
+		// 	fmt.Println("left_y", data)
+		// })
+		// stick.On(joystick.RightX, func(data interface{}) {
+		// 	fmt.Println("right_x", data)
+		// })
+		// stick.On(joystick.RightY, func(data interface{}) {
+		// 	fmt.Println("right_y", data)
+		// })
+		// stick.On(joystick.L2, func(data interface{}) {
+		// 	fmt.Println("L2", data)
+		// })
+		// stick.On(joystick.R2, func(data interface{}) {
+		// 	fmt.Println("R2", data)
+		// })
 	}
 
 	robot := gobot.NewRobot("joystickBot",

--- a/platforms/joystick/README.md
+++ b/platforms/joystick/README.md
@@ -5,6 +5,7 @@ You can use Gobot with any USB joystick or game controller that is compatible wi
 Current configurations included:
 - Dualshock3 game controller
 - Dualshock4 game controller
+- Dualsense game controller
 - Thrustmaster T-Flight Hotas X Joystick
 - XBox360 game controller
 - XBox360 "Rock Band" drum controller
@@ -155,7 +156,7 @@ func main() {
 In the `bin` directory for this package is a CLI utility program that scans for SDL joystick events, and displays the ID and value:
 
 ```
-$ go run ./platforms/joystick/bin/scanner.go 
+$ go run ./platforms/joystick/bin/scanner.go
 Joystick 0 connected
 [6625 ms] Axis: 1       value:-22686
 [6641 ms] Axis: 1       value:-32768

--- a/platforms/joystick/configs/dualsense.json
+++ b/platforms/joystick/configs/dualsense.json
@@ -1,0 +1,100 @@
+{
+    "name": "Sony PLAYSTATION(R)5 Controller",
+    "guid": "E7D56FCA-A01F-4A14-B0D0-4FDAFD847E5E",
+    "axis": [
+        {
+            "name": "left_x",
+            "id": 0
+        },
+        {
+            "name": "left_y",
+            "id": 1
+        },
+        {
+            "name": "right_x",
+            "id": 3
+        },
+        {
+            "name": "right_y",
+            "id": 4
+        },
+        {
+            "name": "l2",
+            "id": 2
+        },
+        {
+            "name": "r2",
+            "id": 5
+        },
+        {
+            "name": "up",
+            "id": 7
+        },
+        {
+            "name": "down",
+            "id": 7
+        },
+        {
+            "name": "left",
+            "id": 6
+        },
+        {
+            "name": "right",
+            "id": 6
+        }
+    ],
+    "buttons": [
+        {
+            "name": "square",
+            "id": 3
+        },
+        {
+            "name": "triangle",
+            "id": 2
+        },
+        {
+            "name": "circle",
+            "id": 1
+        },
+        {
+            "name": "x",
+            "id": 0
+        },
+        {
+            "name": "l1",
+            "id": 4
+        },
+        {
+            "name": "l2",
+            "id": 6
+        },
+        {
+            "name": "r2",
+            "id": 7
+        },
+        {
+            "name": "r1",
+            "id": 5
+        },
+        {
+            "name": "share",
+            "id": 8
+        },
+        {
+            "name": "options",
+            "id": 9
+        },
+        {
+            "name": "ps",
+            "id": 10
+        },
+        {
+            "name": "left",
+            "id": 11
+        },
+        {
+            "name": "right",
+            "id": 12
+        }
+    ]
+}

--- a/platforms/joystick/configs/dualsense.json
+++ b/platforms/joystick/configs/dualsense.json
@@ -12,89 +12,77 @@
         },
         {
             "name": "right_x",
-            "id": 3
+            "id": 2
         },
         {
             "name": "right_y",
-            "id": 4
+            "id": 3
         },
         {
             "name": "l2",
-            "id": 2
+            "id": 4
         },
         {
             "name": "r2",
             "id": 5
-        },
-        {
-            "name": "up",
-            "id": 7
-        },
-        {
-            "name": "down",
-            "id": 7
-        },
-        {
-            "name": "left",
-            "id": 6
-        },
-        {
-            "name": "right",
-            "id": 6
         }
     ],
     "buttons": [
         {
-            "name": "square",
-            "id": 3
-        },
-        {
-            "name": "triangle",
-            "id": 2
+            "name": "x",
+            "id": 0
         },
         {
             "name": "circle",
             "id": 1
         },
         {
-            "name": "x",
-            "id": 0
+            "name": "square",
+            "id": 2
+        },
+        {
+            "name": "triangle",
+            "id": 3
         },
         {
             "name": "l1",
-            "id": 4
-        },
-        {
-            "name": "l2",
-            "id": 6
-        },
-        {
-            "name": "r2",
-            "id": 7
-        },
-        {
-            "name": "r1",
-            "id": 5
-        },
-        {
-            "name": "share",
-            "id": 8
-        },
-        {
-            "name": "options",
             "id": 9
         },
         {
-            "name": "ps",
+            "name": "r1",
             "id": 10
         },
         {
-            "name": "left",
+            "name": "create",
+            "id": 4
+        },
+        {
+            "name": "options",
+            "id": 6
+        },
+        {
+            "name": "ps",
+            "id": 5
+        },
+        {
+            "name": "up",
             "id": 11
         },
         {
-            "name": "right",
+            "name": "down",
             "id": 12
+        },
+        {
+            "name": "left",
+            "id": 13
+        },
+        {
+            "name": "right",
+            "id": 14
+        },
+        {
+            "name": "trackpad",
+            "id": 15
         }
     ]
 }

--- a/platforms/joystick/events.go
+++ b/platforms/joystick/events.go
@@ -75,8 +75,20 @@ const (
 	XRelease = "x_release"
 	// share button press event
 	SharePress = "share_press"
-	// share button relase event
+	// share button release event
 	ShareRelease = "share_release"
+	// create button press event
+	CreatePress = "create_press"
+	// create button release event
+	CreateRelease = "create_release"
+	// ps button press event
+	PSPress = "ps_press"
+	// ps button release event
+	PSRelease = "ps_release"
+	// trackpad button press event
+	TrackpadPress = "trackpad_press"
+	// trackpad button release event
+	TrackpadRelease = "trackpad_release"
 	// options button press event
 	OptionsPress = "options_press"
 	// options button release event

--- a/platforms/joystick/joystick_driver.go
+++ b/platforms/joystick/joystick_driver.go
@@ -17,6 +17,9 @@ const (
 	// Dualshock4 joystick configuration.
 	Dualshock4 = "dualshock4"
 
+	// Dualsense joystick configuration.
+	Dualsense = "dualsense"
+
 	// TFlightHotasX flight stick configuration.
 	TFlightHotasX = "tflightHotasX"
 
@@ -69,7 +72,8 @@ type joystickConfig struct {
 // file location.
 //
 // Optionally accepts:
-//  time.Duration: Interval at which the Driver is polled for new information
+//
+//	time.Duration: Interval at which the Driver is polled for new information
 func NewDriver(a *Adaptor, config string, v ...time.Duration) *Driver {
 	d := &Driver{
 		name:       gobot.DefaultName("Joystick"),
@@ -108,6 +112,7 @@ func (j *Driver) adaptor() *Adaptor {
 // Start and polls the state of the joystick at the given interval.
 //
 // Emits the Events:
+//
 //	Error error - On button error
 //	Events defined in the json button configuration file.
 //	They will have the format:
@@ -120,6 +125,8 @@ func (j *Driver) Start() (err error) {
 		j.config = dualshock3Config
 	case Dualshock4:
 		j.config = dualshock4Config
+	case Dualsense:
+		j.config = dualsenseConfig
 	case TFlightHotasX:
 		j.config = tflightHotasXConfig
 	case Xbox360:

--- a/platforms/joystick/joystick_dualsense.go
+++ b/platforms/joystick/joystick_dualsense.go
@@ -4,102 +4,92 @@ var dualsenseConfig = joystickConfig{
 	Name: "Dualsense Controller",
 	GUID: "E7D56FCA-A01F-4A14-B0D0-4FDAFD847E5E",
 	Axis: []pair{
-		pair{
+		{
 			Name: "left_x",
 			ID:   0,
 		},
-		pair{
+		{
 			Name: "left_y",
 			ID:   1,
 		},
-		pair{
+		{
 			Name: "right_x",
-			ID:   3,
-		},
-		pair{
-			Name: "right_y",
-			ID:   4,
-		},
-		pair{
-			Name: "l2",
 			ID:   2,
 		},
-		pair{
+		{
+			Name: "right_y",
+			ID:   3,
+		},
+		{
+			Name: "l2",
+			ID:   4,
+		},
+		{
 			Name: "r2",
 			ID:   5,
 		},
 	},
 	Buttons: []pair{
-		pair{
-			Name: "square",
-			ID:   3,
-		},
-		pair{
-			Name: "triangle",
-			ID:   2,
-		},
-		pair{
-			Name: "circle",
-			ID:   1,
-		},
-		pair{
+		{
 			Name: "x",
 			ID:   0,
 		},
-		pair{
-			Name: "l1",
+		{
+			Name: "circle",
+			ID:   1,
+		},
+		{
+			Name: "square",
+			ID:   2,
+		},
+		{
+			Name: "triangle",
+			ID:   3,
+		},
+		{
+			Name: "create",
 			ID:   4,
 		},
-		pair{
-			Name: "l2",
+		{
+			Name: "options",
 			ID:   6,
 		},
-		pair{
-			Name: "r1",
+		{
+			Name: "ps",
 			ID:   5,
 		},
-		pair{
+		{
 			Name: "r2",
 			ID:   7,
 		},
-		pair{
-			Name: "share",
-			ID:   8,
-		},
-		pair{
-			Name: "options",
+		{
+			Name: "l1",
 			ID:   9,
 		},
-		pair{
-			Name: "home",
+		{
+			Name: "r1",
 			ID:   10,
 		},
-	},
-	Hats: []hat{
-		hat{
-			Hat:  0,
-			Name: "down",
-			ID:   4,
-		},
-		hat{
-			Hat:  0,
+		{
 			Name: "up",
-			ID:   1,
+			ID:   11,
 		},
-		hat{
-			Hat:  0,
+		{
+			Name: "down",
+			ID:   12,
+		},
+		{
 			Name: "left",
-			ID:   8,
+			ID:   13,
 		},
-		hat{
-			Hat:  0,
+		{
 			Name: "right",
-			ID:   2,
+			ID:   14,
 		},
-		hat{
-			Hat:  0,
-			Name: "released",
-			ID:   0,
+		{
+			Name: "trackpad",
+			ID:   15,
 		},
 	},
+	Hats: []hat{},
 }

--- a/platforms/joystick/joystick_dualsense.go
+++ b/platforms/joystick/joystick_dualsense.go
@@ -1,0 +1,105 @@
+package joystick
+
+var dualsenseConfig = joystickConfig{
+	Name: "Dualsense Controller",
+	GUID: "E7D56FCA-A01F-4A14-B0D0-4FDAFD847E5E",
+	Axis: []pair{
+		pair{
+			Name: "left_x",
+			ID:   0,
+		},
+		pair{
+			Name: "left_y",
+			ID:   1,
+		},
+		pair{
+			Name: "right_x",
+			ID:   3,
+		},
+		pair{
+			Name: "right_y",
+			ID:   4,
+		},
+		pair{
+			Name: "l2",
+			ID:   2,
+		},
+		pair{
+			Name: "r2",
+			ID:   5,
+		},
+	},
+	Buttons: []pair{
+		pair{
+			Name: "square",
+			ID:   3,
+		},
+		pair{
+			Name: "triangle",
+			ID:   2,
+		},
+		pair{
+			Name: "circle",
+			ID:   1,
+		},
+		pair{
+			Name: "x",
+			ID:   0,
+		},
+		pair{
+			Name: "l1",
+			ID:   4,
+		},
+		pair{
+			Name: "l2",
+			ID:   6,
+		},
+		pair{
+			Name: "r1",
+			ID:   5,
+		},
+		pair{
+			Name: "r2",
+			ID:   7,
+		},
+		pair{
+			Name: "share",
+			ID:   8,
+		},
+		pair{
+			Name: "options",
+			ID:   9,
+		},
+		pair{
+			Name: "home",
+			ID:   10,
+		},
+	},
+	Hats: []hat{
+		hat{
+			Hat:  0,
+			Name: "down",
+			ID:   4,
+		},
+		hat{
+			Hat:  0,
+			Name: "up",
+			ID:   1,
+		},
+		hat{
+			Hat:  0,
+			Name: "left",
+			ID:   8,
+		},
+		hat{
+			Hat:  0,
+			Name: "right",
+			ID:   2,
+		},
+		hat{
+			Hat:  0,
+			Name: "released",
+			ID:   0,
+		},
+	},
+}


### PR DESCRIPTION
Added support for PlayStation 5 Dualsense joystick.

Code derived from Dualshock 4 implementation:

* buttons remapped to appropriate IDs
* L2 and R2 are now "axis" instead of "buttons"
* New "create" button (instead of "share" button)
* look at examples/joystick_ps5.go file as a usage example

This PR supersedes https://github.com/hybridgroup/gobot/pull/821.