### PR TITLE
Introduce I2cBusAdaptor for composition in platforms

### DIFF
--- a/drivers/i2c/adafruit_driver.go
+++ b/drivers/i2c/adafruit_driver.go
@@ -199,7 +199,7 @@ func (a *AdafruitMotorHatDriver) startDriver(connection Connection) (err error) 
 
 // Start initializes both I2C-addressable Adafruit Motor HAT drivers
 func (a *AdafruitMotorHatDriver) Start() (err error) {
-	bus := a.GetBusOrDefault(a.connector.GetDefaultBus())
+	bus := a.GetBusOrDefault(a.connector.DefaultBus())
 
 	err = a.startServoHat(bus)
 	if adafruitDebug && err != nil {

--- a/drivers/i2c/bh1750_driver.go
+++ b/drivers/i2c/bh1750_driver.go
@@ -1,8 +1,8 @@
 package i2c
 
 import (
-	"time"
 	"errors"
+	"time"
 
 	"gobot.io/x/gobot"
 )
@@ -44,7 +44,7 @@ func NewBH1750Driver(a Connector, options ...func(Config)) *BH1750Driver {
 		name:      gobot.DefaultName("BH1750"),
 		connector: a,
 		Config:    NewConfig(),
-		mode: BH1750_CONTINUOUS_HIGH_RES_MODE,
+		mode:      BH1750_CONTINUOUS_HIGH_RES_MODE,
 	}
 
 	for _, option := range options {
@@ -66,7 +66,7 @@ func (h *BH1750Driver) Connection() gobot.Connection { return h.connector.(gobot
 
 // Start initialized the bh1750
 func (h *BH1750Driver) Start() (err error) {
-	bus := h.GetBusOrDefault(h.connector.GetDefaultBus())
+	bus := h.GetBusOrDefault(h.connector.DefaultBus())
 	address := h.GetAddressOrDefault(bh1750Address)
 
 	h.connection, err = h.connector.GetConnection(address, bus)

--- a/drivers/i2c/blinkm_driver.go
+++ b/drivers/i2c/blinkm_driver.go
@@ -76,7 +76,7 @@ func (b *BlinkMDriver) Connection() gobot.Connection { return b.connection.(gobo
 
 // Start starts the Driver up, and writes start command
 func (b *BlinkMDriver) Start() (err error) {
-	bus := b.GetBusOrDefault(b.connector.GetDefaultBus())
+	bus := b.GetBusOrDefault(b.connector.DefaultBus())
 	address := b.GetAddressOrDefault(blinkmAddress)
 
 	b.connection, err = b.connector.GetConnection(address, bus)

--- a/drivers/i2c/drv2605l_driver.go
+++ b/drivers/i2c/drv2605l_driver.go
@@ -136,7 +136,7 @@ func (d *DRV2605LDriver) writeByteRegisters(regValPairs []struct{ reg, val uint8
 }
 
 func (d *DRV2605LDriver) initialize() (err error) {
-	bus := d.GetBusOrDefault(d.connector.GetDefaultBus())
+	bus := d.GetBusOrDefault(d.connector.DefaultBus())
 	address := d.GetAddressOrDefault(drv2605Address)
 
 	d.connection, err = d.connector.GetConnection(address, bus)

--- a/drivers/i2c/helpers_test.go
+++ b/drivers/i2c/helpers_test.go
@@ -164,7 +164,7 @@ func (t *i2cTestAdaptor) GetConnection(address int, bus int) (connection Connect
 	return t, nil
 }
 
-func (t *i2cTestAdaptor) GetDefaultBus() int {
+func (t *i2cTestAdaptor) DefaultBus() int {
 	return 0
 }
 

--- a/drivers/i2c/hmc6352_driver.go
+++ b/drivers/i2c/hmc6352_driver.go
@@ -45,7 +45,7 @@ func (h *HMC6352Driver) Connection() gobot.Connection { return h.connector.(gobo
 
 // Start initializes the hmc6352
 func (h *HMC6352Driver) Start() (err error) {
-	bus := h.GetBusOrDefault(h.connector.GetDefaultBus())
+	bus := h.GetBusOrDefault(h.connector.DefaultBus())
 	address := h.GetAddressOrDefault(hmc6352Address)
 
 	h.connection, err = h.connector.GetConnection(address, bus)

--- a/drivers/i2c/i2c_connection.go
+++ b/drivers/i2c/i2c_connection.go
@@ -100,9 +100,8 @@ type Connector interface {
 	// platform specific.
 	GetConnection(address int, busNr int) (device Connection, err error)
 
-	// TODO: rename to golang getter spec (no prefix "Get")
-	// GetDefaultBus returns the default I2C bus index
-	GetDefaultBus() int
+	// DefaultBus returns the default I2C bus index
+	DefaultBus() int
 }
 
 // Connection is a connection to an I2C device with a specified address

--- a/drivers/i2c/i2c_connection.go
+++ b/drivers/i2c/i2c_connection.go
@@ -95,11 +95,12 @@ type I2cDevice interface {
 // Connector lets Adaptors provide the interface for Drivers
 // to get access to the I2C buses on platforms that support I2C.
 type Connector interface {
-	// GetConnection returns a connection to device at the specified address
+	// GetConnection creates and returns a connection to device at the specified address
 	// and bus. Bus numbering starts at index 0, the range of valid buses is
 	// platform specific.
-	GetConnection(address int, bus int) (device Connection, err error)
+	GetConnection(address int, busNr int) (device Connection, err error)
 
+	// TODO: rename to golang getter spec (no prefix "Get")
 	// GetDefaultBus returns the default I2C bus index
 	GetDefaultBus() int
 }

--- a/drivers/i2c/i2c_driver.go
+++ b/drivers/i2c/i2c_driver.go
@@ -63,7 +63,7 @@ func (d *Driver) Start() error {
 	defer d.mutex.Unlock()
 
 	var err error
-	bus := d.GetBusOrDefault(d.connector.GetDefaultBus())
+	bus := d.GetBusOrDefault(d.connector.DefaultBus())
 	address := d.GetAddressOrDefault(int(d.defaultAddress))
 
 	if d.connection, err = d.connector.GetConnection(address, bus); err != nil {

--- a/drivers/i2c/ina3221_driver.go
+++ b/drivers/i2c/ina3221_driver.go
@@ -91,7 +91,7 @@ func (i *INA3221Driver) Connection() gobot.Connection {
 // Start initializes the INA3221
 func (i *INA3221Driver) Start() error {
 	var err error
-	bus := i.GetBusOrDefault(i.connector.GetDefaultBus())
+	bus := i.GetBusOrDefault(i.connector.DefaultBus())
 	address := i.GetAddressOrDefault(int(ina3221Address))
 
 	if i.connection, err = i.connector.GetConnection(address, bus); err != nil {

--- a/drivers/i2c/jhd1313m1_driver.go
+++ b/drivers/i2c/jhd1313m1_driver.go
@@ -144,7 +144,7 @@ func (h *JHD1313M1Driver) Connection() gobot.Connection {
 
 // Start starts the backlit and the screen and initializes the states.
 func (h *JHD1313M1Driver) Start() (err error) {
-	bus := h.GetBusOrDefault(h.connector.GetDefaultBus())
+	bus := h.GetBusOrDefault(h.connector.DefaultBus())
 
 	if h.lcdConnection, err = h.connector.GetConnection(h.lcdAddress, bus); err != nil {
 		return err

--- a/drivers/i2c/lidarlite_driver.go
+++ b/drivers/i2c/lidarlite_driver.go
@@ -51,7 +51,7 @@ func (h *LIDARLiteDriver) Connection() gobot.Connection { return h.connector.(go
 
 // Start initialized the LIDAR
 func (h *LIDARLiteDriver) Start() (err error) {
-	bus := h.GetBusOrDefault(h.connector.GetDefaultBus())
+	bus := h.GetBusOrDefault(h.connector.DefaultBus())
 	address := h.GetAddressOrDefault(lidarliteAddress)
 
 	h.connection, err = h.connector.GetConnection(address, bus)

--- a/drivers/i2c/mma7660_driver.go
+++ b/drivers/i2c/mma7660_driver.go
@@ -71,7 +71,7 @@ func (h *MMA7660Driver) Connection() gobot.Connection { return h.connector.(gobo
 
 // Start initialized the mma7660
 func (h *MMA7660Driver) Start() (err error) {
-	bus := h.GetBusOrDefault(h.connector.GetDefaultBus())
+	bus := h.GetBusOrDefault(h.connector.DefaultBus())
 	address := h.GetAddressOrDefault(mma7660Address)
 
 	h.connection, err = h.connector.GetConnection(address, bus)

--- a/drivers/i2c/pca9501_driver.go
+++ b/drivers/i2c/pca9501_driver.go
@@ -151,7 +151,7 @@ func (p *PCA9501Driver) WriteEEPROM(address uint8, val uint8) error {
 
 func (p *PCA9501Driver) initialize() (err error) {
 	// initialize the EEPROM connection
-	bus := p.GetBusOrDefault(p.connector.GetDefaultBus())
+	bus := p.GetBusOrDefault(p.connector.DefaultBus())
 	addressMem := p.GetAddressOrDefault(pca9501DefaultAddress) | 0x40
 	p.connectionMem, err = p.connector.GetConnection(addressMem, bus)
 	return

--- a/drivers/i2c/pca9685_driver.go
+++ b/drivers/i2c/pca9685_driver.go
@@ -100,7 +100,7 @@ func (p *PCA9685Driver) Connection() gobot.Connection { return p.connector.(gobo
 
 // Start initializes the pca9685
 func (p *PCA9685Driver) Start() (err error) {
-	bus := p.GetBusOrDefault(p.connector.GetDefaultBus())
+	bus := p.GetBusOrDefault(p.connector.DefaultBus())
 	address := p.GetAddressOrDefault(pca9685Address)
 
 	p.connection, err = p.connector.GetConnection(address, bus)

--- a/drivers/i2c/pcf8591_driver.go
+++ b/drivers/i2c/pcf8591_driver.go
@@ -189,7 +189,7 @@ func (p *PCF8591Driver) Connection() gobot.Connection { return p.connector.(gobo
 
 // Start initializes the PCF8591
 func (p *PCF8591Driver) Start() (err error) {
-	bus := p.GetBusOrDefault(p.connector.GetDefaultBus())
+	bus := p.GetBusOrDefault(p.connector.DefaultBus())
 	address := p.GetAddressOrDefault(pcf8591DefaultAddress)
 
 	p.connection, err = p.connector.GetConnection(address, bus)

--- a/drivers/i2c/sht2x_driver.go
+++ b/drivers/i2c/sht2x_driver.go
@@ -118,7 +118,7 @@ func (d *SHT2xDriver) Connection() gobot.Connection { return d.connector.(gobot.
 
 // Start initializes the SHT2x
 func (d *SHT2xDriver) Start() (err error) {
-	bus := d.GetBusOrDefault(d.connector.GetDefaultBus())
+	bus := d.GetBusOrDefault(d.connector.DefaultBus())
 	address := d.GetAddressOrDefault(SHT2xDefaultAddress)
 
 	if d.connection, err = d.connector.GetConnection(address, bus); err != nil {

--- a/drivers/i2c/sht3x_driver.go
+++ b/drivers/i2c/sht3x_driver.go
@@ -102,7 +102,7 @@ func (s *SHT3xDriver) Connection() gobot.Connection { return s.connector.(gobot.
 
 // Start initializes the SHT3x
 func (s *SHT3xDriver) Start() (err error) {
-	bus := s.GetBusOrDefault(s.connector.GetDefaultBus())
+	bus := s.GetBusOrDefault(s.connector.DefaultBus())
 	address := s.GetAddressOrDefault(s.sht3xAddress)
 
 	s.connection, err = s.connector.GetConnection(address, bus)

--- a/drivers/i2c/ssd1306_driver.go
+++ b/drivers/i2c/ssd1306_driver.go
@@ -282,7 +282,7 @@ func (s *SSD1306Driver) Start() (err error) {
 		s.initSequence.contrast = 0x9F
 		s.initSequence.prechargePeriod = 0x22
 	}
-	bus := s.GetBusOrDefault(s.connector.GetDefaultBus())
+	bus := s.GetBusOrDefault(s.connector.DefaultBus())
 	address := s.GetAddressOrDefault(ssd1306I2CAddress)
 	s.connection, err = s.connector.GetConnection(address, bus)
 	if err != nil {

--- a/drivers/i2c/tsl2561_driver.go
+++ b/drivers/i2c/tsl2561_driver.go
@@ -231,7 +231,7 @@ func (d *TSL2561Driver) Connection() gobot.Connection {
 
 // Start initializes the device.
 func (d *TSL2561Driver) Start() (err error) {
-	bus := d.GetBusOrDefault(d.connector.GetDefaultBus())
+	bus := d.GetBusOrDefault(d.connector.DefaultBus())
 	address := d.GetAddressOrDefault(TSL2561AddressFloat)
 
 	if d.connection, err = d.connector.GetConnection(address, bus); err != nil {

--- a/drivers/i2c/wiichuck_driver.go
+++ b/drivers/i2c/wiichuck_driver.go
@@ -86,7 +86,7 @@ func (w *WiichuckDriver) Connection() gobot.Connection { return w.connector.(gob
 // Start initilizes i2c and reads from adaptor
 // using specified interval to update with new value
 func (w *WiichuckDriver) Start() (err error) {
-	bus := w.GetBusOrDefault(w.connector.GetDefaultBus())
+	bus := w.GetBusOrDefault(w.connector.DefaultBus())
 	address := w.GetAddressOrDefault(wiichuckAddress)
 
 	w.connection, err = w.connector.GetConnection(address, bus)

--- a/drivers/spi/spi.go
+++ b/drivers/spi/spi.go
@@ -17,6 +17,8 @@ type Operations interface {
 	Tx(w, r []byte) error
 }
 
+// TODO: rename to golang getter spec (no prefix "Get" for simple getters)
+
 // Connector lets Adaptors provide the interface for Drivers
 // to get access to the SPI buses on platforms that support SPI.
 type Connector interface {

--- a/examples/edison_blink.go
+++ b/examples/edison_blink.go
@@ -12,13 +12,11 @@ import (
 	"gobot.io/x/gobot/platforms/intel-iot/edison"
 )
 
-func main() {
-	e := edison.NewAdaptor()
-	led := gpio.NewLedDriver(e, "13")
+const boardType = "arduino" // "sparkfun" for a Sparkfun Edison board with the GPIO block
 
-	// Uncomment the line below if you are using a Sparkfun
-	// Edison board with the GPIO block
-	// e.SetBoard("sparkfun")
+func main() {
+	e := edison.NewAdaptor(boardType)
+	led := gpio.NewLedDriver(e, "13")
 
 	work := func() {
 		gobot.Every(1*time.Second, func() {

--- a/examples/edison_miniboard_grove_accelerometer.go
+++ b/examples/edison_miniboard_grove_accelerometer.go
@@ -14,8 +14,7 @@ import (
 )
 
 func main() {
-	board := edison.NewAdaptor()
-	board.SetBoard("miniboard")
+	board := edison.NewAdaptor("miniboard")
 
 	accel := i2c.NewGroveAccelerometerDriver(board)
 

--- a/platforms/adaptors/digitalpinsadaptor_test.go
+++ b/platforms/adaptors/digitalpinsadaptor_test.go
@@ -107,6 +107,7 @@ func TestDigitalPinsReConnect(t *testing.T) {
 	err := a.Connect()
 	// assert
 	gobottest.Assert(t, err, nil)
+	gobottest.Refute(t, a.pins, nil)
 	gobottest.Assert(t, len(a.pins), 0)
 }
 

--- a/platforms/adaptors/i2cbusadaptor.go
+++ b/platforms/adaptors/i2cbusadaptor.go
@@ -81,6 +81,6 @@ func (a *I2cBusAdaptor) GetConnection(address int, busNr int) (connection i2c.Co
 }
 
 // GetDefaultBus returns the default i2c bus number for this platform.
-func (a *I2cBusAdaptor) GetDefaultBus() int {
+func (a *I2cBusAdaptor) DefaultBus() int {
 	return a.defaultBusNumber
 }

--- a/platforms/adaptors/i2cbusadaptor.go
+++ b/platforms/adaptors/i2cbusadaptor.go
@@ -1,0 +1,86 @@
+package adaptors
+
+import (
+	"fmt"
+	"sync"
+
+	multierror "github.com/hashicorp/go-multierror"
+	"gobot.io/x/gobot/drivers/i2c"
+	"gobot.io/x/gobot/system"
+)
+
+type i2cBusNumberValidator func(busNumber int) error
+
+// I2cBusAdaptor is a adaptor for i2c bus, normally used for composition in platforms.
+type I2cBusAdaptor struct {
+	sys              *system.Accesser
+	validateNumber   i2cBusNumberValidator
+	defaultBusNumber int
+	mutex            sync.Mutex
+	buses            map[int]i2c.I2cDevice
+}
+
+// NewI2cBusAdaptor provides the access to i2c buses of the board. The validator is used to check the bus number,
+// which is given by user, to the abilities of the board.
+func NewI2cBusAdaptor(sys *system.Accesser, v i2cBusNumberValidator, defaultBusNr int) *I2cBusAdaptor {
+	a := &I2cBusAdaptor{
+		sys:              sys,
+		validateNumber:   v,
+		defaultBusNumber: defaultBusNr,
+	}
+	return a
+}
+
+// Connect prepares the connection to i2c buses.
+func (a *I2cBusAdaptor) Connect() error {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
+	a.buses = make(map[int]i2c.I2cDevice)
+	return nil
+}
+
+// Finalize closes all i2c connections.
+func (a *I2cBusAdaptor) Finalize() error {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
+	var err error
+	for _, bus := range a.buses {
+		if bus != nil {
+			if e := bus.Close(); e != nil {
+				err = multierror.Append(err, e)
+			}
+		}
+	}
+	a.buses = nil
+	return err
+}
+
+// GetConnection returns a connection to a device on a specified i2c bus
+func (a *I2cBusAdaptor) GetConnection(address int, busNr int) (connection i2c.Connection, err error) {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
+	if a.buses == nil {
+		return nil, fmt.Errorf("not connected")
+	}
+
+	bus := a.buses[busNr]
+	if bus == nil {
+		if err := a.validateNumber(busNr); err != nil {
+			return nil, err
+		}
+		bus, err = a.sys.NewI2cDevice(fmt.Sprintf("/dev/i2c-%d", busNr))
+		if err != nil {
+			return nil, err
+		}
+		a.buses[busNr] = bus
+	}
+	return i2c.NewConnection(bus, address), err
+}
+
+// GetDefaultBus returns the default i2c bus number for this platform.
+func (a *I2cBusAdaptor) GetDefaultBus() int {
+	return a.defaultBusNumber
+}

--- a/platforms/adaptors/i2cbusadaptor_test.go
+++ b/platforms/adaptors/i2cbusadaptor_test.go
@@ -1,0 +1,114 @@
+package adaptors
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"gobot.io/x/gobot/drivers/i2c"
+	"gobot.io/x/gobot/gobottest"
+	"gobot.io/x/gobot/system"
+)
+
+// make sure that this Adaptor fulfills all the required interfaces
+var _ i2c.Connector = (*I2cBusAdaptor)(nil)
+
+const i2cBus1 = "/dev/i2c-1"
+
+func initTestI2cAdaptorWithMockedFilesystem(mockPaths []string) (*I2cBusAdaptor, *system.MockFilesystem) {
+	sys := system.NewAccesser()
+	sys.UseMockSyscall()
+	fs := sys.UseMockFilesystem(mockPaths)
+	validator := func(busNr int) error {
+		if busNr > 1 {
+			return fmt.Errorf("%d not valid", busNr)
+		}
+		return nil
+	}
+	a := NewI2cBusAdaptor(sys, validator, 1)
+	if err := a.Connect(); err != nil {
+		panic(err)
+	}
+	return a, fs
+}
+
+func TestI2cWorkflow(t *testing.T) {
+	a, _ := initTestI2cAdaptorWithMockedFilesystem([]string{i2cBus1})
+	gobottest.Assert(t, len(a.buses), 0)
+
+	con, err := a.GetConnection(0xff, 1)
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, len(a.buses), 1)
+
+	_, err = con.Write([]byte{0x00, 0x01})
+	gobottest.Assert(t, err, nil)
+
+	data := []byte{42, 42}
+	_, err = con.Read(data)
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, data, []byte{0x00, 0x01})
+
+	gobottest.Assert(t, a.Finalize(), nil)
+	gobottest.Assert(t, len(a.buses), 0)
+}
+
+func TestI2cGetConnection(t *testing.T) {
+	// arrange
+	a, _ := initTestI2cAdaptorWithMockedFilesystem([]string{i2cBus1})
+	// assert working connection
+	c1, e1 := a.GetConnection(0xff, 1)
+	gobottest.Assert(t, e1, nil)
+	gobottest.Refute(t, c1, nil)
+	gobottest.Assert(t, len(a.buses), 1)
+	// assert invalid bus gets error
+	c2, e2 := a.GetConnection(0x01, 99)
+	gobottest.Assert(t, e2, fmt.Errorf("99 not valid"))
+	gobottest.Assert(t, c2, nil)
+	gobottest.Assert(t, len(a.buses), 1)
+	// assert unconnected gets error
+	gobottest.Assert(t, a.Finalize(), nil)
+	c3, e3 := a.GetConnection(0x01, 99)
+	gobottest.Assert(t, e3, fmt.Errorf("not connected"))
+	gobottest.Assert(t, c3, nil)
+	gobottest.Assert(t, len(a.buses), 0)
+}
+
+func TestI2cFinalize(t *testing.T) {
+	// arrange
+	a, fs := initTestI2cAdaptorWithMockedFilesystem([]string{i2cBus1})
+	// assert that finalize before connect is working
+	gobottest.Assert(t, a.Finalize(), nil)
+	// arrange
+	gobottest.Assert(t, a.Connect(), nil)
+	a.GetConnection(0xaf, 1)
+	gobottest.Assert(t, len(a.buses), 1)
+	// assert that Finalize after GetConnection is working and clean up
+	gobottest.Assert(t, a.Finalize(), nil)
+	gobottest.Assert(t, len(a.buses), 0)
+	// assert that finalize after finalize is working
+	gobottest.Assert(t, a.Finalize(), nil)
+	// assert that close error is recognized
+	gobottest.Assert(t, a.Connect(), nil)
+	con, _ := a.GetConnection(0xbf, 1)
+	gobottest.Assert(t, len(a.buses), 1)
+	con.Write([]byte{0xbf})
+	fs.WithCloseError = true
+	err := a.Finalize()
+	gobottest.Assert(t, strings.Contains(err.Error(), "close error"), true)
+}
+
+func TestI2cReConnect(t *testing.T) {
+	// arrange
+	a, _ := initTestI2cAdaptorWithMockedFilesystem([]string{i2cBus1})
+	gobottest.Assert(t, a.Finalize(), nil)
+	// act
+	gobottest.Assert(t, a.Connect(), nil)
+	// assert
+	gobottest.Refute(t, a.buses, nil)
+	gobottest.Assert(t, len(a.buses), 0)
+}
+
+func TestI2cGetDefaultBus(t *testing.T) {
+	a := NewI2cBusAdaptor(nil, nil, 2)
+	gobottest.Assert(t, a.GetDefaultBus(), 2)
+}

--- a/platforms/adaptors/i2cbusadaptor_test.go
+++ b/platforms/adaptors/i2cbusadaptor_test.go
@@ -110,5 +110,5 @@ func TestI2cReConnect(t *testing.T) {
 
 func TestI2cGetDefaultBus(t *testing.T) {
 	a := NewI2cBusAdaptor(nil, nil, 2)
-	gobottest.Assert(t, a.GetDefaultBus(), 2)
+	gobottest.Assert(t, a.DefaultBus(), 2)
 }

--- a/platforms/adaptors/pwmpinsadaptor_test.go
+++ b/platforms/adaptors/pwmpinsadaptor_test.go
@@ -164,6 +164,7 @@ func TestPWMPinsReConnect(t *testing.T) {
 	err := a.Connect()
 	// assert
 	gobottest.Assert(t, err, nil)
+	gobottest.Refute(t, a.pins, nil)
 	gobottest.Assert(t, len(a.pins), 0)
 }
 

--- a/platforms/beaglebone/beaglebone_adaptor_test.go
+++ b/platforms/beaglebone/beaglebone_adaptor_test.go
@@ -231,6 +231,21 @@ func TestI2cDefaultBus(t *testing.T) {
 	gobottest.Assert(t, a.GetDefaultBus(), 2)
 }
 
+func TestI2cFinalizeWithErrors(t *testing.T) {
+	// arrange
+	a := NewAdaptor()
+	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-2"})
+	gobottest.Assert(t, a.Connect(), nil)
+	con, err := a.GetConnection(0xff, 2)
+	gobottest.Assert(t, err, nil)
+	con.Write([]byte{0xbf})
+	fs.WithCloseError = true
+	// act
+	err = a.Finalize()
+	// assert
+	gobottest.Assert(t, strings.Contains(err.Error(), "close error"), true)
+}
+
 func Test_validateI2cBusNumber(t *testing.T) {
 	var tests = map[string]struct {
 		busNr   int

--- a/platforms/beaglebone/beaglebone_adaptor_test.go
+++ b/platforms/beaglebone/beaglebone_adaptor_test.go
@@ -228,7 +228,7 @@ func TestPocketName(t *testing.T) {
 
 func TestI2cDefaultBus(t *testing.T) {
 	a := NewAdaptor()
-	gobottest.Assert(t, a.GetDefaultBus(), 2)
+	gobottest.Assert(t, a.DefaultBus(), 2)
 }
 
 func TestI2cFinalizeWithErrors(t *testing.T) {

--- a/platforms/beaglebone/beaglebone_adaptor_test.go
+++ b/platforms/beaglebone/beaglebone_adaptor_test.go
@@ -234,11 +234,13 @@ func TestI2cDefaultBus(t *testing.T) {
 func TestI2cFinalizeWithErrors(t *testing.T) {
 	// arrange
 	a := NewAdaptor()
+	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-2"})
 	gobottest.Assert(t, a.Connect(), nil)
 	con, err := a.GetConnection(0xff, 2)
 	gobottest.Assert(t, err, nil)
-	con.Write([]byte{0xbf})
+	_, err = con.Write([]byte{0xbf})
+	gobottest.Assert(t, err, nil)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/chip/chip_adaptor_test.go
+++ b/platforms/chip/chip_adaptor_test.go
@@ -152,11 +152,13 @@ func TestI2cDefaultBus(t *testing.T) {
 func TestI2cFinalizeWithErrors(t *testing.T) {
 	// arrange
 	a := NewAdaptor()
+	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-2"})
 	gobottest.Assert(t, a.Connect(), nil)
 	con, err := a.GetConnection(0xff, 2)
 	gobottest.Assert(t, err, nil)
-	con.Write([]byte{0xbf})
+	_, err = con.Write([]byte{0xbf})
+	gobottest.Assert(t, err, nil)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/chip/chip_adaptor_test.go
+++ b/platforms/chip/chip_adaptor_test.go
@@ -146,7 +146,7 @@ func TestPWM(t *testing.T) {
 
 func TestI2cDefaultBus(t *testing.T) {
 	a := NewAdaptor()
-	gobottest.Assert(t, a.GetDefaultBus(), 1)
+	gobottest.Assert(t, a.DefaultBus(), 1)
 }
 
 func TestI2cFinalizeWithErrors(t *testing.T) {

--- a/platforms/chip/chip_adaptor_test.go
+++ b/platforms/chip/chip_adaptor_test.go
@@ -120,27 +120,6 @@ func TestProDigitalIO(t *testing.T) {
 	gobottest.Assert(t, a.Finalize(), nil)
 }
 
-func TestI2c(t *testing.T) {
-	a := NewAdaptor()
-	a.sys.UseMockFilesystem([]string{"/dev/i2c-1"})
-	a.sys.UseMockSyscall()
-
-	a.Connect()
-
-	con, err := a.GetConnection(0xff, 1)
-	gobottest.Assert(t, err, nil)
-
-	_, err = con.Write([]byte{0x00, 0x01})
-	gobottest.Assert(t, err, nil)
-
-	data := []byte{42, 42}
-	_, err = con.Read(data)
-	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, data, []byte{0x00, 0x01})
-
-	gobottest.Assert(t, a.Finalize(), nil)
-}
-
 func TestPWM(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem()
 	a.Connect()
@@ -165,15 +144,44 @@ func TestPWM(t *testing.T) {
 	gobottest.Assert(t, a.Finalize(), nil)
 }
 
-func TestDefaultBus(t *testing.T) {
+func TestI2cDefaultBus(t *testing.T) {
 	a, _ := initTestAdaptorWithMockedFilesystem()
 	gobottest.Assert(t, a.GetDefaultBus(), 1)
 }
 
-func TestGetConnectionInvalidBus(t *testing.T) {
-	a, _ := initTestAdaptorWithMockedFilesystem()
-	_, err := a.GetConnection(0x01, 99)
-	gobottest.Assert(t, err, errors.New("Bus number 99 out of range"))
+func Test_validateI2cBusNumber(t *testing.T) {
+	var tests = map[string]struct {
+		busNr   int
+		wantErr error
+	}{
+		"number_negative_error": {
+			busNr:   -1,
+			wantErr: fmt.Errorf("Bus number -1 out of range"),
+		},
+		"number_0_ok": {
+			busNr: 0,
+		},
+		"number_1_ok": {
+			busNr: 1,
+		},
+		"number_2_ok": {
+			busNr: 2,
+		},
+		"number_3_error": {
+			busNr:   3,
+			wantErr: fmt.Errorf("Bus number 3 out of range"),
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			a := NewAdaptor()
+			// act
+			err := a.validateI2cBusNumber(tc.busNr)
+			// assert
+			gobottest.Assert(t, err, tc.wantErr)
+		})
+	}
 }
 
 func Test_translatePWMPin(t *testing.T) {

--- a/platforms/chip/chip_adaptor_test.go
+++ b/platforms/chip/chip_adaptor_test.go
@@ -145,8 +145,23 @@ func TestPWM(t *testing.T) {
 }
 
 func TestI2cDefaultBus(t *testing.T) {
-	a, _ := initTestAdaptorWithMockedFilesystem()
+	a := NewAdaptor()
 	gobottest.Assert(t, a.GetDefaultBus(), 1)
+}
+
+func TestI2cFinalizeWithErrors(t *testing.T) {
+	// arrange
+	a := NewAdaptor()
+	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-2"})
+	gobottest.Assert(t, a.Connect(), nil)
+	con, err := a.GetConnection(0xff, 2)
+	gobottest.Assert(t, err, nil)
+	con.Write([]byte{0xbf})
+	fs.WithCloseError = true
+	// act
+	err = a.Finalize()
+	// assert
+	gobottest.Assert(t, strings.Contains(err.Error(), "close error"), true)
 }
 
 func Test_validateI2cBusNumber(t *testing.T) {

--- a/platforms/digispark/digispark_adaptor.go
+++ b/platforms/digispark/digispark_adaptor.go
@@ -107,6 +107,6 @@ func (d *Adaptor) GetConnection(address int, bus int) (connection i2c.Connection
 }
 
 // GetDefaultBus returns the default i2c bus for this platform
-func (d *Adaptor) GetDefaultBus() int {
+func (d *Adaptor) DefaultBus() int {
 	return 0
 }

--- a/platforms/digispark/digispark_i2c_test.go
+++ b/platforms/digispark/digispark_i2c_test.go
@@ -40,7 +40,7 @@ func TestDigisparkAdaptorI2cGetConnection(t *testing.T) {
 	a := initTestAdaptorI2c()
 
 	// act
-	c, err = a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+	c, err = a.GetConnection(availableI2cAddress, a.DefaultBus())
 
 	// assert
 	gobottest.Assert(t, err, nil)
@@ -63,7 +63,7 @@ func TestDigisparkAdaptorI2cStartFailWithWrongAddress(t *testing.T) {
 	// arrange
 	data := []byte{0, 1, 2, 3, 4}
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(0x39, a.GetDefaultBus())
+	c, err := a.GetConnection(0x39, a.DefaultBus())
 
 	// act
 	count, err := c.Write(data)
@@ -79,7 +79,7 @@ func TestDigisparkAdaptorI2cWrite(t *testing.T) {
 	data := []byte{0, 1, 2, 3, 4}
 	dataLen := len(data)
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
 
 	// act
 	count, err := c.Write(data)
@@ -99,7 +99,7 @@ func TestDigisparkAdaptorI2cWriteByte(t *testing.T) {
 	// arrange
 	data := byte(0x02)
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
 
 	// act
 	err = c.WriteByte(data)
@@ -119,7 +119,7 @@ func TestDigisparkAdaptorI2cWriteByteData(t *testing.T) {
 	reg := uint8(0x03)
 	data := byte(0x09)
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
 
 	// act
 	err = c.WriteByteData(reg, data)
@@ -139,7 +139,7 @@ func TestDigisparkAdaptorI2cWriteWordData(t *testing.T) {
 	reg := uint8(0x04)
 	data := uint16(0x0508)
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
 
 	// act
 	err = c.WriteWordData(reg, data)
@@ -159,7 +159,7 @@ func TestDigisparkAdaptorI2cWriteBlockData(t *testing.T) {
 	reg := uint8(0x05)
 	data := []byte{0x80, 0x81, 0x82}
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
 
 	// act
 	err = c.WriteBlockData(reg, data)
@@ -179,7 +179,7 @@ func TestDigisparkAdaptorI2cRead(t *testing.T) {
 	data := []byte{0, 1, 2, 3, 4}
 	dataLen := len(data)
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
 
 	// act
 	count, err := c.Read(data)
@@ -198,7 +198,7 @@ func TestDigisparkAdaptorI2cRead(t *testing.T) {
 func TestDigisparkAdaptorI2cReadByte(t *testing.T) {
 	// arrange
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
 
 	// act
 	data, err := c.ReadByte()
@@ -217,7 +217,7 @@ func TestDigisparkAdaptorI2cReadByteData(t *testing.T) {
 	// arrange
 	reg := uint8(0x04)
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
 
 	// act
 	data, err := c.ReadByteData(reg)
@@ -239,7 +239,7 @@ func TestDigisparkAdaptorI2cReadWordData(t *testing.T) {
 	// 2 bytes of i2cData are used swapped
 	expectedValue := uint16(0x0405)
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
 
 	// act
 	data, err := c.ReadWordData(reg)
@@ -261,7 +261,7 @@ func TestDigisparkAdaptorI2cReadBlockData(t *testing.T) {
 	data := []byte{0, 0, 0, 0, 0}
 	dataLen := len(data)
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
 
 	// act
 	err = c.ReadBlockData(reg, data)
@@ -282,7 +282,7 @@ func TestDigisparkAdaptorI2cUpdateDelay(t *testing.T) {
 	var c i2c.Connection
 	var err error
 	a := initTestAdaptorI2c()
-	c, err = a.GetConnection(availableI2cAddress, a.GetDefaultBus())
+	c, err = a.GetConnection(availableI2cAddress, a.DefaultBus())
 
 	// act
 	err = c.(*digisparkI2cConnection).UpdateDelay(uint(100))

--- a/platforms/dragonboard/dragonboard_adaptor_test.go
+++ b/platforms/dragonboard/dragonboard_adaptor_test.go
@@ -83,6 +83,21 @@ func TestI2cDefaultBus(t *testing.T) {
 	gobottest.Assert(t, a.GetDefaultBus(), 0)
 }
 
+func TestI2cFinalizeWithErrors(t *testing.T) {
+	// arrange
+	a := NewAdaptor()
+	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-1"})
+	gobottest.Assert(t, a.Connect(), nil)
+	con, err := a.GetConnection(0xff, 1)
+	gobottest.Assert(t, err, nil)
+	con.Write([]byte{0xbf})
+	fs.WithCloseError = true
+	// act
+	err = a.Finalize()
+	// assert
+	gobottest.Assert(t, strings.Contains(err.Error(), "close error"), true)
+}
+
 func Test_validateI2cBusNumber(t *testing.T) {
 	var tests = map[string]struct {
 		busNr   int

--- a/platforms/dragonboard/dragonboard_adaptor_test.go
+++ b/platforms/dragonboard/dragonboard_adaptor_test.go
@@ -80,7 +80,7 @@ func TestFinalizeErrorAfterGPIO(t *testing.T) {
 
 func TestI2cDefaultBus(t *testing.T) {
 	a := initTestAdaptor(t)
-	gobottest.Assert(t, a.GetDefaultBus(), 0)
+	gobottest.Assert(t, a.DefaultBus(), 0)
 }
 
 func TestI2cFinalizeWithErrors(t *testing.T) {

--- a/platforms/dragonboard/dragonboard_adaptor_test.go
+++ b/platforms/dragonboard/dragonboard_adaptor_test.go
@@ -86,11 +86,13 @@ func TestI2cDefaultBus(t *testing.T) {
 func TestI2cFinalizeWithErrors(t *testing.T) {
 	// arrange
 	a := NewAdaptor()
+	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-1"})
 	gobottest.Assert(t, a.Connect(), nil)
 	con, err := a.GetConnection(0xff, 1)
 	gobottest.Assert(t, err, nil)
-	con.Write([]byte{0xbf})
+	_, err = con.Write([]byte{0xbf})
+	gobottest.Assert(t, err, nil)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/firmata/firmata_adaptor.go
+++ b/platforms/firmata/firmata_adaptor.go
@@ -251,6 +251,6 @@ func (f *Adaptor) GetConnection(address int, bus int) (connection i2c.Connection
 }
 
 // GetDefaultBus returns the default i2c bus for this platform
-func (f *Adaptor) GetDefaultBus() int {
+func (f *Adaptor) DefaultBus() int {
 	return 0
 }

--- a/platforms/firmata/firmata_i2c_test.go
+++ b/platforms/firmata/firmata_i2c_test.go
@@ -238,7 +238,7 @@ func TestWriteBlockData(t *testing.T) {
 
 func TestDefaultBus(t *testing.T) {
 	a := NewAdaptor()
-	gobottest.Assert(t, a.GetDefaultBus(), 0)
+	gobottest.Assert(t, a.DefaultBus(), 0)
 }
 
 func TestGetConnectionInvalidBus(t *testing.T) {

--- a/platforms/intel-iot/edison/edison_adaptor_test.go
+++ b/platforms/intel-iot/edison/edison_adaptor_test.go
@@ -231,7 +231,7 @@ func TestName(t *testing.T) {
 func TestConnect(t *testing.T) {
 	a, _ := initTestAdaptorWithMockedFilesystem("arduino")
 
-	gobottest.Assert(t, a.GetDefaultBus(), 6)
+	gobottest.Assert(t, a.DefaultBus(), 6)
 	gobottest.Assert(t, a.board, "arduino")
 	gobottest.Assert(t, a.Connect(), nil)
 }
@@ -337,7 +337,7 @@ func TestConnectSparkfun(t *testing.T) {
 	a, _ := initTestAdaptorWithMockedFilesystem("sparkfun")
 
 	gobottest.Assert(t, a.Connect(), nil)
-	gobottest.Assert(t, a.GetDefaultBus(), 1)
+	gobottest.Assert(t, a.DefaultBus(), 1)
 	gobottest.Assert(t, a.board, "sparkfun")
 }
 
@@ -345,7 +345,7 @@ func TestConnectMiniboard(t *testing.T) {
 	a, _ := initTestAdaptorWithMockedFilesystem("miniboard")
 
 	gobottest.Assert(t, a.Connect(), nil)
-	gobottest.Assert(t, a.GetDefaultBus(), 1)
+	gobottest.Assert(t, a.DefaultBus(), 1)
 	gobottest.Assert(t, a.board, "miniboard")
 }
 

--- a/platforms/intel-iot/edison/edison_adaptor_test.go
+++ b/platforms/intel-iot/edison/edison_adaptor_test.go
@@ -1,7 +1,7 @@
 package edison
 
 import (
-	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -93,6 +93,92 @@ var testPinFiles = []string{
 	"/dev/i2c-6",
 }
 
+var pwmMockPathsMux13Arduino = []string{
+	"/sys/class/gpio/export",
+	"/sys/class/gpio/unexport",
+	"/sys/kernel/debug/gpio_debug/gpio13/current_pinmux",
+	"/sys/kernel/debug/gpio_debug/gpio40/current_pinmux",
+	"/sys/kernel/debug/gpio_debug/gpio109/current_pinmux",
+	"/sys/kernel/debug/gpio_debug/gpio111/current_pinmux",
+	"/sys/kernel/debug/gpio_debug/gpio114/current_pinmux",
+	"/sys/kernel/debug/gpio_debug/gpio115/current_pinmux",
+	"/sys/kernel/debug/gpio_debug/gpio129/current_pinmux",
+	"/sys/kernel/debug/gpio_debug/gpio131/current_pinmux",
+	"/sys/class/gpio/gpio13/direction",
+	"/sys/class/gpio/gpio13/value",
+	"/sys/class/gpio/gpio214/direction",
+	"/sys/class/gpio/gpio214/value",
+	"/sys/class/gpio/gpio221/direction",
+	"/sys/class/gpio/gpio221/value",
+	"/sys/class/gpio/gpio240/direction",
+	"/sys/class/gpio/gpio240/value",
+	"/sys/class/gpio/gpio241/direction",
+	"/sys/class/gpio/gpio241/value",
+	"/sys/class/gpio/gpio242/direction",
+	"/sys/class/gpio/gpio242/value",
+	"/sys/class/gpio/gpio243/direction",
+	"/sys/class/gpio/gpio243/value",
+	"/sys/class/gpio/gpio253/direction",
+	"/sys/class/gpio/gpio253/value",
+	"/sys/class/gpio/gpio262/direction",
+	"/sys/class/gpio/gpio262/value",
+	"/sys/class/gpio/gpio263/direction",
+	"/sys/class/gpio/gpio263/value",
+}
+
+var pwmMockPathsMux13ArduinoI2c = []string{
+	"/sys/class/gpio/export",
+	"/sys/class/gpio/unexport",
+	"/sys/kernel/debug/gpio_debug/gpio13/current_pinmux",
+	"/sys/kernel/debug/gpio_debug/gpio27/current_pinmux",
+	"/sys/kernel/debug/gpio_debug/gpio28/current_pinmux",
+	"/sys/kernel/debug/gpio_debug/gpio40/current_pinmux",
+	"/sys/kernel/debug/gpio_debug/gpio109/current_pinmux",
+	"/sys/kernel/debug/gpio_debug/gpio111/current_pinmux",
+	"/sys/kernel/debug/gpio_debug/gpio114/current_pinmux",
+	"/sys/kernel/debug/gpio_debug/gpio115/current_pinmux",
+	"/sys/kernel/debug/gpio_debug/gpio129/current_pinmux",
+	"/sys/kernel/debug/gpio_debug/gpio131/current_pinmux",
+	"/sys/class/gpio/gpio13/direction",
+	"/sys/class/gpio/gpio13/value",
+	"/sys/class/gpio/gpio14/direction",
+	"/sys/class/gpio/gpio14/value",
+	"/sys/class/gpio/gpio28/direction",
+	"/sys/class/gpio/gpio28/value",
+	"/sys/class/gpio/gpio165/direction",
+	"/sys/class/gpio/gpio165/value",
+	"/sys/class/gpio/gpio212/direction",
+	"/sys/class/gpio/gpio212/value",
+	"/sys/class/gpio/gpio213/direction",
+	"/sys/class/gpio/gpio213/value",
+	"/sys/class/gpio/gpio214/direction",
+	"/sys/class/gpio/gpio214/value",
+	"/sys/class/gpio/gpio221/direction",
+	"/sys/class/gpio/gpio221/value",
+	"/sys/class/gpio/gpio236/direction",
+	"/sys/class/gpio/gpio236/value",
+	"/sys/class/gpio/gpio237/direction",
+	"/sys/class/gpio/gpio237/value",
+	"/sys/class/gpio/gpio204/value",
+	"/sys/class/gpio/gpio204/direction",
+	"/sys/class/gpio/gpio205/value",
+	"/sys/class/gpio/gpio205/direction",
+	"/sys/class/gpio/gpio240/direction",
+	"/sys/class/gpio/gpio240/value",
+	"/sys/class/gpio/gpio241/direction",
+	"/sys/class/gpio/gpio241/value",
+	"/sys/class/gpio/gpio242/direction",
+	"/sys/class/gpio/gpio242/value",
+	"/sys/class/gpio/gpio243/direction",
+	"/sys/class/gpio/gpio243/value",
+	"/sys/class/gpio/gpio253/direction",
+	"/sys/class/gpio/gpio253/value",
+	"/sys/class/gpio/gpio262/direction",
+	"/sys/class/gpio/gpio262/value",
+	"/sys/class/gpio/gpio263/direction",
+	"/sys/class/gpio/gpio263/value",
+}
+
 var pwmMockPathsMux13 = []string{
 	"/sys/kernel/debug/gpio_debug/gpio13/current_pinmux",
 	"/sys/class/gpio/export",
@@ -123,8 +209,8 @@ var pwmMockPathsMux40 = []string{
 	"/sys/class/gpio/gpio261/direction",
 }
 
-func initTestAdaptorWithMockedFilesystem() (*Adaptor, *system.MockFilesystem) {
-	a := NewAdaptor()
+func initTestAdaptorWithMockedFilesystem(boardType string) (*Adaptor, *system.MockFilesystem) {
+	a := NewAdaptor(boardType)
 	fs := a.sys.UseMockFilesystem(testPinFiles)
 	fs.Files["/sys/class/pwm/pwmchip0/pwm1/period"].Contents = "5000"
 	if err := a.Connect(); err != nil {
@@ -142,15 +228,15 @@ func TestName(t *testing.T) {
 }
 
 func TestConnect(t *testing.T) {
-	a, _ := initTestAdaptorWithMockedFilesystem()
+	a, _ := initTestAdaptorWithMockedFilesystem("arduino")
 
 	gobottest.Assert(t, a.GetDefaultBus(), 6)
-	gobottest.Assert(t, a.Board(), "arduino")
+	gobottest.Assert(t, a.board, "arduino")
 	gobottest.Assert(t, a.Connect(), nil)
 }
 
 func TestArduinoSetupFail263(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 	delete(fs.Files, "/sys/class/gpio/gpio263/direction")
 
 	err := a.arduinoSetup()
@@ -158,7 +244,7 @@ func TestArduinoSetupFail263(t *testing.T) {
 }
 
 func TestArduinoSetupFail240(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 	delete(fs.Files, "/sys/class/gpio/gpio240/direction")
 
 	err := a.arduinoSetup()
@@ -166,7 +252,7 @@ func TestArduinoSetupFail240(t *testing.T) {
 }
 
 func TestArduinoSetupFail111(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 	delete(fs.Files, "/sys/kernel/debug/gpio_debug/gpio111/current_pinmux")
 
 	err := a.arduinoSetup()
@@ -174,7 +260,7 @@ func TestArduinoSetupFail111(t *testing.T) {
 }
 
 func TestArduinoSetupFail131(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 	delete(fs.Files, "/sys/kernel/debug/gpio_debug/gpio131/current_pinmux")
 
 	err := a.arduinoSetup()
@@ -182,16 +268,16 @@ func TestArduinoSetupFail131(t *testing.T) {
 }
 
 func TestArduinoI2CSetupFailTristate(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 	gobottest.Assert(t, a.arduinoSetup(), nil)
 
 	fs.WithWriteError = true
 	err := a.arduinoI2CSetup()
-	gobottest.Assert(t, err, errors.New("write error"))
+	gobottest.Assert(t, err, fmt.Errorf("write error"))
 }
 
 func TestArduinoI2CSetupFail14(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 
 	gobottest.Assert(t, a.arduinoSetup(), nil)
 	delete(fs.Files, "/sys/class/gpio/gpio14/direction")
@@ -201,7 +287,7 @@ func TestArduinoI2CSetupFail14(t *testing.T) {
 }
 
 func TestArduinoI2CSetupUnexportFail(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 
 	gobottest.Assert(t, a.arduinoSetup(), nil)
 	delete(fs.Files, "/sys/class/gpio/unexport")
@@ -211,7 +297,7 @@ func TestArduinoI2CSetupUnexportFail(t *testing.T) {
 }
 
 func TestArduinoI2CSetupFail236(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 
 	gobottest.Assert(t, a.arduinoSetup(), nil)
 	delete(fs.Files, "/sys/class/gpio/gpio236/direction")
@@ -221,7 +307,7 @@ func TestArduinoI2CSetupFail236(t *testing.T) {
 }
 
 func TestArduinoI2CSetupFail28(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 
 	gobottest.Assert(t, a.arduinoSetup(), nil)
 	delete(fs.Files, "/sys/kernel/debug/gpio_debug/gpio28/current_pinmux")
@@ -231,7 +317,7 @@ func TestArduinoI2CSetupFail28(t *testing.T) {
 }
 
 func TestConnectArduinoError(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 	fs.WithWriteError = true
 
 	err := a.Connect()
@@ -239,7 +325,7 @@ func TestConnectArduinoError(t *testing.T) {
 }
 
 func TestConnectArduinoWriteError(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 	fs.WithWriteError = true
 
 	err := a.Connect()
@@ -247,33 +333,30 @@ func TestConnectArduinoWriteError(t *testing.T) {
 }
 
 func TestConnectSparkfun(t *testing.T) {
-	a, _ := initTestAdaptorWithMockedFilesystem()
+	a, _ := initTestAdaptorWithMockedFilesystem("sparkfun")
 
-	a.SetBoard("sparkfun")
 	gobottest.Assert(t, a.Connect(), nil)
 	gobottest.Assert(t, a.GetDefaultBus(), 1)
-	gobottest.Assert(t, a.Board(), "sparkfun")
+	gobottest.Assert(t, a.board, "sparkfun")
 }
 
 func TestConnectMiniboard(t *testing.T) {
-	a, _ := initTestAdaptorWithMockedFilesystem()
+	a, _ := initTestAdaptorWithMockedFilesystem("miniboard")
 
-	a.SetBoard("miniboard")
 	gobottest.Assert(t, a.Connect(), nil)
 	gobottest.Assert(t, a.GetDefaultBus(), 1)
-	gobottest.Assert(t, a.Board(), "miniboard")
+	gobottest.Assert(t, a.board, "miniboard")
 }
 
 func TestConnectUnknown(t *testing.T) {
-	a, _ := initTestAdaptorWithMockedFilesystem()
-	a.SetBoard("wha")
+	a := NewAdaptor("wha")
 
 	err := a.Connect()
 	gobottest.Assert(t, strings.Contains(err.Error(), "Unknown board type: wha"), true)
 }
 
 func TestFinalize(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 
 	a.DigitalWrite("3", 1)
 	a.PwmWrite("5", 100)
@@ -281,15 +364,20 @@ func TestFinalize(t *testing.T) {
 	a.GetConnection(0xff, 6)
 	gobottest.Assert(t, a.Finalize(), nil)
 
+	// assert that finalize after finalize is working
+	gobottest.Assert(t, a.Finalize(), nil)
+
+	// assert that re-connect is working
+	a.Connect()
 	// remove one file to force Finalize error
 	delete(fs.Files, "/sys/class/gpio/unexport")
 	err := a.Finalize()
-	gobottest.Assert(t, strings.Contains(err.Error(), "4 errors occurred"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "1 error occurred"), true)
 	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/gpio/unexport"), true)
 }
 
 func TestFinalizeError(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 
 	a.PwmWrite("5", 100)
 
@@ -302,7 +390,7 @@ func TestFinalizeError(t *testing.T) {
 }
 
 func TestDigitalIO(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 
 	a.DigitalWrite("13", 1)
 	gobottest.Assert(t, fs.Files["/sys/class/gpio/gpio40/value"].Contents, "1")
@@ -359,23 +447,95 @@ func TestDigitalPinInMuxFileError(t *testing.T) {
 }
 
 func TestDigitalWriteError(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 	fs.WithWriteError = true
 
 	err := a.DigitalWrite("13", 1)
-	gobottest.Assert(t, err, errors.New("write error"))
+	gobottest.Assert(t, err, fmt.Errorf("write error"))
 }
 
 func TestDigitalReadWriteError(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 	fs.WithWriteError = true
 
 	_, err := a.DigitalRead("13")
-	gobottest.Assert(t, err, errors.New("write error"))
+	gobottest.Assert(t, err, fmt.Errorf("write error"))
 }
 
-func TestI2c(t *testing.T) {
-	a, _ := initTestAdaptorWithMockedFilesystem()
+func TestPwm(t *testing.T) {
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
+
+	err := a.PwmWrite("5", 100)
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm1/duty_cycle"].Contents, "1960")
+
+	err = a.PwmWrite("7", 100)
+	gobottest.Assert(t, err, fmt.Errorf("'7' is not a valid id for a PWM pin"))
+}
+
+func TestPwmExportError(t *testing.T) {
+	a := NewAdaptor()
+	fs := a.sys.UseMockFilesystem(pwmMockPathsMux13Arduino)
+	delete(fs.Files, "/sys/class/pwm/pwmchip0/export")
+	err := a.Connect()
+	gobottest.Assert(t, err, nil)
+
+	err = a.PwmWrite("5", 100)
+	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/pwm/pwmchip0/export: No such file"), true)
+}
+
+func TestPwmEnableError(t *testing.T) {
+	a := NewAdaptor()
+	fs := a.sys.UseMockFilesystem(pwmMockPathsMux13)
+	delete(fs.Files, "/sys/class/pwm/pwmchip0/pwm1/enable")
+	a.Connect()
+
+	err := a.PwmWrite("5", 100)
+	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/pwm/pwmchip0/pwm1/enable: No such file"), true)
+}
+
+func TestPwmWritePinError(t *testing.T) {
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
+	fs.WithWriteError = true
+
+	err := a.PwmWrite("5", 100)
+	gobottest.Assert(t, err, fmt.Errorf("write error"))
+}
+
+func TestPwmWriteError(t *testing.T) {
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
+	fs.WithWriteError = true
+
+	err := a.PwmWrite("5", 100)
+	gobottest.Assert(t, strings.Contains(err.Error(), "write error"), true)
+}
+
+func TestPwmReadError(t *testing.T) {
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
+	fs.WithReadError = true
+
+	err := a.PwmWrite("5", 100)
+	gobottest.Assert(t, strings.Contains(err.Error(), "read error"), true)
+}
+
+func TestAnalog(t *testing.T) {
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
+	fs.Files["/sys/bus/iio/devices/iio:device1/in_voltage0_raw"].Contents = "1000\n"
+
+	i, _ := a.AnalogRead("0")
+	gobottest.Assert(t, i, 250)
+}
+
+func TestAnalogError(t *testing.T) {
+	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
+	fs.WithReadError = true
+
+	_, err := a.AnalogRead("0")
+	gobottest.Assert(t, err, fmt.Errorf("read error"))
+}
+
+func TestI2cWorkflow(t *testing.T) {
+	a, _ := initTestAdaptorWithMockedFilesystem("arduino")
 	a.sys.UseMockSyscall()
 
 	con, err := a.GetConnection(0xff, 6)
@@ -392,80 +552,48 @@ func TestI2c(t *testing.T) {
 	gobottest.Assert(t, a.Finalize(), nil)
 }
 
-func TestI2cInvalidBus(t *testing.T) {
-	a, _ := initTestAdaptorWithMockedFilesystem()
-
-	_, err := a.GetConnection(0xff, 3)
-	gobottest.Assert(t, err, errors.New("Unsupported I2C bus"))
-}
-
-func TestPwm(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
-
-	err := a.PwmWrite("5", 100)
-	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm1/duty_cycle"].Contents, "1960")
-
-	err = a.PwmWrite("7", 100)
-	gobottest.Assert(t, err, errors.New("'7' is not a valid id for a PWM pin"))
-}
-
-func TestPwmExportError(t *testing.T) {
-	a := NewAdaptor()
-	fs := a.sys.UseMockFilesystem(pwmMockPathsMux13)
-	delete(fs.Files, "/sys/class/pwm/pwmchip0/export")
-	a.Connect()
-
-	err := a.PwmWrite("5", 100)
-	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/pwm/pwmchip0/export: No such file"), true)
-}
-
-func TestPwmEnableError(t *testing.T) {
-	a := NewAdaptor()
-	fs := a.sys.UseMockFilesystem(pwmMockPathsMux13)
-	delete(fs.Files, "/sys/class/pwm/pwmchip0/pwm1/enable")
-	a.Connect()
-
-	err := a.PwmWrite("5", 100)
-	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/pwm/pwmchip0/pwm1/enable: No such file"), true)
-}
-
-func TestPwmWritePinError(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
-	fs.WithWriteError = true
-
-	err := a.PwmWrite("5", 100)
-	gobottest.Assert(t, err, errors.New("write error"))
-}
-
-func TestPwmWriteError(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
-	fs.WithWriteError = true
-
-	err := a.PwmWrite("5", 100)
-	gobottest.Assert(t, strings.Contains(err.Error(), "write error"), true)
-}
-
-func TestPwmReadError(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
-	fs.WithReadError = true
-
-	err := a.PwmWrite("5", 100)
-	gobottest.Assert(t, strings.Contains(err.Error(), "read error"), true)
-}
-
-func TestAnalog(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
-	fs.Files["/sys/bus/iio/devices/iio:device1/in_voltage0_raw"].Contents = "1000\n"
-
-	i, _ := a.AnalogRead("0")
-	gobottest.Assert(t, i, 250)
-}
-
-func TestAnalogError(t *testing.T) {
-	a, fs := initTestAdaptorWithMockedFilesystem()
-	fs.WithReadError = true
-
-	_, err := a.AnalogRead("0")
-	gobottest.Assert(t, err, errors.New("read error"))
+func Test_validateI2cBusNumber(t *testing.T) {
+	var tests = map[string]struct {
+		board   string
+		busNr   int
+		wantErr error
+	}{
+		"arduino_number_negative_error": {
+			busNr:   -1,
+			wantErr: fmt.Errorf("Unsupported I2C bus '-1'"),
+		},
+		"arduino_number_1_error": {
+			busNr:   1,
+			wantErr: fmt.Errorf("Unsupported I2C bus '1'"),
+		},
+		"arduino_number_6_ok": {
+			busNr: 6,
+		},
+		"sparkfun_number_negative_error": {
+			board:   "sparkfun",
+			busNr:   -1,
+			wantErr: fmt.Errorf("Unsupported I2C bus '-1'"),
+		},
+		"sparkfun_number_1_ok": {
+			board: "sparkfun",
+			busNr: 1,
+		},
+		"miniboard_number_6_error": {
+			board:   "miniboard",
+			busNr:   6,
+			wantErr: fmt.Errorf("Unsupported I2C bus '6'"),
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			a := NewAdaptor(tc.board)
+			a.sys.UseMockFilesystem(pwmMockPathsMux13ArduinoI2c)
+			a.Connect()
+			// act
+			err := a.validateAndSetupI2cBusNumber(tc.busNr)
+			// assert
+			gobottest.Assert(t, err, tc.wantErr)
+		})
+	}
 }

--- a/platforms/intel-iot/joule/joule_adaptor_test.go
+++ b/platforms/intel-iot/joule/joule_adaptor_test.go
@@ -173,11 +173,13 @@ func TestI2cDefaultBus(t *testing.T) {
 func TestI2cFinalizeWithErrors(t *testing.T) {
 	// arrange
 	a := NewAdaptor()
+	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-2"})
 	gobottest.Assert(t, a.Connect(), nil)
 	con, err := a.GetConnection(0xff, 2)
 	gobottest.Assert(t, err, nil)
-	con.Write([]byte{0xbf})
+	_, err = con.Write([]byte{0xbf})
+	gobottest.Assert(t, err, nil)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/intel-iot/joule/joule_adaptor_test.go
+++ b/platforms/intel-iot/joule/joule_adaptor_test.go
@@ -167,7 +167,7 @@ func TestPwmPinEnableError(t *testing.T) {
 
 func TestI2cDefaultBus(t *testing.T) {
 	a := NewAdaptor()
-	gobottest.Assert(t, a.GetDefaultBus(), 0)
+	gobottest.Assert(t, a.DefaultBus(), 0)
 }
 
 func TestI2cFinalizeWithErrors(t *testing.T) {

--- a/platforms/intel-iot/joule/joule_adaptor_test.go
+++ b/platforms/intel-iot/joule/joule_adaptor_test.go
@@ -165,9 +165,24 @@ func TestPwmPinEnableError(t *testing.T) {
 	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/pwm/pwmchip0/pwm0/enable: No such file"), true)
 }
 
-func TestI2cGetDefaultBus(t *testing.T) {
+func TestI2cDefaultBus(t *testing.T) {
 	a := NewAdaptor()
 	gobottest.Assert(t, a.GetDefaultBus(), 0)
+}
+
+func TestI2cFinalizeWithErrors(t *testing.T) {
+	// arrange
+	a := NewAdaptor()
+	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-2"})
+	gobottest.Assert(t, a.Connect(), nil)
+	con, err := a.GetConnection(0xff, 2)
+	gobottest.Assert(t, err, nil)
+	con.Write([]byte{0xbf})
+	fs.WithCloseError = true
+	// act
+	err = a.Finalize()
+	// assert
+	gobottest.Assert(t, strings.Contains(err.Error(), "close error"), true)
 }
 
 func Test_validateI2cBusNumber(t *testing.T) {
@@ -188,7 +203,7 @@ func Test_validateI2cBusNumber(t *testing.T) {
 		"number_2_ok": {
 			busNr: 2,
 		},
-		"number_3_not_ok": {
+		"number_3_error": {
 			busNr:   3,
 			wantErr: fmt.Errorf("Bus number 3 out of range"),
 		},

--- a/platforms/jetson/jetson_adaptor_test.go
+++ b/platforms/jetson/jetson_adaptor_test.go
@@ -161,7 +161,7 @@ func TestDigitalPinConcurrency(t *testing.T) {
 
 func TestI2cDefaultBus(t *testing.T) {
 	a := NewAdaptor()
-	gobottest.Assert(t, a.GetDefaultBus(), 1)
+	gobottest.Assert(t, a.DefaultBus(), 1)
 }
 
 func TestI2cFinalizeWithErrors(t *testing.T) {

--- a/platforms/jetson/jetson_adaptor_test.go
+++ b/platforms/jetson/jetson_adaptor_test.go
@@ -167,11 +167,13 @@ func TestI2cDefaultBus(t *testing.T) {
 func TestI2cFinalizeWithErrors(t *testing.T) {
 	// arrange
 	a := NewAdaptor()
+	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-1"})
 	gobottest.Assert(t, a.Connect(), nil)
 	con, err := a.GetConnection(0xff, 1)
 	gobottest.Assert(t, err, nil)
-	con.Write([]byte{0xbf})
+	_, err = con.Write([]byte{0xbf})
+	gobottest.Assert(t, err, nil)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/raspi/raspi_adaptor.go
+++ b/platforms/raspi/raspi_adaptor.go
@@ -105,7 +105,7 @@ func (c *Adaptor) Finalize() error {
 
 // GetDefaultBus returns the default i2c bus for this platform.
 // This overrides the base function due to the revision dependency.
-func (c *Adaptor) GetDefaultBus() int {
+func (c *Adaptor) DefaultBus() int {
 	rev := c.readRevision()
 	if rev == "2" || rev == "3" {
 		return 1

--- a/platforms/raspi/raspi_adaptor.go
+++ b/platforms/raspi/raspi_adaptor.go
@@ -10,7 +10,6 @@ import (
 
 	multierror "github.com/hashicorp/go-multierror"
 	"gobot.io/x/gobot"
-	"gobot.io/x/gobot/drivers/i2c"
 	"gobot.io/x/gobot/drivers/spi"
 	"gobot.io/x/gobot/platforms/adaptors"
 	"gobot.io/x/gobot/system"
@@ -24,9 +23,9 @@ type Adaptor struct {
 	mutex    sync.Mutex
 	sys      *system.Accesser
 	revision string
+	pwmPins  map[string]gobot.PWMPinner
 	*adaptors.DigitalPinsAdaptor
-	pwmPins            map[string]gobot.PWMPinner
-	i2cBuses           [2]i2c.I2cDevice
+	*adaptors.I2cBusAdaptor
 	spiDevices         [2]spi.Connection
 	spiDefaultMaxSpeed int64
 	PiBlasterPeriod    uint32
@@ -41,6 +40,7 @@ func NewAdaptor() *Adaptor {
 		PiBlasterPeriod: 10000000,
 	}
 	c.DigitalPinsAdaptor = adaptors.NewDigitalPinsAdaptor(sys, c.getPinTranslatorFunction())
+	c.I2cBusAdaptor = adaptors.NewI2cBusAdaptor(sys, c.validateI2cBusNumber, 1)
 	return c
 }
 
@@ -65,6 +65,10 @@ func (c *Adaptor) Connect() error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
+	if err := c.I2cBusAdaptor.Connect(); err != nil {
+		return err
+	}
+
 	c.pwmPins = make(map[string]gobot.PWMPinner)
 	return c.DigitalPinsAdaptor.Connect()
 }
@@ -85,13 +89,10 @@ func (c *Adaptor) Finalize() error {
 	}
 	c.pwmPins = nil
 
-	for _, bus := range c.i2cBuses {
-		if bus != nil {
-			if e := bus.Close(); e != nil {
-				err = multierror.Append(err, e)
-			}
-		}
+	if e := c.I2cBusAdaptor.Finalize(); e != nil {
+		err = multierror.Append(err, e)
 	}
+
 	for _, dev := range c.spiDevices {
 		if dev != nil {
 			if e := dev.Close(); e != nil {
@@ -102,30 +103,8 @@ func (c *Adaptor) Finalize() error {
 	return err
 }
 
-// GetConnection returns an i2c connection to a device on a specified bus.
-// Valid bus number is [0..1] which corresponds to /dev/i2c-0 through /dev/i2c-1.
-func (c *Adaptor) GetConnection(address int, bus int) (connection i2c.Connection, err error) {
-	if (bus < 0) || (bus > 1) {
-		return nil, fmt.Errorf("Bus number %d out of range", bus)
-	}
-
-	device, err := c.getI2cBus(bus)
-
-	return i2c.NewConnection(device, address), err
-}
-
-func (c *Adaptor) getI2cBus(bus int) (_ i2c.I2cDevice, err error) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	if c.i2cBuses[bus] == nil {
-		c.i2cBuses[bus], err = c.sys.NewI2cDevice(fmt.Sprintf("/dev/i2c-%d", bus))
-	}
-
-	return c.i2cBuses[bus], err
-}
-
-// GetDefaultBus returns the default i2c bus for this platform
+// GetDefaultBus returns the default i2c bus for this platform.
+// This overrides the base function due to the revision dependency.
 func (c *Adaptor) GetDefaultBus() int {
 	rev := c.readRevision()
 	if rev == "2" || rev == "3" {
@@ -210,6 +189,14 @@ func (c *Adaptor) ServoWrite(pin string, angle byte) (err error) {
 
 	duty := uint32(gobot.FromScale(float64(angle), 0, 180) * float64(c.PiBlasterPeriod))
 	return sysPin.SetDutyCycle(duty)
+}
+
+func (c *Adaptor) validateI2cBusNumber(busNr int) error {
+	// Valid bus number is [0..1] which corresponds to /dev/i2c-0 through /dev/i2c-1.
+	if (busNr < 0) || (busNr > 1) {
+		return fmt.Errorf("Bus number %d out of range", busNr)
+	}
+	return nil
 }
 
 func (c *Adaptor) getPinTranslatorFunction() func(string) (string, int, error) {

--- a/platforms/raspi/raspi_adaptor_test.go
+++ b/platforms/raspi/raspi_adaptor_test.go
@@ -79,7 +79,7 @@ func TestGetDefaultBus(t *testing.T) {
 			fs.Files[infoFile].Contents = fmt.Sprintf(contentPattern, tc.revisionPart)
 			gobottest.Assert(t, a.revision, "")
 			//act, will read and refresh the revision
-			gotBus := a.GetDefaultBus()
+			gotBus := a.DefaultBus()
 			//assert
 			gobottest.Assert(t, a.revision, tc.wantRev)
 			gobottest.Assert(t, gotBus, tc.wantBus)
@@ -258,10 +258,10 @@ func TestI2cDefaultBus(t *testing.T) {
 	a.sys.UseMockSyscall()
 
 	a.revision = "0"
-	gobottest.Assert(t, a.GetDefaultBus(), 0)
+	gobottest.Assert(t, a.DefaultBus(), 0)
 
 	a.revision = "2"
-	gobottest.Assert(t, a.GetDefaultBus(), 1)
+	gobottest.Assert(t, a.DefaultBus(), 1)
 }
 
 func TestI2cFinalizeWithErrors(t *testing.T) {

--- a/platforms/raspi/raspi_adaptor_test.go
+++ b/platforms/raspi/raspi_adaptor_test.go
@@ -267,11 +267,13 @@ func TestI2cDefaultBus(t *testing.T) {
 func TestI2cFinalizeWithErrors(t *testing.T) {
 	// arrange
 	a := NewAdaptor()
+	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-1"})
 	gobottest.Assert(t, a.Connect(), nil)
 	con, err := a.GetConnection(0xff, 1)
 	gobottest.Assert(t, err, nil)
-	con.Write([]byte{0xbf})
+	_, err = con.Write([]byte{0xbf})
+	gobottest.Assert(t, err, nil)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/tinkerboard/adaptor_test.go
+++ b/platforms/tinkerboard/adaptor_test.go
@@ -207,11 +207,13 @@ func TestI2cDefaultBus(t *testing.T) {
 func TestI2cFinalizeWithErrors(t *testing.T) {
 	// arrange
 	a := NewAdaptor()
+	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-4"})
 	gobottest.Assert(t, a.Connect(), nil)
 	con, err := a.GetConnection(0xff, 4)
 	gobottest.Assert(t, err, nil)
-	con.Write([]byte{0xbf})
+	_, err = con.Write([]byte{0xbf})
+	gobottest.Assert(t, err, nil)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/tinkerboard/adaptor_test.go
+++ b/platforms/tinkerboard/adaptor_test.go
@@ -201,7 +201,7 @@ func TestFinalizeErrorAfterPWM(t *testing.T) {
 
 func TestI2cDefaultBus(t *testing.T) {
 	a := NewAdaptor()
-	gobottest.Assert(t, a.GetDefaultBus(), 1)
+	gobottest.Assert(t, a.DefaultBus(), 1)
 }
 
 func TestI2cFinalizeWithErrors(t *testing.T) {

--- a/platforms/upboard/up2/adaptor_test.go
+++ b/platforms/upboard/up2/adaptor_test.go
@@ -141,7 +141,7 @@ func TestFinalizeErrorAfterPWM(t *testing.T) {
 
 func TestI2cDefaultBus(t *testing.T) {
 	a := NewAdaptor()
-	gobottest.Assert(t, a.GetDefaultBus(), 5)
+	gobottest.Assert(t, a.DefaultBus(), 5)
 }
 
 func TestI2cFinalizeWithErrors(t *testing.T) {

--- a/platforms/upboard/up2/adaptor_test.go
+++ b/platforms/upboard/up2/adaptor_test.go
@@ -147,11 +147,13 @@ func TestI2cDefaultBus(t *testing.T) {
 func TestI2cFinalizeWithErrors(t *testing.T) {
 	// arrange
 	a := NewAdaptor()
+	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-5"})
 	gobottest.Assert(t, a.Connect(), nil)
 	con, err := a.GetConnection(0xff, 5)
 	gobottest.Assert(t, err, nil)
-	con.Write([]byte{0xbf})
+	_, err = con.Write([]byte{0xbf})
+	gobottest.Assert(t, err, nil)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/upboard/up2/adaptor_test.go
+++ b/platforms/upboard/up2/adaptor_test.go
@@ -80,25 +80,6 @@ func TestDigitalIO(t *testing.T) {
 	gobottest.Assert(t, a.Finalize(), nil)
 }
 
-func TestI2c(t *testing.T) {
-	a := NewAdaptor()
-	a.sys.UseMockFilesystem([]string{"/dev/i2c-5"})
-	a.sys.UseMockSyscall()
-
-	con, err := a.GetConnection(0xff, 5)
-	gobottest.Assert(t, err, nil)
-
-	_, err = con.Write([]byte{0x00, 0x01})
-	gobottest.Assert(t, err, nil)
-
-	data := []byte{42, 42}
-	_, err = con.Read(data)
-	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, data, []byte{0x00, 0x01})
-
-	gobottest.Assert(t, a.Finalize(), nil)
-}
-
 func TestSPI(t *testing.T) {
 	a := NewAdaptor()
 
@@ -136,18 +117,6 @@ func TestPWM(t *testing.T) {
 	gobottest.Assert(t, a.Finalize(), nil)
 }
 
-func TestI2CDefaultBus(t *testing.T) {
-	a := NewAdaptor()
-	gobottest.Assert(t, a.GetDefaultBus(), 5)
-}
-
-func TestGetConnectionInvalidBus(t *testing.T) {
-	a := NewAdaptor()
-
-	_, err := a.GetConnection(0x01, 99)
-	gobottest.Assert(t, err, errors.New("Bus number 99 out of range"))
-}
-
 func TestFinalizeErrorAfterGPIO(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem(gpioMockPaths)
 
@@ -168,6 +137,62 @@ func TestFinalizeErrorAfterPWM(t *testing.T) {
 
 	err := a.Finalize()
 	gobottest.Assert(t, strings.Contains(err.Error(), "write error"), true)
+}
+
+func TestI2cDefaultBus(t *testing.T) {
+	a := NewAdaptor()
+	gobottest.Assert(t, a.GetDefaultBus(), 5)
+}
+
+func TestI2cFinalizeWithErrors(t *testing.T) {
+	// arrange
+	a := NewAdaptor()
+	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-5"})
+	gobottest.Assert(t, a.Connect(), nil)
+	con, err := a.GetConnection(0xff, 5)
+	gobottest.Assert(t, err, nil)
+	con.Write([]byte{0xbf})
+	fs.WithCloseError = true
+	// act
+	err = a.Finalize()
+	// assert
+	gobottest.Assert(t, strings.Contains(err.Error(), "close error"), true)
+}
+
+func Test_validateI2cBusNumber(t *testing.T) {
+	var tests = map[string]struct {
+		busNr   int
+		wantErr error
+	}{
+		"number_negative_error": {
+			busNr:   -1,
+			wantErr: fmt.Errorf("Bus number -1 out of range"),
+		},
+		"number_4_error": {
+			busNr:   4,
+			wantErr: fmt.Errorf("Bus number 4 out of range"),
+		},
+		"number_5_ok": {
+			busNr: 5,
+		},
+		"number_6_ok": {
+			busNr: 6,
+		},
+		"number_7_error": {
+			busNr:   7,
+			wantErr: fmt.Errorf("Bus number 7 out of range"),
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			a := NewAdaptor()
+			// act
+			err := a.validateI2cBusNumber(tc.busNr)
+			// assert
+			gobottest.Assert(t, err, tc.wantErr)
+		})
+	}
 }
 
 func Test_translatePWMPin(t *testing.T) {

--- a/system/fs_mock.go
+++ b/system/fs_mock.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -19,6 +20,7 @@ type MockFilesystem struct {
 	Files          map[string]*MockFile
 	WithReadError  bool
 	WithWriteError bool
+	WithCloseError bool
 }
 
 // A MockFile represents a mock file that contains a single string.  Any write
@@ -34,8 +36,9 @@ type MockFile struct {
 }
 
 var (
-	errRead  = errors.New("read error")
-	errWrite = errors.New("write error")
+	errRead  = fmt.Errorf("read error")
+	errWrite = fmt.Errorf("write error")
+	errClose = fmt.Errorf("close error")
 )
 
 // Write writes string(b) to f.Contents
@@ -91,6 +94,9 @@ func (f *MockFile) Fd() uintptr {
 
 // Close implements the File interface Close function
 func (f *MockFile) Close() error {
+	if f != nil && f.fs != nil && f.fs.WithCloseError {
+		return errClose
+	}
 	return nil
 }
 

--- a/system/fs_mock.go
+++ b/system/fs_mock.go
@@ -93,10 +93,13 @@ func (f *MockFile) Fd() uintptr {
 
 // Close implements the File interface Close function
 func (f *MockFile) Close() error {
-	if f != nil && f.fs != nil && f.fs.WithCloseError {
+	if f != nil {
 		f.Opened = false
-		f.Closed = false
-		return errClose
+		f.Closed = true
+		if f.fs != nil && f.fs.WithCloseError {
+			f.Closed = false
+			return errClose
+		}
 	}
 	return nil
 }

--- a/system/fs_mock.go
+++ b/system/fs_mock.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -95,6 +94,8 @@ func (f *MockFile) Fd() uintptr {
 // Close implements the File interface Close function
 func (f *MockFile) Close() error {
 	if f != nil && f.fs != nil && f.fs.WithCloseError {
+		f.Opened = false
+		f.Closed = false
 		return errClose
 	}
 	return nil
@@ -121,7 +122,8 @@ func (fs *MockFilesystem) openFile(name string, flag int, perm os.FileMode) (fil
 		f.Closed = false
 		return f, nil
 	}
-	return (*MockFile)(nil), &os.PathError{Err: errors.New(name + ": No such file.")}
+
+	return (*MockFile)(nil), &os.PathError{Err: fmt.Errorf("%s: No such file.", name)}
 }
 
 // Stat returns a generic FileInfo for all files in fs.Files.
@@ -153,7 +155,7 @@ func (fs *MockFilesystem) stat(name string) (os.FileInfo, error) {
 		}
 	}
 
-	return nil, &os.PathError{Err: errors.New(name + ": No such file.")}
+	return nil, &os.PathError{Err: fmt.Errorf("%s: No such file.", name)}
 }
 
 // Find returns all items (files or folders) below the given directory matching the given pattern.
@@ -188,7 +190,7 @@ func (fs *MockFilesystem) readFile(name string) ([]byte, error) {
 
 	f, ok := fs.Files[name]
 	if !ok {
-		return nil, &os.PathError{Err: errors.New(name + ": No such file.")}
+		return nil, &os.PathError{Err: fmt.Errorf("%s: No such file.", name)}
 	}
 	return []byte(f.Contents), nil
 }

--- a/system/i2c_device.go
+++ b/system/i2c_device.go
@@ -58,6 +58,8 @@ type i2cDevice struct {
 	fs       filesystem
 }
 
+// TODO: possibly rename this to NewI2cDeviceAccess or NewI2cBus
+
 // NewI2cDevice returns an io.ReadWriteCloser with the proper ioctrl given
 // an i2c bus location.
 func (a *Accesser) NewI2cDevice(location string) (*i2cDevice, error) {

--- a/system/i2c_device.go
+++ b/system/i2c_device.go
@@ -58,8 +58,6 @@ type i2cDevice struct {
 	fs       filesystem
 }
 
-// TODO: possibly rename this to NewI2cDeviceAccess or NewI2cBus
-
 // NewI2cDevice returns an io.ReadWriteCloser with the proper ioctrl given
 // an i2c bus location.
 func (a *Accesser) NewI2cDevice(location string) (*i2cDevice, error) {
@@ -223,7 +221,6 @@ func (d *i2cDevice) Write(b []byte) (n int, err error) {
 			return 0, err
 		}
 	}
-
 	return d.file.Write(b)
 }
 


### PR DESCRIPTION
This also fixes possible caching problems on re-connect.

This Platforms needs to be adapted:
- [x] beaglebone
- [x] chip
- [x] dragonboard
- [x] edison (remove SetBoard(name), Board() if possible, fix finalize/re-connect tristate, fix return err "arduinoI2CSetup()")
- [x] joule
- [x] jetson
- [x] raspi
- [x] tinkerboard
   - [x] manual test
- [x] up2

In addition:
adjust interface GetDefaultBus() - DefaultBus() to match golang style for getters (no prefix "get")