### PR TITLE
Improve: use base driver for all I2C devices

### DIFF
--- a/drivers/i2c/adafruit_driver.go
+++ b/drivers/i2c/adafruit_driver.go
@@ -199,7 +199,7 @@ func (a *AdafruitMotorHatDriver) startDriver(connection Connection) (err error) 
 
 // Start initializes both I2C-addressable Adafruit Motor HAT drivers
 func (a *AdafruitMotorHatDriver) Start() (err error) {
-	bus := a.GetBusOrDefault(a.connector.DefaultBus())
+	bus := a.GetBusOrDefault(a.connector.DefaultI2cBus())
 
 	err = a.startServoHat(bus)
 	if adafruitDebug && err != nil {
@@ -216,7 +216,7 @@ func (a *AdafruitMotorHatDriver) Start() (err error) {
 
 // startServoHat starts the Servo motors connection.
 func (a *AdafruitMotorHatDriver) startServoHat(bus int) (err error) {
-	if a.servoHatConnection, err = a.connector.GetConnection(servoHatAddress, bus); err != nil {
+	if a.servoHatConnection, err = a.connector.GetI2cConnection(servoHatAddress, bus); err != nil {
 		return
 	}
 
@@ -229,7 +229,7 @@ func (a *AdafruitMotorHatDriver) startServoHat(bus int) (err error) {
 
 // startMotorHat starts the DC motors connection.
 func (a *AdafruitMotorHatDriver) startMotorHat(bus int) (err error) {
-	if a.motorHatConnection, err = a.connector.GetConnection(motorHatAddress, bus); err != nil {
+	if a.motorHatConnection, err = a.connector.GetI2cConnection(motorHatAddress, bus); err != nil {
 		return
 	}
 

--- a/drivers/i2c/adafruit_driver_test.go
+++ b/drivers/i2c/adafruit_driver_test.go
@@ -9,6 +9,7 @@ import (
 	"gobot.io/x/gobot/gobottest"
 )
 
+// this ensures that the implementation implements the gobot.Driver interface
 var _ gobot.Driver = (*AdafruitMotorHatDriver)(nil)
 
 // --------- HELPERS
@@ -24,14 +25,12 @@ func initTestAdafruitMotorHatDriverWithStubbedAdaptor() (*AdafruitMotorHatDriver
 
 // --------- TESTS
 func TestNewAdafruitMotorHatDriver(t *testing.T) {
-	var adafruit interface{} = NewAdafruitMotorHatDriver(newI2cTestAdaptor())
-	_, ok := adafruit.(*AdafruitMotorHatDriver)
+	var di interface{} = NewAdafruitMotorHatDriver(newI2cTestAdaptor())
+	d, ok := di.(*AdafruitMotorHatDriver)
 	if !ok {
 		t.Errorf("AdafruitMotorHatDriver() should have returned a *AdafruitMotorHatDriver")
 	}
-
-	a := NewAdafruitMotorHatDriver(newI2cTestAdaptor())
-	gobottest.Assert(t, strings.HasPrefix(a.Name(), "AdafruitMotorHat"), true)
+	gobottest.Assert(t, strings.HasPrefix(d.Name(), "AdafruitMotorHat"), true)
 }
 
 // Methods

--- a/drivers/i2c/adxl345_driver_test.go
+++ b/drivers/i2c/adxl345_driver_test.go
@@ -27,6 +27,7 @@ func TestNewADXL345Driver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "ADXL345"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x53)
 	gobottest.Assert(t, d.powerCtl.measure, uint8(1))
 	gobottest.Assert(t, d.dataFormat.fullScaleRange, ADXL345FsRangeConfig(0x00))
 	gobottest.Assert(t, d.bwRate.rate, ADXL345RateConfig(0x0A))

--- a/drivers/i2c/bh1750_driver.go
+++ b/drivers/i2c/bh1750_driver.go
@@ -3,11 +3,9 @@ package i2c
 import (
 	"errors"
 	"time"
-
-	"gobot.io/x/gobot"
 )
 
-const bh1750Address = 0x23
+const bh1750DefaultAddress = 0x23
 
 const (
 	BH1750_POWER_DOWN                 = 0x00
@@ -24,67 +22,32 @@ const (
 // BH1750Driver is a driver for the BH1750 digital Ambient Light Sensor IC for I²C bus interface.
 //
 type BH1750Driver struct {
-	name       string
-	connector  Connector
-	connection Connection
-	mode       byte
-	Config
+	*Driver
+	mode byte
 }
 
 // NewBH1750Driver creates a new driver with specified i2c interface
 // Params:
-//		conn Connector - the Adaptor to use with this Driver
+//		c Connector - the Adaptor to use with this Driver
 //
 // Optional params:
 //		i2c.WithBus(int):	bus to use with this driver
 //		i2c.WithAddress(int):	address to use with this driver
 //
-func NewBH1750Driver(a Connector, options ...func(Config)) *BH1750Driver {
-	m := &BH1750Driver{
-		name:      gobot.DefaultName("BH1750"),
-		connector: a,
-		Config:    NewConfig(),
-		mode:      BH1750_CONTINUOUS_HIGH_RES_MODE,
+func NewBH1750Driver(c Connector, options ...func(Config)) *BH1750Driver {
+	h := &BH1750Driver{
+		Driver: NewDriver(c, "BH1750", bh1750DefaultAddress),
+		mode:   BH1750_CONTINUOUS_HIGH_RES_MODE,
 	}
+	h.afterStart = h.initialize
 
 	for _, option := range options {
-		option(m)
+		option(h)
 	}
 
 	// TODO: add commands for API
-	return m
+	return h
 }
-
-// Name returns the Name for the Driver
-func (h *BH1750Driver) Name() string { return h.name }
-
-// SetName sets the Name for the Driver
-func (h *BH1750Driver) SetName(n string) { h.name = n }
-
-// Connection returns the connection for the Driver
-func (h *BH1750Driver) Connection() gobot.Connection { return h.connector.(gobot.Connection) }
-
-// Start initialized the bh1750
-func (h *BH1750Driver) Start() (err error) {
-	bus := h.GetBusOrDefault(h.connector.DefaultBus())
-	address := h.GetAddressOrDefault(bh1750Address)
-
-	h.connection, err = h.connector.GetConnection(address, bus)
-	if err != nil {
-		return err
-	}
-
-	err = h.connection.WriteByte(h.mode)
-	time.Sleep(10 * time.Microsecond)
-	if err != nil {
-		return err
-	}
-
-	return
-}
-
-// Halt returns true if devices is halted successfully
-func (h *BH1750Driver) Halt() (err error) { return }
 
 // RawSensorData returns the raw value from the bh1750
 func (h *BH1750Driver) RawSensorData() (level int, err error) {
@@ -110,4 +73,13 @@ func (h *BH1750Driver) Lux() (lux int, err error) {
 	lux = int(float64(lux) / 1.2)
 
 	return
+}
+
+func (h *BH1750Driver) initialize() error {
+	err := h.connection.WriteByte(h.mode)
+	time.Sleep(10 * time.Microsecond)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/drivers/i2c/bh1750_driver_test.go
+++ b/drivers/i2c/bh1750_driver_test.go
@@ -32,6 +32,7 @@ func TestNewBH1750Driver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "BH1750"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x23)
 }
 
 func TestBH1750Options(t *testing.T) {

--- a/drivers/i2c/blinkm_driver_test.go
+++ b/drivers/i2c/blinkm_driver_test.go
@@ -2,225 +2,178 @@ package i2c
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"gobot.io/x/gobot"
 	"gobot.io/x/gobot/gobottest"
 )
 
+// this ensures that the implementation is based on i2c.Driver, which implements the gobot.Driver
+// and tests all implementations, so no further tests needed here for gobot.Driver interface
 var _ gobot.Driver = (*BlinkMDriver)(nil)
 
-// --------- HELPERS
-func initTestBlinkMDriver() (driver *BlinkMDriver) {
-	driver, _ = initTestBlinkDriverWithStubbedAdaptor()
-	return
+func initTestBlinkMDriverWithStubbedAdaptor() (*BlinkMDriver, *i2cTestAdaptor) {
+	a := newI2cTestAdaptor()
+	d := NewBlinkMDriver(a)
+	if err := d.Start(); err != nil {
+		panic(err)
+	}
+	return d, a
 }
-
-func initTestBlinkDriverWithStubbedAdaptor() (*BlinkMDriver, *i2cTestAdaptor) {
-	adaptor := newI2cTestAdaptor()
-	return NewBlinkMDriver(adaptor), adaptor
-}
-
-// --------- TESTS
 
 func TestNewBlinkMDriver(t *testing.T) {
-	// Does it return a pointer to an instance of BlinkMDriver?
-	var bm interface{} = NewBlinkMDriver(newI2cTestAdaptor())
-	_, ok := bm.(*BlinkMDriver)
+	var di interface{} = NewBlinkMDriver(newI2cTestAdaptor())
+	d, ok := di.(*BlinkMDriver)
 	if !ok {
 		t.Errorf("NewBlinkMDriver() should have returned a *BlinkMDriver")
 	}
+	gobottest.Refute(t, d.Driver, nil)
+	gobottest.Assert(t, strings.HasPrefix(d.Name(), "BlinkM"), true)
+}
+
+func TestBlinkMOptions(t *testing.T) {
+	// This is a general test, that options are applied in constructor by using the common WithBus() option and
+	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".
+	d := NewBlinkMDriver(newI2cTestAdaptor(), WithBus(2))
+	gobottest.Assert(t, d.GetBusOrDefault(1), 2)
+}
+
+func TestBlinkMStart(t *testing.T) {
+	d := NewBlinkMDriver(newI2cTestAdaptor())
+	gobottest.Assert(t, d.Start(), nil)
+}
+
+func TestBlinkMHalt(t *testing.T) {
+	d, _ := initTestBlinkMDriverWithStubbedAdaptor()
+	gobottest.Assert(t, d.Halt(), nil)
 }
 
 // Commands
 func TestNewBlinkMDriverCommands_Rgb(t *testing.T) {
-	blinkM := initTestBlinkMDriver()
+	d, _ := initTestBlinkMDriverWithStubbedAdaptor()
 
-	gobottest.Assert(t, blinkM.Start(), nil)
-
-	result := blinkM.Command("Rgb")(rgb)
+	result := d.Command("Rgb")(rgb)
 	gobottest.Assert(t, result, nil)
 }
 
 func TestNewBlinkMDriverCommands_Fade(t *testing.T) {
-	blinkM := initTestBlinkMDriver()
+	d, _ := initTestBlinkMDriverWithStubbedAdaptor()
 
-	gobottest.Assert(t, blinkM.Start(), nil)
-
-	result := blinkM.Command("Fade")(rgb)
+	result := d.Command("Fade")(rgb)
 	gobottest.Assert(t, result, nil)
 }
 
 func TestNewBlinkMDriverCommands_FirmwareVersion(t *testing.T) {
-	blinkM, adaptor := initTestBlinkDriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, blinkM.Start(), nil)
-
+	d, a := initTestBlinkMDriverWithStubbedAdaptor()
 	param := make(map[string]interface{})
-
 	// When len(data) is 2
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{99, 1})
 		return 2, nil
 	}
 
-	result := blinkM.Command("FirmwareVersion")(param)
+	result := d.Command("FirmwareVersion")(param)
 
-	version, _ := blinkM.FirmwareVersion()
+	version, _ := d.FirmwareVersion()
 	gobottest.Assert(t, result.(map[string]interface{})["version"].(string), version)
 
 	// When len(data) is not 2
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{99})
 		return 1, nil
 	}
-	result = blinkM.Command("FirmwareVersion")(param)
+	result = d.Command("FirmwareVersion")(param)
 
-	version, _ = blinkM.FirmwareVersion()
+	version, _ = d.FirmwareVersion()
 	gobottest.Assert(t, result.(map[string]interface{})["version"].(string), version)
 }
 
 func TestNewBlinkMDriverCommands_Color(t *testing.T) {
-	blinkM := initTestBlinkMDriver()
-
-	gobottest.Assert(t, blinkM.Start(), nil)
-
+	d, _ := initTestBlinkMDriverWithStubbedAdaptor()
 	param := make(map[string]interface{})
 
-	result := blinkM.Command("Color")(param)
+	result := d.Command("Color")(param)
 
-	color, _ := blinkM.Color()
+	color, _ := d.Color()
 	gobottest.Assert(t, result.(map[string]interface{})["color"].([]byte), color)
 }
 
-// Methods
-func TestBlinkMDriver(t *testing.T) {
-	blinkM := initTestBlinkMDriver()
-
-	gobottest.Assert(t, blinkM.Start(), nil)
-	gobottest.Refute(t, blinkM.Connection(), nil)
-}
-
-func TestBlinkMDriverStart(t *testing.T) {
-	blinkM, adaptor := initTestBlinkDriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, blinkM.Start(), nil)
-
-	adaptor.i2cWriteImpl = func([]byte) (int, error) {
-		return 0, errors.New("write error")
-	}
-	gobottest.Assert(t, blinkM.Start(), errors.New("write error"))
-}
-
-func TestBlinkMDriverStartConnectError(t *testing.T) {
-	d, adaptor := initTestBlinkDriverWithStubbedAdaptor()
-	adaptor.Testi2cConnectErr(true)
-	gobottest.Assert(t, d.Start(), errors.New("Invalid i2c connection"))
-}
-
-func TestBlinkMDriverHalt(t *testing.T) {
-	blinkM := initTestBlinkMDriver()
-	gobottest.Assert(t, blinkM.Halt(), nil)
-}
-
-func TestBlinkMDriverFirmwareVersion(t *testing.T) {
-	blinkM, adaptor := initTestBlinkDriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, blinkM.Start(), nil)
-
+func TestBlinkMFirmwareVersion(t *testing.T) {
+	d, a := initTestBlinkMDriverWithStubbedAdaptor()
 	// when len(data) is 2
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{99, 1})
 		return 2, nil
 	}
 
-	version, _ := blinkM.FirmwareVersion()
+	version, _ := d.FirmwareVersion()
 	gobottest.Assert(t, version, "99.1")
 
 	// when len(data) is not 2
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{99})
 		return 1, nil
 	}
 
-	version, _ = blinkM.FirmwareVersion()
+	version, _ = d.FirmwareVersion()
 	gobottest.Assert(t, version, "")
 
-	adaptor.i2cWriteImpl = func([]byte) (int, error) {
+	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
 
-	version, err := blinkM.FirmwareVersion()
+	version, err := d.FirmwareVersion()
 	gobottest.Assert(t, err, errors.New("write error"))
 }
 
-func TestBlinkMDriverColor(t *testing.T) {
-	blinkM, adaptor := initTestBlinkDriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, blinkM.Start(), nil)
-
+func TestBlinkMColor(t *testing.T) {
+	d, a := initTestBlinkMDriverWithStubbedAdaptor()
 	// when len(data) is 3
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{99, 1, 2})
 		return 3, nil
 	}
 
-	color, _ := blinkM.Color()
+	color, _ := d.Color()
 	gobottest.Assert(t, color, []byte{99, 1, 2})
 
 	// when len(data) is not 3
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{99})
 		return 1, nil
 	}
 
-	color, _ = blinkM.Color()
+	color, _ = d.Color()
 	gobottest.Assert(t, color, []byte{})
 
-	adaptor.i2cWriteImpl = func([]byte) (int, error) {
+	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
 
-	color, err := blinkM.Color()
+	color, err := d.Color()
 	gobottest.Assert(t, err, errors.New("write error"))
 
 }
 
-func TestBlinkMDriverFade(t *testing.T) {
-	blinkM, adaptor := initTestBlinkDriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, blinkM.Start(), nil)
-
-	adaptor.i2cWriteImpl = func([]byte) (int, error) {
+func TestBlinkMFade(t *testing.T) {
+	d, a := initTestBlinkMDriverWithStubbedAdaptor()
+	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
 
-	err := blinkM.Fade(100, 100, 100)
+	err := d.Fade(100, 100, 100)
 	gobottest.Assert(t, err, errors.New("write error"))
 
 }
 
-func TestBlinkMDriverRGB(t *testing.T) {
-	blinkM, adaptor := initTestBlinkDriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, blinkM.Start(), nil)
-
-	adaptor.i2cWriteImpl = func([]byte) (int, error) {
+func TestBlinkMRGB(t *testing.T) {
+	d, a := initTestBlinkMDriverWithStubbedAdaptor()
+	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
 
-	err := blinkM.Rgb(100, 100, 100)
+	err := d.Rgb(100, 100, 100)
 	gobottest.Assert(t, err, errors.New("write error"))
 
-}
-
-func TestBlinkMDriverSetName(t *testing.T) {
-	d := initTestBlinkMDriver()
-	d.SetName("TESTME")
-	gobottest.Assert(t, d.Name(), "TESTME")
-}
-
-func TestBlinkMDriverOptions(t *testing.T) {
-	d := NewBlinkMDriver(newI2cTestAdaptor(), WithBus(2))
-	gobottest.Assert(t, d.GetBusOrDefault(1), 2)
 }

--- a/drivers/i2c/blinkm_driver_test.go
+++ b/drivers/i2c/blinkm_driver_test.go
@@ -30,6 +30,7 @@ func TestNewBlinkMDriver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "BlinkM"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x09)
 }
 
 func TestBlinkMOptions(t *testing.T) {

--- a/drivers/i2c/drv2605l_driver_test.go
+++ b/drivers/i2c/drv2605l_driver_test.go
@@ -39,6 +39,7 @@ func TestNewDRV2605LDriver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "DRV2605L"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x5a)
 }
 
 func TestDRV2605LOptions(t *testing.T) {

--- a/drivers/i2c/grovepi_driver_test.go
+++ b/drivers/i2c/grovepi_driver_test.go
@@ -43,6 +43,7 @@ func TestNewGrovePiDriver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "GrovePi"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x04)
 	gobottest.Refute(t, d.pins, nil)
 }
 

--- a/drivers/i2c/helpers_test.go
+++ b/drivers/i2c/helpers_test.go
@@ -155,7 +155,7 @@ func (t *i2cTestAdaptor) WriteBlockData(reg uint8, b []byte) error {
 	return t.writeBytes(buf)
 }
 
-func (t *i2cTestAdaptor) GetConnection(address int, bus int) (connection Connection, err error) {
+func (t *i2cTestAdaptor) GetI2cConnection(address int, bus int) (connection Connection, err error) {
 	if t.i2cConnectErr {
 		return nil, errors.New("Invalid i2c connection")
 	}
@@ -164,7 +164,7 @@ func (t *i2cTestAdaptor) GetConnection(address int, bus int) (connection Connect
 	return t, nil
 }
 
-func (t *i2cTestAdaptor) DefaultBus() int {
+func (t *i2cTestAdaptor) DefaultI2cBus() int {
 	return 0
 }
 

--- a/drivers/i2c/hmc5883l_driver_test.go
+++ b/drivers/i2c/hmc5883l_driver_test.go
@@ -25,6 +25,7 @@ func TestNewHMC5883LDriver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.name, "HMC5883L"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x1E)
 	gobottest.Assert(t, d.samplesAvg, uint8(8))
 	gobottest.Assert(t, d.outputRate, uint32(15000))
 	gobottest.Assert(t, d.applyBias, int8(0))

--- a/drivers/i2c/hmc6352_driver.go
+++ b/drivers/i2c/hmc6352_driver.go
@@ -1,66 +1,32 @@
 package i2c
 
-import "gobot.io/x/gobot"
-
-const hmc6352Address = 0x21
+const hmc6352DefaultAddress = 0x21
 
 // HMC6352Driver is a Driver for a HMC6352 digital compass
 type HMC6352Driver struct {
-	name       string
-	connector  Connector
-	connection Connection
-	Config
+	*Driver
 }
 
 // NewHMC6352Driver creates a new driver with specified i2c interface
 // Params:
-//		conn Connector - the Adaptor to use with this Driver
+//		c Connector - the Adaptor to use with this Driver
 //
 // Optional params:
 //		i2c.WithBus(int):	bus to use with this driver
 //		i2c.WithAddress(int):	address to use with this driver
 //
-func NewHMC6352Driver(a Connector, options ...func(Config)) *HMC6352Driver {
-	hmc := &HMC6352Driver{
-		name:      gobot.DefaultName("HMC6352"),
-		connector: a,
-		Config:    NewConfig(),
+func NewHMC6352Driver(c Connector, options ...func(Config)) *HMC6352Driver {
+	h := &HMC6352Driver{
+		Driver: NewDriver(c, "HMC6352", hmc6352DefaultAddress),
 	}
+	h.afterStart = h.initialize
 
 	for _, option := range options {
-		option(hmc)
+		option(h)
 	}
 
-	return hmc
+	return h
 }
-
-// Name returns the name for this Driver
-func (h *HMC6352Driver) Name() string { return h.name }
-
-// SetName sets the name for this Driver
-func (h *HMC6352Driver) SetName(n string) { h.name = n }
-
-// Connection returns the connection for this Driver
-func (h *HMC6352Driver) Connection() gobot.Connection { return h.connector.(gobot.Connection) }
-
-// Start initializes the hmc6352
-func (h *HMC6352Driver) Start() (err error) {
-	bus := h.GetBusOrDefault(h.connector.DefaultBus())
-	address := h.GetAddressOrDefault(hmc6352Address)
-
-	h.connection, err = h.connector.GetConnection(address, bus)
-	if err != nil {
-		return err
-	}
-
-	if _, err := h.connection.Write([]byte("A")); err != nil {
-		return err
-	}
-	return
-}
-
-// Halt returns true if devices is halted successfully
-func (h *HMC6352Driver) Halt() (err error) { return }
 
 // Heading returns the current heading
 func (h *HMC6352Driver) Heading() (heading uint16, err error) {
@@ -79,4 +45,11 @@ func (h *HMC6352Driver) Heading() (heading uint16, err error) {
 
 	err = ErrNotEnoughBytes
 	return
+}
+
+func (h *HMC6352Driver) initialize() error {
+	if _, err := h.connection.Write([]byte("A")); err != nil {
+		return err
+	}
+	return nil
 }

--- a/drivers/i2c/hmc6352_driver_test.go
+++ b/drivers/i2c/hmc6352_driver_test.go
@@ -2,126 +2,92 @@ package i2c
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"gobot.io/x/gobot"
 	"gobot.io/x/gobot/gobottest"
 )
 
+// this ensures that the implementation is based on i2c.Driver, which implements the gobot.Driver
+// and tests all implementations, so no further tests needed here for gobot.Driver interface
 var _ gobot.Driver = (*HMC6352Driver)(nil)
 
-// --------- HELPERS
-func initTestHMC6352Driver() (driver *HMC6352Driver) {
-	driver, _ = initTestHMC6352DriverWithStubbedAdaptor()
-	return
-}
-
 func initTestHMC6352DriverWithStubbedAdaptor() (*HMC6352Driver, *i2cTestAdaptor) {
-	adaptor := newI2cTestAdaptor()
-	return NewHMC6352Driver(adaptor), adaptor
+	a := newI2cTestAdaptor()
+	d := NewHMC6352Driver(a)
+	if err := d.Start(); err != nil {
+		panic(err)
+	}
+	return d, a
 }
-
-// --------- TESTS
 
 func TestNewHMC6352Driver(t *testing.T) {
-	// Does it return a pointer to an instance of HMC6352Driver?
-	var bm interface{} = NewHMC6352Driver(newI2cTestAdaptor())
-	_, ok := bm.(*HMC6352Driver)
+	var di interface{} = NewHMC6352Driver(newI2cTestAdaptor())
+	d, ok := di.(*HMC6352Driver)
 	if !ok {
 		t.Errorf("NewHMC6352Driver() should have returned a *HMC6352Driver")
 	}
-
-	b := NewHMC6352Driver(newI2cTestAdaptor())
-	gobottest.Refute(t, b.Connection(), nil)
+	gobottest.Refute(t, d.Driver, nil)
+	gobottest.Assert(t, strings.HasPrefix(d.Name(), "HMC6352"), true)
 }
 
-// Methods
-func TestHMC6352DriverStart(t *testing.T) {
-	hmc, adaptor := initTestHMC6352DriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, hmc.Start(), nil)
-
-	adaptor.i2cWriteImpl = func([]byte) (int, error) {
-		return 0, errors.New("write error")
-	}
-	err := hmc.Start()
-	gobottest.Assert(t, err, errors.New("write error"))
+func TestHMC6352Options(t *testing.T) {
+	// This is a general test, that options are applied in constructor by using the common WithBus() option and
+	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".
+	d := NewHMC6352Driver(newI2cTestAdaptor(), WithBus(2))
+	gobottest.Assert(t, d.GetBusOrDefault(1), 2)
 }
 
-func TestHMC6352StartConnectError(t *testing.T) {
-	d, adaptor := initTestHMC6352DriverWithStubbedAdaptor()
-	adaptor.Testi2cConnectErr(true)
-	gobottest.Assert(t, d.Start(), errors.New("Invalid i2c connection"))
+func TestHMC6352Start(t *testing.T) {
+	d := NewHMC6352Driver(newI2cTestAdaptor())
+	gobottest.Assert(t, d.Start(), nil)
 }
 
-func TestHMC6352DriverHalt(t *testing.T) {
-	hmc := initTestHMC6352Driver()
-
-	gobottest.Assert(t, hmc.Halt(), nil)
+func TestHMC6352Halt(t *testing.T) {
+	d, _ := initTestHMC6352DriverWithStubbedAdaptor()
+	gobottest.Assert(t, d.Halt(), nil)
 }
 
-func TestHMC6352DriverHeading(t *testing.T) {
+func TestHMC6352Heading(t *testing.T) {
 	// when len(data) is 2
-	hmc, adaptor := initTestHMC6352DriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, hmc.Start(), nil)
-
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	d, a := initTestHMC6352DriverWithStubbedAdaptor()
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{99, 1})
 		return 2, nil
 	}
 
-	heading, _ := hmc.Heading()
+	heading, _ := d.Heading()
 	gobottest.Assert(t, heading, uint16(2534))
 
 	// when len(data) is not 2
-	hmc, adaptor = initTestHMC6352DriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, hmc.Start(), nil)
-
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	d, a = initTestHMC6352DriverWithStubbedAdaptor()
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{99})
 		return 1, nil
 	}
 
-	heading, err := hmc.Heading()
+	heading, err := d.Heading()
 	gobottest.Assert(t, heading, uint16(0))
 	gobottest.Assert(t, err, ErrNotEnoughBytes)
 
 	// when read error
-	hmc, adaptor = initTestHMC6352DriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, hmc.Start(), nil)
-
-	adaptor.i2cReadImpl = func([]byte) (int, error) {
+	d, a = initTestHMC6352DriverWithStubbedAdaptor()
+	a.i2cReadImpl = func([]byte) (int, error) {
 		return 0, errors.New("read error")
 	}
 
-	heading, err = hmc.Heading()
+	heading, err = d.Heading()
 	gobottest.Assert(t, heading, uint16(0))
 	gobottest.Assert(t, err, errors.New("read error"))
 
 	// when write error
-	hmc, adaptor = initTestHMC6352DriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, hmc.Start(), nil)
-
-	adaptor.i2cWriteImpl = func([]byte) (int, error) {
+	d, a = initTestHMC6352DriverWithStubbedAdaptor()
+	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
 
-	heading, err = hmc.Heading()
+	heading, err = d.Heading()
 	gobottest.Assert(t, heading, uint16(0))
 	gobottest.Assert(t, err, errors.New("write error"))
-}
-
-func TestHMC6352DriverSetName(t *testing.T) {
-	d := initTestHMC6352Driver()
-	d.SetName("TESTME")
-	gobottest.Assert(t, d.Name(), "TESTME")
-}
-
-func TestHMC6352DriverOptions(t *testing.T) {
-	d := NewHMC6352Driver(newI2cTestAdaptor(), WithBus(2))
-	gobottest.Assert(t, d.GetBusOrDefault(1), 2)
 }

--- a/drivers/i2c/hmc6352_driver_test.go
+++ b/drivers/i2c/hmc6352_driver_test.go
@@ -30,6 +30,7 @@ func TestNewHMC6352Driver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "HMC6352"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x21)
 }
 
 func TestHMC6352Options(t *testing.T) {

--- a/drivers/i2c/i2c_config.go
+++ b/drivers/i2c/i2c_config.go
@@ -5,29 +5,27 @@ type i2cConfig struct {
 	address int
 }
 
-// Config is the interface which describes how a Driver can specify
-// optional I2C params such as which I2C bus it wants to use.
-type Config interface {
-	// WithBus sets which bus to use
-	WithBus(bus int)
-
-	// GetBusOrDefault gets which bus to use
-	GetBusOrDefault(def int) int
-
-	// WithAddress sets which address to use
-	WithAddress(address int)
-
-	// GetAddressOrDefault gets which address to use
-	GetAddressOrDefault(def int) int
-}
-
 // NewConfig returns a new I2c Config.
 func NewConfig() Config {
 	return &i2cConfig{bus: BusNotInitialized, address: AddressNotInitialized}
 }
 
-// WithBus sets preferred bus to use.
-func (i *i2cConfig) WithBus(bus int) {
+// WithBus sets which bus to use as a optional param.
+func WithBus(bus int) func(Config) {
+	return func(i Config) {
+		i.SetBus(bus)
+	}
+}
+
+// WithAddress sets which address to use as a optional param.
+func WithAddress(address int) func(Config) {
+	return func(i Config) {
+		i.SetAddress(address)
+	}
+}
+
+// SetBus sets preferred bus to use.
+func (i *i2cConfig) SetBus(bus int) {
 	i.bus = bus
 }
 
@@ -41,15 +39,8 @@ func (i *i2cConfig) GetBusOrDefault(d int) int {
 	return i.bus
 }
 
-// WithBus sets which bus to use as a optional param.
-func WithBus(bus int) func(Config) {
-	return func(i Config) {
-		i.WithBus(bus)
-	}
-}
-
-// WithAddress sets which address to use.
-func (i *i2cConfig) WithAddress(address int) {
+// SetAddress sets which address to use.
+func (i *i2cConfig) SetAddress(address int) {
 	i.address = address
 }
 
@@ -62,11 +53,4 @@ func (i *i2cConfig) GetAddressOrDefault(a int) int {
 	}
 
 	return i.address
-}
-
-// WithAddress sets which address to use as a optional param.
-func WithAddress(address int) func(Config) {
-	return func(i Config) {
-		i.WithAddress(address)
-	}
 }

--- a/drivers/i2c/i2c_config_test.go
+++ b/drivers/i2c/i2c_config_test.go
@@ -22,7 +22,7 @@ func TestWithBus(t *testing.T) {
 	// arrange
 	c := NewConfig()
 	// act
-	c.WithBus(0x23)
+	c.SetBus(0x23)
 	// assert
 	gobottest.Assert(t, c.(*i2cConfig).bus, 0x23)
 }
@@ -31,7 +31,7 @@ func TestWithAddress(t *testing.T) {
 	// arrange
 	c := NewConfig()
 	// act
-	c.WithAddress(0x24)
+	c.SetAddress(0x24)
 	// assert
 	gobottest.Assert(t, c.(*i2cConfig).address, 0x24)
 }

--- a/drivers/i2c/i2c_connection.go
+++ b/drivers/i2c/i2c_connection.go
@@ -92,18 +92,6 @@ type I2cDevice interface {
 	SetAddress(int) error
 }
 
-// Connector lets Adaptors provide the interface for Drivers
-// to get access to the I2C buses on platforms that support I2C.
-type Connector interface {
-	// GetConnection creates and returns a connection to device at the specified address
-	// and bus. Bus numbering starts at index 0, the range of valid buses is
-	// platform specific.
-	GetConnection(address int, busNr int) (device Connection, err error)
-
-	// DefaultBus returns the default I2C bus index
-	DefaultBus() int
-}
-
 // Connection is a connection to an I2C device with a specified address
 // on a specific bus. Used as an alternative to the I2c interface.
 // Implements I2cOperations to talk to the device, wrapping the

--- a/drivers/i2c/i2c_driver.go
+++ b/drivers/i2c/i2c_driver.go
@@ -9,6 +9,33 @@ import (
 	"gobot.io/x/gobot"
 )
 
+// Config is the interface to set and get I2C device related parameters.
+type Config interface {
+	// SetBus sets which bus to use
+	SetBus(bus int)
+
+	// GetBusOrDefault gets which bus to use
+	GetBusOrDefault(def int) int
+
+	// SetAddress sets which address to use
+	SetAddress(address int)
+
+	// GetAddressOrDefault gets which address to use
+	GetAddressOrDefault(def int) int
+}
+
+// Connector lets adaptors (platforms) provide the interface for Drivers to get access to the I2C buses on platforms
+// that support I2C. The "I2C" specifier is part of the name to differentiate to SPI at platform level.
+type Connector interface {
+	// GetI2cConnection creates and returns a connection to device at the specified address
+	// and bus. Bus numbering starts at index 0, the range of valid buses is
+	// platform specific.
+	GetI2cConnection(address int, busNr int) (device Connection, err error)
+
+	// DefaultI2cBus returns the default I2C bus index
+	DefaultI2cBus() int
+}
+
 // Driver implements the interface gobot.Driver.
 type Driver struct {
 	name           string
@@ -63,10 +90,10 @@ func (d *Driver) Start() error {
 	defer d.mutex.Unlock()
 
 	var err error
-	bus := d.GetBusOrDefault(d.connector.DefaultBus())
+	bus := d.GetBusOrDefault(d.connector.DefaultI2cBus())
 	address := d.GetAddressOrDefault(int(d.defaultAddress))
 
-	if d.connection, err = d.connector.GetConnection(address, bus); err != nil {
+	if d.connection, err = d.connector.GetI2cConnection(address, bus); err != nil {
 		return err
 	}
 

--- a/drivers/i2c/ina3221_driver.go
+++ b/drivers/i2c/ina3221_driver.go
@@ -7,15 +7,11 @@ package i2c
 //
 // This module was tested with SwitchDoc Labs INA3221 breakout board found at http://www.switchdoc.com/
 
-import (
-	"gobot.io/x/gobot"
-)
-
 // INA3221Channel type that defines which INA3221 channel to read from.
 type INA3221Channel uint8
 
 const (
-	ina3221Address            uint8   = 0x40 // 1000000 (A0+A1=GND)
+	ina3221DefaultAddress             = 0x40 // 1000000 (A0+A1=GND)
 	ina3221Read               uint8   = 0x01
 	ina3221RegConfig          uint8   = 0x00   // CONFIG REGISTER (R/W)
 	ina3221ConfigReset        uint16  = 0x8000 // Reset Bit
@@ -45,69 +41,28 @@ const (
 
 // INA3221Driver is a driver for the INA3221 three-channel current and bus voltage monitoring device.
 type INA3221Driver struct {
-	name       string
-	connector  Connector
-	connection Connection
-	Config
+	*Driver
 	halt chan bool
 }
 
 // NewINA3221Driver creates a new driver with the specified i2c interface.
 // Params:
-//		conn Connector - the Adaptor to use with this Driver
+//		c Connector - the Adaptor to use with this Driver
 //
 // Optional params:
 //		i2c.WithBus(int):		bus to use with this driver
 //		i2c.WithAddress(int):		address to use with this driver
 func NewINA3221Driver(c Connector, options ...func(Config)) *INA3221Driver {
 	i := &INA3221Driver{
-		name:      gobot.DefaultName("INA3221"),
-		connector: c,
-		Config:    NewConfig(),
+		Driver: NewDriver(c, "INA3221", ina3221DefaultAddress),
 	}
+	i.afterStart = i.initialize
 
 	for _, option := range options {
 		option(i)
 	}
 
 	return i
-}
-
-// Name returns the name of the device.
-func (i *INA3221Driver) Name() string {
-	return i.name
-}
-
-// SetName sets the name of the device.
-func (i *INA3221Driver) SetName(name string) {
-	i.name = name
-}
-
-// Connection returns the connection of the device.
-func (i *INA3221Driver) Connection() gobot.Connection {
-	return i.connector.(gobot.Connection)
-}
-
-// Start initializes the INA3221
-func (i *INA3221Driver) Start() error {
-	var err error
-	bus := i.GetBusOrDefault(i.connector.DefaultBus())
-	address := i.GetAddressOrDefault(int(ina3221Address))
-
-	if i.connection, err = i.connector.GetConnection(address, bus); err != nil {
-		return err
-	}
-
-	if err := i.initialize(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// Halt halts the device.
-func (i *INA3221Driver) Halt() error {
-	return nil
 }
 
 // GetBusVoltage gets the bus voltage in Volts

--- a/drivers/i2c/ina3221_driver_test.go
+++ b/drivers/i2c/ina3221_driver_test.go
@@ -11,58 +11,48 @@ import (
 	"gobot.io/x/gobot/gobottest"
 )
 
+// this ensures that the implementation is based on i2c.Driver, which implements the gobot.Driver
+// and tests all implementations, so no further tests needed here for gobot.Driver interface
 var _ gobot.Driver = (*INA3221Driver)(nil)
-
-func initTestINA3221Driver() *INA3221Driver {
-	d, _ := initTestINA3221DriverWithStubbedAdaptor()
-	return d
-}
 
 func initTestINA3221DriverWithStubbedAdaptor() (*INA3221Driver, *i2cTestAdaptor) {
 	a := newI2cTestAdaptor()
-	return NewINA3221Driver(a), a
+	d := NewINA3221Driver(a)
+	if err := d.Start(); err != nil {
+		panic(err)
+	}
+	return d, a
 }
 
 func TestNewINA3221Driver(t *testing.T) {
-	var d interface{} = NewINA3221Driver(newI2cTestAdaptor())
-	if _, ok := d.(*INA3221Driver); !ok {
+	var di interface{} = NewINA3221Driver(newI2cTestAdaptor())
+	d, ok := di.(*INA3221Driver)
+	if !ok {
 		t.Error("NewINA3221Driver() should return a *INA3221Driver")
 	}
+	gobottest.Refute(t, d.Driver, nil)
+	gobottest.Assert(t, strings.HasPrefix(d.Name(), "INA3221"), true)
 }
 
-func TestINA3221Driver_Connection(t *testing.T) {
-	d := initTestINA3221Driver()
-	gobottest.Refute(t, d.Connection(), nil)
+func TestINA3221Options(t *testing.T) {
+	// This is a general test, that options are applied in constructor by using the common WithBus() option and
+	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".
+	d := NewINA3221Driver(newI2cTestAdaptor(), WithBus(2))
+	gobottest.Assert(t, d.GetBusOrDefault(1), 2)
 }
 
-func TestINA3221Driver_Start(t *testing.T) {
-	d := initTestINA3221Driver()
+func TestINA3221Start(t *testing.T) {
+	d := NewINA3221Driver(newI2cTestAdaptor())
 	gobottest.Assert(t, d.Start(), nil)
 }
 
-func TestINA3221Driver_ConnectError(t *testing.T) {
-	d, a := initTestINA3221DriverWithStubbedAdaptor()
-	a.Testi2cConnectErr(true)
-	gobottest.Assert(t, d.Start(), errors.New("Invalid i2c connection"))
-}
-
-func TestINA3221Driver_StartWriteError(t *testing.T) {
-	d, a := initTestINA3221DriverWithStubbedAdaptor()
-	a.i2cWriteImpl = func([]byte) (int, error) {
-		return 0, errors.New("write error")
-	}
-	gobottest.Assert(t, d.Start(), errors.New("write error"))
-}
-
-func TestINA3221Driver_Halt(t *testing.T) {
-	d := initTestINA3221Driver()
+func TestINA3221Halt(t *testing.T) {
+	d, _ := initTestINA3221DriverWithStubbedAdaptor()
 	gobottest.Assert(t, d.Halt(), nil)
 }
 
-func TestINA3221DriverGetBusVoltage(t *testing.T) {
+func TestINA3221GetBusVoltage(t *testing.T) {
 	d, a := initTestINA3221DriverWithStubbedAdaptor()
-	gobottest.Assert(t, d.Start(), nil)
-
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		// bus voltage sensor values from 12V battery
 		copy(b, []byte{0x36, 0x68})
@@ -74,10 +64,8 @@ func TestINA3221DriverGetBusVoltage(t *testing.T) {
 	gobottest.Assert(t, err, nil)
 }
 
-func TestINA3221DriverGetBusVoltageReadError(t *testing.T) {
+func TestINA3221GetBusVoltageReadError(t *testing.T) {
 	d, a := initTestINA3221DriverWithStubbedAdaptor()
-	gobottest.Assert(t, d.Start(), nil)
-
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		return 0, errors.New("read error")
 	}
@@ -86,10 +74,8 @@ func TestINA3221DriverGetBusVoltageReadError(t *testing.T) {
 	gobottest.Assert(t, err, errors.New("read error"))
 }
 
-func TestINA3221DriverGetShuntVoltage(t *testing.T) {
+func TestINA3221GetShuntVoltage(t *testing.T) {
 	d, a := initTestINA3221DriverWithStubbedAdaptor()
-	gobottest.Assert(t, d.Start(), nil)
-
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		// shunt voltage sensor values from 12V battery
 		copy(b, []byte{0x05, 0xD8})
@@ -101,10 +87,8 @@ func TestINA3221DriverGetShuntVoltage(t *testing.T) {
 	gobottest.Assert(t, err, nil)
 }
 
-func TestINA3221DriverGetShuntVoltageReadError(t *testing.T) {
+func TestINA3221GetShuntVoltageReadError(t *testing.T) {
 	d, a := initTestINA3221DriverWithStubbedAdaptor()
-	gobottest.Assert(t, d.Start(), nil)
-
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		return 0, errors.New("read error")
 	}
@@ -113,10 +97,8 @@ func TestINA3221DriverGetShuntVoltageReadError(t *testing.T) {
 	gobottest.Assert(t, err, errors.New("read error"))
 }
 
-func TestINA3221DriverGetCurrent(t *testing.T) {
+func TestINA3221GetCurrent(t *testing.T) {
 	d, a := initTestINA3221DriverWithStubbedAdaptor()
-	gobottest.Assert(t, d.Start(), nil)
-
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		// shunt voltage sensor values from 12V battery
 		copy(b, []byte{0x05, 0x0D8})
@@ -128,10 +110,8 @@ func TestINA3221DriverGetCurrent(t *testing.T) {
 	gobottest.Assert(t, err, nil)
 }
 
-func TestINA3221DriverCurrentReadError(t *testing.T) {
+func TestINA3221CurrentReadError(t *testing.T) {
 	d, a := initTestINA3221DriverWithStubbedAdaptor()
-	gobottest.Assert(t, d.Start(), nil)
-
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		return 0, errors.New("read error")
 	}
@@ -140,10 +120,8 @@ func TestINA3221DriverCurrentReadError(t *testing.T) {
 	gobottest.Assert(t, err, errors.New("read error"))
 }
 
-func TestINA3221DriverGetLoadVoltage(t *testing.T) {
+func TestINA3221GetLoadVoltage(t *testing.T) {
 	d, a := initTestINA3221DriverWithStubbedAdaptor()
-	gobottest.Assert(t, d.Start(), nil)
-
 	i := 0
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		// TODO: return test data as read from actual sensor
@@ -157,25 +135,12 @@ func TestINA3221DriverGetLoadVoltage(t *testing.T) {
 	gobottest.Assert(t, err, nil)
 }
 
-func TestINA3221DriverGetLoadVoltageReadError(t *testing.T) {
+func TestINA3221GetLoadVoltageReadError(t *testing.T) {
 	d, a := initTestINA3221DriverWithStubbedAdaptor()
-	gobottest.Assert(t, d.Start(), nil)
-
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		return 0, errors.New("read error")
 	}
 
 	_, err := d.GetLoadVoltage(INA3221Channel2)
 	gobottest.Assert(t, err, errors.New("read error"))
-}
-
-func TestINA3221DriverName(t *testing.T) {
-	d := initTestINA3221Driver()
-	gobottest.Assert(t, strings.HasPrefix(d.Name(), "INA3221"), true)
-}
-
-func TestINA3221DriverSetName(t *testing.T) {
-	d := initTestINA3221Driver()
-	d.SetName("foobot")
-	gobottest.Assert(t, d.Name(), "foobot")
 }

--- a/drivers/i2c/ina3221_driver_test.go
+++ b/drivers/i2c/ina3221_driver_test.go
@@ -32,6 +32,7 @@ func TestNewINA3221Driver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "INA3221"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x40)
 }
 
 func TestINA3221Options(t *testing.T) {

--- a/drivers/i2c/jhd1313m1_driver.go
+++ b/drivers/i2c/jhd1313m1_driver.go
@@ -144,13 +144,13 @@ func (h *JHD1313M1Driver) Connection() gobot.Connection {
 
 // Start starts the backlit and the screen and initializes the states.
 func (h *JHD1313M1Driver) Start() (err error) {
-	bus := h.GetBusOrDefault(h.connector.DefaultBus())
+	bus := h.GetBusOrDefault(h.connector.DefaultI2cBus())
 
-	if h.lcdConnection, err = h.connector.GetConnection(h.lcdAddress, bus); err != nil {
+	if h.lcdConnection, err = h.connector.GetI2cConnection(h.lcdAddress, bus); err != nil {
 		return err
 	}
 
-	if h.rgbConnection, err = h.connector.GetConnection(h.rgbAddress, bus); err != nil {
+	if h.rgbConnection, err = h.connector.GetI2cConnection(h.rgbAddress, bus); err != nil {
 		return err
 	}
 

--- a/drivers/i2c/l3gd20h_driver_test.go
+++ b/drivers/i2c/l3gd20h_driver_test.go
@@ -2,6 +2,7 @@ package i2c
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"gobot.io/x/gobot"
@@ -33,6 +34,8 @@ func TestNewL3GD20HDriver(t *testing.T) {
 		t.Errorf("NewL3GD20HDriver() should have returned a *L3GD20HDriver")
 	}
 	gobottest.Refute(t, d.Driver, nil)
+	gobottest.Assert(t, strings.HasPrefix(d.Name(), "L3GD20H"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x6b)
 	gobottest.Assert(t, d.Scale(), L3GD20HScale250dps)
 }
 

--- a/drivers/i2c/lidarlite_driver.go
+++ b/drivers/i2c/lidarlite_driver.go
@@ -1,35 +1,28 @@
 package i2c
 
 import (
-	"gobot.io/x/gobot"
-
 	"time"
 )
 
-const lidarliteAddress = 0x62
+const lidarliteDefaultAddress = 0x62
 
 // LIDARLiteDriver is the Gobot driver for the LIDARLite I2C LIDAR device.
 type LIDARLiteDriver struct {
-	name       string
-	connector  Connector
-	connection Connection
-	Config
+	*Driver
 }
 
 // NewLIDARLiteDriver creates a new driver for the LIDARLite I2C LIDAR device.
 //
 // Params:
-//		conn Connector - the Adaptor to use with this Driver
+//		c Connector - the Adaptor to use with this Driver
 //
 // Optional params:
 //		i2c.WithBus(int):	bus to use with this driver
 //		i2c.WithAddress(int):	address to use with this driver
 //
-func NewLIDARLiteDriver(a Connector, options ...func(Config)) *LIDARLiteDriver {
+func NewLIDARLiteDriver(c Connector, options ...func(Config)) *LIDARLiteDriver {
 	l := &LIDARLiteDriver{
-		name:      gobot.DefaultName("LIDARLite"),
-		connector: a,
-		Config:    NewConfig(),
+		Driver: NewDriver(c, "LIDARLite", lidarliteDefaultAddress),
 	}
 
 	for _, option := range options {
@@ -39,30 +32,6 @@ func NewLIDARLiteDriver(a Connector, options ...func(Config)) *LIDARLiteDriver {
 	// TODO: add commands to API
 	return l
 }
-
-// Name returns the Name for the Driver
-func (h *LIDARLiteDriver) Name() string { return h.name }
-
-// SetName sets the Name for the Driver
-func (h *LIDARLiteDriver) SetName(n string) { h.name = n }
-
-// Connection returns the connection for the Driver
-func (h *LIDARLiteDriver) Connection() gobot.Connection { return h.connector.(gobot.Connection) }
-
-// Start initialized the LIDAR
-func (h *LIDARLiteDriver) Start() (err error) {
-	bus := h.GetBusOrDefault(h.connector.DefaultBus())
-	address := h.GetAddressOrDefault(lidarliteAddress)
-
-	h.connection, err = h.connector.GetConnection(address, bus)
-	if err != nil {
-		return err
-	}
-	return
-}
-
-// Halt returns true if devices is halted successfully
-func (h *LIDARLiteDriver) Halt() (err error) { return }
 
 // Distance returns the current distance in cm
 func (h *LIDARLiteDriver) Distance() (distance int, err error) {

--- a/drivers/i2c/lidarlite_driver_test.go
+++ b/drivers/i2c/lidarlite_driver_test.go
@@ -36,6 +36,7 @@ func TestNewLIDARLiteDriver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "LIDARLite"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x62)
 }
 
 func TestLIDARLiteDriverOptions(t *testing.T) {

--- a/drivers/i2c/mcp23017_driver_test.go
+++ b/drivers/i2c/mcp23017_driver_test.go
@@ -47,6 +47,7 @@ func TestNewMCP23017Driver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "MCP23017"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x20)
 	gobottest.Refute(t, d.mcpConf, nil)
 	gobottest.Refute(t, d.mcpBehav, nil)
 }

--- a/drivers/i2c/mma7660_driver.go
+++ b/drivers/i2c/mma7660_driver.go
@@ -1,10 +1,6 @@
 package i2c
 
-import (
-	"gobot.io/x/gobot"
-)
-
-const mma7660Address = 0x4c
+const mma7660DefaultAddress = 0x4c
 
 const (
 	MMA7660_X              = 0x00
@@ -31,81 +27,40 @@ const (
 )
 
 type MMA7660Driver struct {
-	name       string
-	connector  Connector
-	connection Connection
-	Config
+	*Driver
 }
 
 // NewMMA7660Driver creates a new driver with specified i2c interface
 // Params:
-//		conn Connector - the Adaptor to use with this Driver
+//		c Connector - the Adaptor to use with this Driver
 //
 // Optional params:
 //		i2c.WithBus(int):	bus to use with this driver
 //		i2c.WithAddress(int):	address to use with this driver
 //
-func NewMMA7660Driver(a Connector, options ...func(Config)) *MMA7660Driver {
-	m := &MMA7660Driver{
-		name:      gobot.DefaultName("MMA7660"),
-		connector: a,
-		Config:    NewConfig(),
+func NewMMA7660Driver(c Connector, options ...func(Config)) *MMA7660Driver {
+	d := &MMA7660Driver{
+		Driver: NewDriver(c, "MMA7660", mma7660DefaultAddress),
 	}
+	d.afterStart = d.initialize
 
 	for _, option := range options {
-		option(m)
+		option(d)
 	}
 
 	// TODO: add commands for API
-	return m
+	return d
 }
-
-// Name returns the Name for the Driver
-func (h *MMA7660Driver) Name() string { return h.name }
-
-// SetName sets the Name for the Driver
-func (h *MMA7660Driver) SetName(n string) { h.name = n }
-
-// Connection returns the connection for the Driver
-func (h *MMA7660Driver) Connection() gobot.Connection { return h.connector.(gobot.Connection) }
-
-// Start initialized the mma7660
-func (h *MMA7660Driver) Start() (err error) {
-	bus := h.GetBusOrDefault(h.connector.DefaultBus())
-	address := h.GetAddressOrDefault(mma7660Address)
-
-	h.connection, err = h.connector.GetConnection(address, bus)
-	if err != nil {
-		return err
-	}
-
-	if _, err := h.connection.Write([]byte{MMA7660_MODE, MMA7660_STAND_BY}); err != nil {
-		return err
-	}
-
-	if _, err := h.connection.Write([]byte{MMA7660_SR, MMA7660_AUTO_SLEEP_32}); err != nil {
-		return err
-	}
-
-	if _, err := h.connection.Write([]byte{MMA7660_MODE, MMA7660_ACTIVE}); err != nil {
-		return err
-	}
-
-	return
-}
-
-// Halt returns true if devices is halted successfully
-func (h *MMA7660Driver) Halt() (err error) { return }
 
 // Acceleration returns the acceleration of the provided x, y, z
-func (h *MMA7660Driver) Acceleration(x, y, z float64) (ax, ay, az float64) {
+func (d *MMA7660Driver) Acceleration(x, y, z float64) (ax, ay, az float64) {
 	return x / 21.0, y / 21.0, z / 21.0
 }
 
 // XYZ returns the raw x,y and z axis from the mma7660
-func (h *MMA7660Driver) XYZ() (x float64, y float64, z float64, err error) {
+func (d *MMA7660Driver) XYZ() (x float64, y float64, z float64, err error) {
 	buf := []byte{0, 0, 0}
-	bytesRead, err := h.connection.Read(buf)
+	bytesRead, err := d.connection.Read(buf)
 	if err != nil {
 		return
 	}
@@ -127,4 +82,20 @@ func (h *MMA7660Driver) XYZ() (x float64, y float64, z float64, err error) {
 	z = float64((int8(buf[2]) << 2)) / 4.0
 
 	return
+}
+
+func (d *MMA7660Driver) initialize() error {
+	if _, err := d.connection.Write([]byte{MMA7660_MODE, MMA7660_STAND_BY}); err != nil {
+		return err
+	}
+
+	if _, err := d.connection.Write([]byte{MMA7660_SR, MMA7660_AUTO_SLEEP_32}); err != nil {
+		return err
+	}
+
+	if _, err := d.connection.Write([]byte{MMA7660_MODE, MMA7660_ACTIVE}); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/drivers/i2c/mma7660_driver_test.go
+++ b/drivers/i2c/mma7660_driver_test.go
@@ -31,6 +31,7 @@ func TestNewMMA7660Driver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "MMA7660"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x4c)
 }
 
 func TestMMA7660Options(t *testing.T) {

--- a/drivers/i2c/mpu6050_driver_test.go
+++ b/drivers/i2c/mpu6050_driver_test.go
@@ -23,7 +23,6 @@ func initTestMPU6050WithStubbedAdaptor() (*MPU6050Driver, *i2cTestAdaptor) {
 }
 
 func TestNewMPU6050Driver(t *testing.T) {
-	// Does it return a pointer to an instance of MPU6050Driver?
 	var di interface{} = NewMPU6050Driver(newI2cTestAdaptor())
 	d, ok := di.(*MPU6050Driver)
 	if !ok {

--- a/drivers/i2c/mpu6050_driver_test.go
+++ b/drivers/i2c/mpu6050_driver_test.go
@@ -30,6 +30,7 @@ func TestNewMPU6050Driver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.name, "MPU6050"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x68)
 	gobottest.Assert(t, d.dlpf, MPU6050DlpfConfig(0x00))
 	gobottest.Assert(t, d.frameSync, MPU6050FrameSyncConfig(0x00))
 	gobottest.Assert(t, d.accelFs, MPU6050AccelFsConfig(0x00))

--- a/drivers/i2c/pca9501_driver.go
+++ b/drivers/i2c/pca9501_driver.go
@@ -151,8 +151,8 @@ func (p *PCA9501Driver) WriteEEPROM(address uint8, val uint8) error {
 
 func (p *PCA9501Driver) initialize() (err error) {
 	// initialize the EEPROM connection
-	bus := p.GetBusOrDefault(p.connector.DefaultBus())
+	bus := p.GetBusOrDefault(p.connector.DefaultI2cBus())
 	addressMem := p.GetAddressOrDefault(pca9501DefaultAddress) | 0x40
-	p.connectionMem, err = p.connector.GetConnection(addressMem, bus)
+	p.connectionMem, err = p.connector.GetI2cConnection(addressMem, bus)
 	return
 }

--- a/drivers/i2c/pca9501_driver_test.go
+++ b/drivers/i2c/pca9501_driver_test.go
@@ -49,6 +49,7 @@ func TestNewPCA9501Driver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "PCA9501"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x3f)
 }
 
 func TestPCA9501Options(t *testing.T) {

--- a/drivers/i2c/pca9501_driver_test.go
+++ b/drivers/i2c/pca9501_driver_test.go
@@ -2,6 +2,7 @@ package i2c
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"gobot.io/x/gobot"
@@ -32,7 +33,9 @@ var (
 func initPCA9501WithStubbedAdaptor() (*PCA9501Driver, *i2cTestAdaptor) {
 	a := newI2cTestAdaptor()
 	d := NewPCA9501Driver(a)
-	d.Start()
+	if err := d.Start(); err != nil {
+		panic(err)
+	}
 	return d, a
 }
 
@@ -45,6 +48,14 @@ func TestNewPCA9501Driver(t *testing.T) {
 		t.Errorf("NewPCA9501Driver() should have returned a *PCA9501Driver")
 	}
 	gobottest.Refute(t, d.Driver, nil)
+	gobottest.Assert(t, strings.HasPrefix(d.Name(), "PCA9501"), true)
+}
+
+func TestPCA9501Options(t *testing.T) {
+	// This is a general test, that options are applied in constructor by using the common WithBus() option and
+	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".
+	d := NewPCA9501Driver(newI2cTestAdaptor(), WithBus(2))
+	gobottest.Assert(t, d.GetBusOrDefault(1), 2)
 }
 
 func TestPCA9501CommandsWriteGPIO(t *testing.T) {

--- a/drivers/i2c/pca953x_driver_test.go
+++ b/drivers/i2c/pca953x_driver_test.go
@@ -31,6 +31,7 @@ func TestNewPCA953xDriver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "PCA953x"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x63)
 }
 
 func TestPCA953xWriteGPIO(t *testing.T) {

--- a/drivers/i2c/pca9685_driver_test.go
+++ b/drivers/i2c/pca9685_driver_test.go
@@ -35,6 +35,7 @@ func TestNewPCA9685Driver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "PCA9685"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x40)
 }
 
 func TestPCA9685Options(t *testing.T) {

--- a/drivers/i2c/pcf8583_driver_test.go
+++ b/drivers/i2c/pcf8583_driver_test.go
@@ -28,6 +28,7 @@ func TestNewPCF8583Driver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.name, "PCF8583"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x50)
 	gobottest.Assert(t, d.mode, PCF8583Control(0x00))
 	gobottest.Assert(t, d.yearOffset, 0)
 	gobottest.Assert(t, d.ramOffset, uint8(0x10))

--- a/drivers/i2c/pcf8591_driver_test.go
+++ b/drivers/i2c/pcf8591_driver_test.go
@@ -30,6 +30,7 @@ func TestNewPCF8591Driver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "PCF8591"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x48)
 }
 
 func TestPCF8591Start(t *testing.T) {

--- a/drivers/i2c/pcf8591_driver_test.go
+++ b/drivers/i2c/pcf8591_driver_test.go
@@ -1,42 +1,70 @@
 package i2c
 
 import (
+	"strings"
 	"testing"
 
+	"gobot.io/x/gobot"
 	"gobot.io/x/gobot/gobottest"
 )
 
+// this ensures that the implementation is based on i2c.Driver, which implements the gobot.Driver
+// and tests all implementations, so no further tests needed here for gobot.Driver interface
+var _ gobot.Driver = (*PCF8591Driver)(nil)
+
 func initTestPCF8591DriverWithStubbedAdaptor() (*PCF8591Driver, *i2cTestAdaptor) {
-	adaptor := newI2cTestAdaptor()
-	pcf := NewPCF8591Driver(adaptor, WithPCF8591With400kbitStabilization(0, 2))
-	pcf.lastCtrlByte = 0xFF // prevent skipping of write
-	pcf.Start()
-	return pcf, adaptor
+	a := newI2cTestAdaptor()
+	d := NewPCF8591Driver(a, WithPCF8591With400kbitStabilization(0, 2))
+	d.lastCtrlByte = 0xFF // prevent skipping of write
+	if err := d.Start(); err != nil {
+		panic(err)
+	}
+	return d, a
 }
 
-func TestPCF8591DriverWithPCF8591With400kbitStabilization(t *testing.T) {
-	pcf := NewPCF8591Driver(newI2cTestAdaptor(), WithPCF8591With400kbitStabilization(5, 6))
-	gobottest.Assert(t, pcf.additionalReadWrite, uint8(5))
-	gobottest.Assert(t, pcf.additionalRead, uint8(6))
+func TestNewPCF8591Driver(t *testing.T) {
+	var di interface{} = NewPCF8591Driver(newI2cTestAdaptor())
+	d, ok := di.(*PCF8591Driver)
+	if !ok {
+		t.Errorf("NewPCF8591Driver() should have returned a *PCF8591Driver")
+	}
+	gobottest.Refute(t, d.Driver, nil)
+	gobottest.Assert(t, strings.HasPrefix(d.Name(), "PCF8591"), true)
 }
 
-func TestPCF8591DriverAnalogReadSingle(t *testing.T) {
+func TestPCF8591Start(t *testing.T) {
+	d := NewPCF8591Driver(newI2cTestAdaptor())
+	gobottest.Assert(t, d.Start(), nil)
+}
+
+func TestPCF8591Halt(t *testing.T) {
+	d := NewPCF8591Driver(newI2cTestAdaptor())
+	gobottest.Assert(t, d.Halt(), nil)
+}
+
+func TestPCF8591WithPCF8591With400kbitStabilization(t *testing.T) {
+	d := NewPCF8591Driver(newI2cTestAdaptor(), WithPCF8591With400kbitStabilization(5, 6))
+	gobottest.Assert(t, d.additionalReadWrite, uint8(5))
+	gobottest.Assert(t, d.additionalRead, uint8(6))
+}
+
+func TestPCF8591AnalogReadSingle(t *testing.T) {
 	// sequence to read the input channel:
 	// * prepare value (with channel and mode) and write control register
 	// * read 3 values to drop (see description in implementation)
 	// * read the analog value
 	//
 	// arrange
-	pcf, adaptor := initTestPCF8591DriverWithStubbedAdaptor()
-	adaptor.written = []byte{} // reset writes of Start() and former test
+	d, a := initTestPCF8591DriverWithStubbedAdaptor()
+	a.written = []byte{} // reset writes of Start() and former test
 	description := "s.1"
-	pcf.lastCtrlByte = 0x00
+	d.lastCtrlByte = 0x00
 	ctrlByteOn := uint8(pcf8591_ALLSINGLE) | uint8(pcf8591_CHAN1)
 	returnRead := []uint8{0x01, 0x02, 0x03, 0xFF}
 	want := int(returnRead[3])
 	// arrange reads
 	numCallsRead := 0
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		numCallsRead++
 		if numCallsRead == 1 {
 			b = returnRead[0:len(b)]
@@ -47,16 +75,16 @@ func TestPCF8591DriverAnalogReadSingle(t *testing.T) {
 		return len(b), nil
 	}
 	// act
-	got, err := pcf.AnalogRead(description)
+	got, err := d.AnalogRead(description)
 	// assert
 	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, len(adaptor.written), 1)
-	gobottest.Assert(t, adaptor.written[0], ctrlByteOn)
+	gobottest.Assert(t, len(a.written), 1)
+	gobottest.Assert(t, a.written[0], ctrlByteOn)
 	gobottest.Assert(t, numCallsRead, 2)
 	gobottest.Assert(t, got, want)
 }
 
-func TestPCF8591DriverAnalogReadDiff(t *testing.T) {
+func TestPCF8591AnalogReadDiff(t *testing.T) {
 	// sequence to read the input channel:
 	// * prepare value (with channel and mode) and write control register
 	// * read 3 values to drop (see description in implementation)
@@ -64,10 +92,10 @@ func TestPCF8591DriverAnalogReadDiff(t *testing.T) {
 	// * convert to 8-bit two's complement (-127...128)
 	//
 	// arrange
-	pcf, adaptor := initTestPCF8591DriverWithStubbedAdaptor()
-	adaptor.written = []byte{} // reset writes of Start() and former test
+	d, a := initTestPCF8591DriverWithStubbedAdaptor()
+	a.written = []byte{} // reset writes of Start() and former test
 	description := "m.2-3"
-	pcf.lastCtrlByte = 0x00
+	d.lastCtrlByte = 0x00
 	ctrlByteOn := uint8(pcf8591_MIXED) | uint8(pcf8591_CHAN2)
 	// some two' complements
 	// 0x80 => -128
@@ -78,7 +106,7 @@ func TestPCF8591DriverAnalogReadDiff(t *testing.T) {
 	want := -1
 	// arrange reads
 	numCallsRead := 0
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		numCallsRead++
 		if numCallsRead == 1 {
 			b = returnRead[0:len(b)]
@@ -89,77 +117,61 @@ func TestPCF8591DriverAnalogReadDiff(t *testing.T) {
 		return len(b), nil
 	}
 	// act
-	got, err := pcf.AnalogRead(description)
+	got, err := d.AnalogRead(description)
 	// assert
 	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, len(adaptor.written), 1)
-	gobottest.Assert(t, adaptor.written[0], ctrlByteOn)
+	gobottest.Assert(t, len(a.written), 1)
+	gobottest.Assert(t, a.written[0], ctrlByteOn)
 	gobottest.Assert(t, numCallsRead, 2)
 	gobottest.Assert(t, got, want)
 }
 
-func TestPCF8591DriverAnalogWrite(t *testing.T) {
+func TestPCF8591AnalogWrite(t *testing.T) {
 	// sequence to write the output:
 	// * create new value for the control register (ANAON)
 	// * write the control register and value
 	//
 	// arrange
-	pcf, adaptor := initTestPCF8591DriverWithStubbedAdaptor()
-	adaptor.written = []byte{} // reset writes of Start() and former test
-	pcf.lastCtrlByte = 0x00
-	pcf.lastAnaOut = 0x00
+	d, a := initTestPCF8591DriverWithStubbedAdaptor()
+	a.written = []byte{} // reset writes of Start() and former test
+	d.lastCtrlByte = 0x00
+	d.lastAnaOut = 0x00
 	ctrlByteOn := uint8(pcf8591_ANAON)
 	want := uint8(0x15)
 	// arrange writes
-	adaptor.i2cWriteImpl = func(b []byte) (int, error) {
+	a.i2cWriteImpl = func(b []byte) (int, error) {
 		return len(b), nil
 	}
 	// act
-	err := pcf.AnalogWrite("", int(want))
+	err := d.AnalogWrite("", int(want))
 	// assert
 	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, len(adaptor.written), 2)
-	gobottest.Assert(t, adaptor.written[0], ctrlByteOn)
-	gobottest.Assert(t, adaptor.written[1], want)
+	gobottest.Assert(t, len(a.written), 2)
+	gobottest.Assert(t, a.written[0], ctrlByteOn)
+	gobottest.Assert(t, a.written[1], want)
 }
 
-func TestPCF8591DriverAnalogOutputState(t *testing.T) {
+func TestPCF8591AnalogOutputState(t *testing.T) {
 	// sequence to set the state:
 	// * create the new value (ctrlByte) for the control register (ANAON)
 	// * write the register value
 	//
 	// arrange
-	pcf, adaptor := initTestPCF8591DriverWithStubbedAdaptor()
+	d, a := initTestPCF8591DriverWithStubbedAdaptor()
 	for bitState := 0; bitState <= 1; bitState++ {
-		adaptor.written = []byte{} // reset writes of Start() and former test
+		a.written = []byte{} // reset writes of Start() and former test
 		// arrange some values
-		pcf.lastCtrlByte = uint8(0x00)
+		d.lastCtrlByte = uint8(0x00)
 		wantCtrlByteVal := uint8(pcf8591_ANAON)
 		if bitState == 0 {
-			pcf.lastCtrlByte = uint8(0xFF)
+			d.lastCtrlByte = uint8(0xFF)
 			wantCtrlByteVal = uint8(0xFF & ^pcf8591_ANAON)
 		}
 		// act
-		err := pcf.AnalogOutputState(bitState == 1)
+		err := d.AnalogOutputState(bitState == 1)
 		// assert
 		gobottest.Assert(t, err, nil)
-		gobottest.Assert(t, len(adaptor.written), 1)
-		gobottest.Assert(t, adaptor.written[0], wantCtrlByteVal)
+		gobottest.Assert(t, len(a.written), 1)
+		gobottest.Assert(t, a.written[0], wantCtrlByteVal)
 	}
-}
-
-func TestPCF8591DriverStart(t *testing.T) {
-	yl := NewPCF8591Driver(newI2cTestAdaptor())
-	gobottest.Assert(t, yl.Start(), nil)
-}
-
-func TestPCF8591DriverHalt(t *testing.T) {
-	yl := NewPCF8591Driver(newI2cTestAdaptor())
-	gobottest.Assert(t, yl.Halt(), nil)
-}
-
-func TestPCF8591DriverSetName(t *testing.T) {
-	d := NewPCF8591Driver(newI2cTestAdaptor())
-	d.SetName("TESTME")
-	gobottest.Assert(t, d.Name(), "TESTME")
 }

--- a/drivers/i2c/sht2x_driver.go
+++ b/drivers/i2c/sht2x_driver.go
@@ -27,10 +27,9 @@ import (
 	"github.com/sigurn/crc8"
 )
 
-const (
-	// SHT2xDefaultAddress is the default I2C address for SHT2x
-	SHT2xDefaultAddress = 0x40
+const sht2xDefaultAddress = 0x40
 
+const (
 	// SHT2xAccuracyLow is the faster, but lower accuracy sample setting
 	//  0/1 = 8bit RH, 12bit Temp
 	SHT2xAccuracyLow = byte(0x01)
@@ -86,9 +85,17 @@ type SHT2xDriver struct {
 //
 func NewSHT2xDriver(c Connector, options ...func(Config)) *SHT2xDriver {
 	// From the document "CRC Checksum Calculation -- For Safe Communication with SHT2x Sensors":
-	crc8Params := crc8.Params{0x31, 0x00, false, false, 0x00, 0x00, "CRC-8/SENSIRION-SHT2x"}
+	crc8Params := crc8.Params{
+		Poly:   0x31,
+		Init:   0x00,
+		RefIn:  false,
+		RefOut: false,
+		XorOut: 0x00,
+		Check:  0x00,
+		Name:   "CRC-8/SENSIRION-SHT2x",
+	}
 	d := &SHT2xDriver{
-		Driver:   NewDriver(c, "SHT2x", SHT2xDefaultAddress),
+		Driver:   NewDriver(c, "SHT2x", sht2xDefaultAddress),
 		Units:    "C",
 		crcTable: crc8.MakeTable(crc8Params),
 	}

--- a/drivers/i2c/sht2x_driver.go
+++ b/drivers/i2c/sht2x_driver.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/sigurn/crc8"
-	"gobot.io/x/gobot"
 )
 
 const (
@@ -69,12 +68,8 @@ const (
 
 // SHT2xDriver is a Driver for a SHT2x humidity and temperature sensor
 type SHT2xDriver struct {
-	Units string
-
-	name       string
-	connector  Connector
-	connection Connection
-	Config
+	*Driver
+	Units        string
 	sht2xAddress int
 	accuracy     byte
 	delay        time.Duration
@@ -83,59 +78,28 @@ type SHT2xDriver struct {
 
 // NewSHT2xDriver creates a new driver with specified i2c interface
 // Params:
-//		conn Connector - the Adaptor to use with this Driver
+//		c Connector - the Adaptor to use with this Driver
 //
 // Optional params:
 //		i2c.WithBus(int):	bus to use with this driver
 //		i2c.WithAddress(int):	address to use with this driver
 //
-func NewSHT2xDriver(a Connector, options ...func(Config)) *SHT2xDriver {
+func NewSHT2xDriver(c Connector, options ...func(Config)) *SHT2xDriver {
 	// From the document "CRC Checksum Calculation -- For Safe Communication with SHT2x Sensors":
 	crc8Params := crc8.Params{0x31, 0x00, false, false, 0x00, 0x00, "CRC-8/SENSIRION-SHT2x"}
-	s := &SHT2xDriver{
-		Units:     "C",
-		name:      gobot.DefaultName("SHT2x"),
-		connector: a,
-		Config:    NewConfig(),
-		crcTable:  crc8.MakeTable(crc8Params),
+	d := &SHT2xDriver{
+		Driver:   NewDriver(c, "SHT2x", SHT2xDefaultAddress),
+		Units:    "C",
+		crcTable: crc8.MakeTable(crc8Params),
 	}
+	d.afterStart = d.initialize
 
 	for _, option := range options {
-		option(s)
+		option(d)
 	}
 
-	return s
+	return d
 }
-
-// Name returns the name for this Driver
-func (d *SHT2xDriver) Name() string { return d.name }
-
-// SetName sets the name for this Driver
-func (d *SHT2xDriver) SetName(n string) { d.name = n }
-
-// Connection returns the connection for this Driver
-func (d *SHT2xDriver) Connection() gobot.Connection { return d.connector.(gobot.Connection) }
-
-// Start initializes the SHT2x
-func (d *SHT2xDriver) Start() (err error) {
-	bus := d.GetBusOrDefault(d.connector.DefaultBus())
-	address := d.GetAddressOrDefault(SHT2xDefaultAddress)
-
-	if d.connection, err = d.connector.GetConnection(address, bus); err != nil {
-		return
-	}
-
-	if err = d.Reset(); err != nil {
-		return
-	}
-
-	d.sendAccuracy()
-
-	return
-}
-
-// Halt returns true if devices is halted successfully
-func (d *SHT2xDriver) Halt() (err error) { return }
 
 func (d *SHT2xDriver) Accuracy() byte { return d.accuracy }
 
@@ -228,6 +192,16 @@ func (d *SHT2xDriver) readSensor(cmd byte) (read uint16, err error) {
 	read &= 0xfffc // clear two low bits (status bits)
 
 	return
+}
+
+func (d *SHT2xDriver) initialize() error {
+	if err := d.Reset(); err != nil {
+		return err
+	}
+
+	d.sendAccuracy()
+
+	return nil
 }
 
 func (d *SHT2xDriver) sendAccuracy() (err error) {

--- a/drivers/i2c/sht2x_driver_test.go
+++ b/drivers/i2c/sht2x_driver_test.go
@@ -31,6 +31,7 @@ func TestNewSHT2xDriver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "SHT2x"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x40)
 }
 
 func TestSHT2xOptions(t *testing.T) {

--- a/drivers/i2c/sht2x_driver_test.go
+++ b/drivers/i2c/sht2x_driver_test.go
@@ -3,187 +3,170 @@ package i2c
 import (
 	"bytes"
 	"errors"
+	"strings"
 	"testing"
 
 	"gobot.io/x/gobot"
 	"gobot.io/x/gobot/gobottest"
 )
 
+// this ensures that the implementation is based on i2c.Driver, which implements the gobot.Driver
+// and tests all implementations, so no further tests needed here for gobot.Driver interface
 var _ gobot.Driver = (*SHT2xDriver)(nil)
 
-// --------- HELPERS
-func initTestSHT2xDriver() (driver *SHT2xDriver) {
-	driver, _ = initTestSHT2xDriverWithStubbedAdaptor()
-	return
-}
-
 func initTestSHT2xDriverWithStubbedAdaptor() (*SHT2xDriver, *i2cTestAdaptor) {
-	adaptor := newI2cTestAdaptor()
-	return NewSHT2xDriver(adaptor), adaptor
+	a := newI2cTestAdaptor()
+	d := NewSHT2xDriver(a)
+	if err := d.Start(); err != nil {
+		panic(err)
+	}
+	return d, a
 }
-
-// --------- TESTS
 
 func TestNewSHT2xDriver(t *testing.T) {
-	// Does it return a pointer to an instance of SHT2xDriver?
-	var sht2x interface{} = NewSHT2xDriver(newI2cTestAdaptor())
-	_, ok := sht2x.(*SHT2xDriver)
+	var di interface{} = NewSHT2xDriver(newI2cTestAdaptor())
+	d, ok := di.(*SHT2xDriver)
 	if !ok {
 		t.Errorf("NewSHT2xDriver() should have returned a *SHT2xDriver")
 	}
+	gobottest.Refute(t, d.Driver, nil)
+	gobottest.Assert(t, strings.HasPrefix(d.Name(), "SHT2x"), true)
 }
 
-func TestSHT2xDriver(t *testing.T) {
-	sht2x := initTestSHT2xDriver()
-	gobottest.Refute(t, sht2x.Connection(), nil)
+func TestSHT2xOptions(t *testing.T) {
+	// This is a general test, that options are applied in constructor by using the common WithBus() option and
+	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".
+	b := NewSHT2xDriver(newI2cTestAdaptor(), WithBus(2))
+	gobottest.Assert(t, b.GetBusOrDefault(1), 2)
 }
 
-func TestSHT2xDriverStart(t *testing.T) {
-	sht2x, _ := initTestSHT2xDriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, sht2x.Start(), nil)
+func TestSHT2xStart(t *testing.T) {
+	d := NewSHT2xDriver(newI2cTestAdaptor())
+	gobottest.Assert(t, d.Start(), nil)
 }
 
-func TestSHT2xStartConnectError(t *testing.T) {
-	d, adaptor := initTestSHT2xDriverWithStubbedAdaptor()
-	adaptor.Testi2cConnectErr(true)
-	gobottest.Assert(t, d.Start(), errors.New("Invalid i2c connection"))
+func TestSHT2xHalt(t *testing.T) {
+	d, _ := initTestSHT2xDriverWithStubbedAdaptor()
+	gobottest.Assert(t, d.Halt(), nil)
 }
 
-func TestSHT2xDriverHalt(t *testing.T) {
-	sht2x := initTestSHT2xDriver()
-
-	gobottest.Assert(t, sht2x.Halt(), nil)
-}
-
-func TestSHT2xDriverReset(t *testing.T) {
-	sht2x, adaptor := initTestSHT2xDriverWithStubbedAdaptor()
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+func TestSHT2xReset(t *testing.T) {
+	d, a := initTestSHT2xDriverWithStubbedAdaptor()
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		return 0, nil
 	}
-	sht2x.Start()
-	err := sht2x.Reset()
+	d.Start()
+	err := d.Reset()
 	gobottest.Assert(t, err, nil)
 }
 
-func TestSHT2xDriverMeasurements(t *testing.T) {
-	sht2x, adaptor := initTestSHT2xDriverWithStubbedAdaptor()
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+func TestSHT2xMeasurements(t *testing.T) {
+	d, a := initTestSHT2xDriverWithStubbedAdaptor()
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		buf := new(bytes.Buffer)
 		// Values produced by dumping data from actual sensor
-		if adaptor.written[len(adaptor.written)-1] == SHT2xTriggerTempMeasureNohold {
+		if a.written[len(a.written)-1] == SHT2xTriggerTempMeasureNohold {
 			buf.Write([]byte{95, 168, 59})
-		} else if adaptor.written[len(adaptor.written)-1] == SHT2xTriggerHumdMeasureNohold {
+		} else if a.written[len(a.written)-1] == SHT2xTriggerHumdMeasureNohold {
 			buf.Write([]byte{94, 202, 22})
 		}
 		copy(b, buf.Bytes())
 		return buf.Len(), nil
 	}
-	sht2x.Start()
-	temp, err := sht2x.Temperature()
+	d.Start()
+	temp, err := d.Temperature()
 	gobottest.Assert(t, err, nil)
 	gobottest.Assert(t, temp, float32(18.809052))
-	hum, err := sht2x.Humidity()
+	hum, err := d.Humidity()
 	gobottest.Assert(t, err, nil)
 	gobottest.Assert(t, hum, float32(40.279907))
 }
 
-func TestSHT2xDriverAccuracy(t *testing.T) {
-	sht2x, adaptor := initTestSHT2xDriverWithStubbedAdaptor()
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+func TestSHT2xAccuracy(t *testing.T) {
+	d, a := initTestSHT2xDriverWithStubbedAdaptor()
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		buf := new(bytes.Buffer)
-		if adaptor.written[len(adaptor.written)-1] == SHT2xReadUserReg {
+		if a.written[len(a.written)-1] == SHT2xReadUserReg {
 			buf.Write([]byte{0x3a})
-		} else if adaptor.written[len(adaptor.written)-2] == SHT2xWriteUserReg {
-			buf.Write([]byte{adaptor.written[len(adaptor.written)-1]})
+		} else if a.written[len(a.written)-2] == SHT2xWriteUserReg {
+			buf.Write([]byte{a.written[len(a.written)-1]})
 		} else {
 			return 0, nil
 		}
 		copy(b, buf.Bytes())
 		return buf.Len(), nil
 	}
-	sht2x.Start()
-	sht2x.SetAccuracy(SHT2xAccuracyLow)
-	gobottest.Assert(t, sht2x.Accuracy(), SHT2xAccuracyLow)
-	err := sht2x.sendAccuracy()
+	d.Start()
+	d.SetAccuracy(SHT2xAccuracyLow)
+	gobottest.Assert(t, d.Accuracy(), SHT2xAccuracyLow)
+	err := d.sendAccuracy()
 	gobottest.Assert(t, err, nil)
 }
 
-func TestSHT2xDriverTemperatureCrcError(t *testing.T) {
-	sht2x, adaptor := initTestSHT2xDriverWithStubbedAdaptor()
-	sht2x.Start()
+func TestSHT2xTemperatureCrcError(t *testing.T) {
+	d, a := initTestSHT2xDriverWithStubbedAdaptor()
+	d.Start()
 
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		buf := new(bytes.Buffer)
-		if adaptor.written[len(adaptor.written)-1] == SHT2xTriggerTempMeasureNohold {
+		if a.written[len(a.written)-1] == SHT2xTriggerTempMeasureNohold {
 			buf.Write([]byte{95, 168, 0})
 		}
 		copy(b, buf.Bytes())
 		return buf.Len(), nil
 	}
-	temp, err := sht2x.Temperature()
+	temp, err := d.Temperature()
 	gobottest.Assert(t, err, errors.New("Invalid crc"))
 	gobottest.Assert(t, temp, float32(0.0))
 }
 
-func TestSHT2xDriverHumidityCrcError(t *testing.T) {
-	sht2x, adaptor := initTestSHT2xDriverWithStubbedAdaptor()
-	sht2x.Start()
+func TestSHT2xHumidityCrcError(t *testing.T) {
+	d, a := initTestSHT2xDriverWithStubbedAdaptor()
+	d.Start()
 
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		buf := new(bytes.Buffer)
-		if adaptor.written[len(adaptor.written)-1] == SHT2xTriggerHumdMeasureNohold {
+		if a.written[len(a.written)-1] == SHT2xTriggerHumdMeasureNohold {
 			buf.Write([]byte{94, 202, 0})
 		}
 		copy(b, buf.Bytes())
 		return buf.Len(), nil
 	}
-	hum, err := sht2x.Humidity()
+	hum, err := d.Humidity()
 	gobottest.Assert(t, err, errors.New("Invalid crc"))
 	gobottest.Assert(t, hum, float32(0.0))
 }
 
-func TestSHT2xDriverTemperatureLengthError(t *testing.T) {
-	sht2x, adaptor := initTestSHT2xDriverWithStubbedAdaptor()
-	sht2x.Start()
+func TestSHT2xTemperatureLengthError(t *testing.T) {
+	d, a := initTestSHT2xDriverWithStubbedAdaptor()
+	d.Start()
 
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		buf := new(bytes.Buffer)
-		if adaptor.written[len(adaptor.written)-1] == SHT2xTriggerTempMeasureNohold {
+		if a.written[len(a.written)-1] == SHT2xTriggerTempMeasureNohold {
 			buf.Write([]byte{95, 168})
 		}
 		copy(b, buf.Bytes())
 		return buf.Len(), nil
 	}
-	temp, err := sht2x.Temperature()
+	temp, err := d.Temperature()
 	gobottest.Assert(t, err, ErrNotEnoughBytes)
 	gobottest.Assert(t, temp, float32(0.0))
 }
 
-func TestSHT2xDriverHumidityLengthError(t *testing.T) {
-	sht2x, adaptor := initTestSHT2xDriverWithStubbedAdaptor()
-	sht2x.Start()
+func TestSHT2xHumidityLengthError(t *testing.T) {
+	d, a := initTestSHT2xDriverWithStubbedAdaptor()
+	d.Start()
 
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		buf := new(bytes.Buffer)
-		if adaptor.written[len(adaptor.written)-1] == SHT2xTriggerHumdMeasureNohold {
+		if a.written[len(a.written)-1] == SHT2xTriggerHumdMeasureNohold {
 			buf.Write([]byte{94, 202})
 		}
 		copy(b, buf.Bytes())
 		return buf.Len(), nil
 	}
-	hum, err := sht2x.Humidity()
+	hum, err := d.Humidity()
 	gobottest.Assert(t, err, ErrNotEnoughBytes)
 	gobottest.Assert(t, hum, float32(0.0))
-}
-
-func TestSHT2xDriverSetName(t *testing.T) {
-	b := initTestSHT2xDriver()
-	b.SetName("TESTME")
-	gobottest.Assert(t, b.Name(), "TESTME")
-}
-
-func TestSHT2xDriverOptions(t *testing.T) {
-	b := NewSHT2xDriver(newI2cTestAdaptor(), WithBus(2))
-	gobottest.Assert(t, b.GetBusOrDefault(1), 2)
 }

--- a/drivers/i2c/sht3x_driver.go
+++ b/drivers/i2c/sht3x_driver.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/sigurn/crc8"
-	"gobot.io/x/gobot"
 )
 
 // SHT3xAddressA is the default address of device
@@ -53,34 +52,26 @@ var (
 
 // SHT3xDriver is a Driver for a SHT3x humidity and temperature sensor
 type SHT3xDriver struct {
-	Units string
-
-	name       string
-	connector  Connector
-	connection Connection
-	Config
-	sht3xAddress int
-	accuracy     byte
-	delay        time.Duration
-	crcTable     *crc8.Table
+	*Driver
+	Units    string
+	accuracy byte
+	delay    time.Duration
+	crcTable *crc8.Table
 }
 
 // NewSHT3xDriver creates a new driver with specified i2c interface
 // Params:
-//		conn Connector - the Adaptor to use with this Driver
+//		c Connector - the Adaptor to use with this Driver
 //
 // Optional params:
 //		i2c.WithBus(int):	bus to use with this driver
 //		i2c.WithAddress(int):	address to use with this driver
 //
-func NewSHT3xDriver(a Connector, options ...func(Config)) *SHT3xDriver {
+func NewSHT3xDriver(c Connector, options ...func(Config)) *SHT3xDriver {
 	s := &SHT3xDriver{
-		Units:        "C",
-		name:         gobot.DefaultName("SHT3x"),
-		connector:    a,
-		Config:       NewConfig(),
-		sht3xAddress: SHT3xAddressA,
-		crcTable:     crc8.MakeTable(crc8Params),
+		Driver:   NewDriver(c, "SHT3x", SHT3xAddressA),
+		Units:    "C",
+		crcTable: crc8.MakeTable(crc8Params),
 	}
 	s.SetAccuracy(SHT3xAccuracyHigh)
 
@@ -90,30 +81,6 @@ func NewSHT3xDriver(a Connector, options ...func(Config)) *SHT3xDriver {
 
 	return s
 }
-
-// Name returns the name for this Driver
-func (s *SHT3xDriver) Name() string { return s.name }
-
-// SetName sets the name for this Driver
-func (s *SHT3xDriver) SetName(n string) { s.name = n }
-
-// Connection returns the connection for this Driver
-func (s *SHT3xDriver) Connection() gobot.Connection { return s.connector.(gobot.Connection) }
-
-// Start initializes the SHT3x
-func (s *SHT3xDriver) Start() (err error) {
-	bus := s.GetBusOrDefault(s.connector.DefaultBus())
-	address := s.GetAddressOrDefault(s.sht3xAddress)
-
-	s.connection, err = s.connector.GetConnection(address, bus)
-	return
-}
-
-// Halt returns true if devices is halted successfully
-func (s *SHT3xDriver) Halt() (err error) { return }
-
-// SetAddress sets the address of the device
-func (s *SHT3xDriver) SetAddress(address int) { s.sht3xAddress = address }
 
 // Accuracy returns the accuracy of the sampling
 func (s *SHT3xDriver) Accuracy() byte { return s.accuracy }

--- a/drivers/i2c/sht3x_driver_test.go
+++ b/drivers/i2c/sht3x_driver_test.go
@@ -9,263 +9,214 @@ import (
 	"gobot.io/x/gobot/gobottest"
 )
 
+// this ensures that the implementation is based on i2c.Driver, which implements the gobot.Driver
+// and tests all implementations, so no further tests needed here for gobot.Driver interface
 var _ gobot.Driver = (*SHT3xDriver)(nil)
 
-// --------- HELPERS
-func initTestSHT3xDriver() (driver *SHT3xDriver) {
-	driver, _ = initTestSHT3xDriverWithStubbedAdaptor()
-	return
-}
-
 func initTestSHT3xDriverWithStubbedAdaptor() (*SHT3xDriver, *i2cTestAdaptor) {
-	adaptor := newI2cTestAdaptor()
-	return NewSHT3xDriver(adaptor), adaptor
+	a := newI2cTestAdaptor()
+	d := NewSHT3xDriver(a)
+	if err := d.Start(); err != nil {
+		panic(err)
+	}
+	return d, a
 }
-
-// --------- TESTS
 
 func TestNewSHT3xDriver(t *testing.T) {
-	// Does it return a pointer to an instance of SHT3xDriver?
-	var bm interface{} = NewSHT3xDriver(newI2cTestAdaptor())
-	_, ok := bm.(*SHT3xDriver)
+	var di interface{} = NewSHT3xDriver(newI2cTestAdaptor())
+	d, ok := di.(*SHT3xDriver)
 	if !ok {
 		t.Errorf("NewSHT3xDriver() should have returned a *SHT3xDriver")
 	}
-
-	b := NewSHT3xDriver(newI2cTestAdaptor())
-	gobottest.Refute(t, b.Connection(), nil)
+	gobottest.Refute(t, d.Driver, nil)
+	gobottest.Assert(t, strings.HasPrefix(d.Name(), "SHT3x"), true)
 }
 
-// Methods
-
-func TestSHT3xDriverStart(t *testing.T) {
-	sht3x, _ := initTestSHT3xDriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, sht3x.Start(), nil)
-}
-
-func TestSHT3xStartConnectError(t *testing.T) {
-	d, adaptor := initTestSHT3xDriverWithStubbedAdaptor()
-	adaptor.Testi2cConnectErr(true)
-	gobottest.Assert(t, d.Start(), errors.New("Invalid i2c connection"))
-}
-
-func TestSHT3xDriverHalt(t *testing.T) {
-	sht3x := initTestSHT3xDriver()
-
-	gobottest.Assert(t, sht3x.Halt(), nil)
-}
-
-// Test Name & SetName
-func TestSHT3xDriverName(t *testing.T) {
-	sht3x := initTestSHT3xDriver()
-
-	gobottest.Assert(t, strings.HasPrefix(sht3x.Name(), "SHT3x"), true)
-	sht3x.SetName("Sensor")
-	gobottest.Assert(t, sht3x.Name(), "Sensor")
-}
-
-func TestSHT3xDriverOptions(t *testing.T) {
+func TestSHT3xOptions(t *testing.T) {
+	// This is a general test, that options are applied in constructor by using the common WithBus() option and
+	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".
 	d := NewSHT3xDriver(newI2cTestAdaptor(), WithBus(2))
 	gobottest.Assert(t, d.GetBusOrDefault(1), 2)
 }
 
-// Test Accuracy & SetAccuracy
-func TestSHT3xDriverSetAccuracy(t *testing.T) {
-	sht3x := initTestSHT3xDriver()
-
-	gobottest.Assert(t, sht3x.Accuracy(), byte(SHT3xAccuracyHigh))
-
-	err := sht3x.SetAccuracy(SHT3xAccuracyMedium)
-	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, sht3x.Accuracy(), byte(SHT3xAccuracyMedium))
-
-	err = sht3x.SetAccuracy(SHT3xAccuracyLow)
-	gobottest.Assert(t, err, nil)
-	gobottest.Assert(t, sht3x.Accuracy(), byte(SHT3xAccuracyLow))
-
-	err = sht3x.SetAccuracy(0xff)
-	gobottest.Assert(t, err, ErrInvalidAccuracy)
+func TestSHT3xStart(t *testing.T) {
+	d := NewSHT3xDriver(newI2cTestAdaptor())
+	gobottest.Assert(t, d.Start(), nil)
 }
 
-// Test Sample
-func TestSHT3xDriverSampleNormal(t *testing.T) {
-	sht3x, adaptor := initTestSHT3xDriverWithStubbedAdaptor()
+func TestSHT3xHalt(t *testing.T) {
+	d, _ := initTestSHT3xDriverWithStubbedAdaptor()
+	gobottest.Assert(t, d.Halt(), nil)
+}
 
-	gobottest.Assert(t, sht3x.Start(), nil)
-
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+func TestSHT3xSampleNormal(t *testing.T) {
+	d, a := initTestSHT3xDriverWithStubbedAdaptor()
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{0xbe, 0xef, 0x92, 0xbe, 0xef, 0x92})
 		return 6, nil
 	}
 
-	temp, rh, _ := sht3x.Sample()
+	temp, rh, _ := d.Sample()
 	gobottest.Assert(t, temp, float32(85.523003))
 	gobottest.Assert(t, rh, float32(74.5845))
 
 	// check the temp with the units in F
-	sht3x.Units = "F"
-	temp, _, _ = sht3x.Sample()
+	d.Units = "F"
+	temp, _, _ = d.Sample()
 	gobottest.Assert(t, temp, float32(185.9414))
 }
 
-func TestSHT3xDriverSampleBadCrc(t *testing.T) {
-	sht3x, adaptor := initTestSHT3xDriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, sht3x.Start(), nil)
-
+func TestSHT3xSampleBadCrc(t *testing.T) {
+	d, a := initTestSHT3xDriverWithStubbedAdaptor()
 	// Check that the 1st crc failure is caught
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{0xbe, 0xef, 0x00, 0xbe, 0xef, 0x92})
 		return 6, nil
 	}
 
-	_, _, err := sht3x.Sample()
+	_, _, err := d.Sample()
 	gobottest.Assert(t, err, ErrInvalidCrc)
 
 	// Check that the 2nd crc failure is caught
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{0xbe, 0xef, 0x92, 0xbe, 0xef, 0x00})
 		return 6, nil
 	}
 
-	_, _, err = sht3x.Sample()
+	_, _, err = d.Sample()
 	gobottest.Assert(t, err, ErrInvalidCrc)
 }
 
-func TestSHT3xDriverSampleBadRead(t *testing.T) {
-	sht3x, adaptor := initTestSHT3xDriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, sht3x.Start(), nil)
-
+func TestSHT3xSampleBadRead(t *testing.T) {
+	d, a := initTestSHT3xDriverWithStubbedAdaptor()
 	// Check that the 1st crc failure is caught
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{0xbe, 0xef, 0x00, 0xbe, 0xef})
 		return 5, nil
 	}
 
-	_, _, err := sht3x.Sample()
+	_, _, err := d.Sample()
 	gobottest.Assert(t, err, ErrNotEnoughBytes)
 }
 
-func TestSHT3xDriverSampleUnits(t *testing.T) {
-	sht3x, adaptor := initTestSHT3xDriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, sht3x.Start(), nil)
-
+func TestSHT3xSampleUnits(t *testing.T) {
+	d, a := initTestSHT3xDriverWithStubbedAdaptor()
 	// Check that the 1st crc failure is caught
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{0xbe, 0xef, 0x92, 0xbe, 0xef, 0x92})
 		return 6, nil
 	}
 
-	sht3x.Units = "K"
-	_, _, err := sht3x.Sample()
+	d.Units = "K"
+	_, _, err := d.Sample()
 	gobottest.Assert(t, err, ErrInvalidTemp)
 }
 
 // Test internal sendCommandDelayGetResponse
-func TestSHT3xDriverSCDGRIoFailures(t *testing.T) {
-	sht3x, adaptor := initTestSHT3xDriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, sht3x.Start(), nil)
-
+func TestSHT3xSCDGRIoFailures(t *testing.T) {
+	d, a := initTestSHT3xDriverWithStubbedAdaptor()
 	invalidRead := errors.New("Read error")
 	invalidWrite := errors.New("Write error")
 
 	// Only send 5 bytes
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{0xbe, 0xef, 0x92, 0xbe, 0xef})
 		return 5, nil
 	}
 
-	_, err := sht3x.sendCommandDelayGetResponse(nil, nil, 2)
+	_, err := d.sendCommandDelayGetResponse(nil, nil, 2)
 	gobottest.Assert(t, err, ErrNotEnoughBytes)
 
 	// Don't read any bytes and return an error
-	adaptor.i2cReadImpl = func([]byte) (int, error) {
+	a.i2cReadImpl = func([]byte) (int, error) {
 		return 0, invalidRead
 	}
 
-	_, err = sht3x.sendCommandDelayGetResponse(nil, nil, 1)
+	_, err = d.sendCommandDelayGetResponse(nil, nil, 1)
 	gobottest.Assert(t, err, invalidRead)
 
 	// Don't write any bytes and return an error
-	adaptor.i2cWriteImpl = func([]byte) (int, error) {
+	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 42, invalidWrite
 	}
 
-	_, err = sht3x.sendCommandDelayGetResponse(nil, nil, 1)
+	_, err = d.sendCommandDelayGetResponse(nil, nil, 1)
 	gobottest.Assert(t, err, invalidWrite)
 }
 
 // Test Heater and getStatusRegister
-func TestSHT3xDriverHeater(t *testing.T) {
-	sht3x, adaptor := initTestSHT3xDriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, sht3x.Start(), nil)
-
+func TestSHT3xHeater(t *testing.T) {
+	d, a := initTestSHT3xDriverWithStubbedAdaptor()
 	// heater enabled
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{0x20, 0x00, 0x5d})
 		return 3, nil
 	}
 
-	status, err := sht3x.Heater()
+	status, err := d.Heater()
 	gobottest.Assert(t, err, nil)
 	gobottest.Assert(t, status, true)
 
 	// heater disabled
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{0x00, 0x00, 0x81})
 		return 3, nil
 	}
 
-	status, err = sht3x.Heater()
+	status, err = d.Heater()
 	gobottest.Assert(t, err, nil)
 	gobottest.Assert(t, status, false)
 
 	// heater crc failed
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{0x00, 0x00, 0x00})
 		return 3, nil
 	}
 
-	status, err = sht3x.Heater()
+	status, err = d.Heater()
 	gobottest.Assert(t, err, ErrInvalidCrc)
 
 	// heater read failed
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{0x00, 0x00})
 		return 2, nil
 	}
 
-	status, err = sht3x.Heater()
+	status, err = d.Heater()
 	gobottest.Refute(t, err, nil)
 }
 
-// Test SetHeater
-func TestSHT3xDriverSetHeater(t *testing.T) {
-	sht3x, _ := initTestSHT3xDriverWithStubbedAdaptor()
-
-	gobottest.Assert(t, sht3x.Start(), nil)
-
-	sht3x.SetHeater(false)
-	sht3x.SetHeater(true)
+func TestSHT3xSetHeater(t *testing.T) {
+	d, _ := initTestSHT3xDriverWithStubbedAdaptor()
+	d.SetHeater(false)
+	d.SetHeater(true)
 }
 
-// Test SerialNumber
-func TestSHT3xDriverSerialNumber(t *testing.T) {
-	sht3x, adaptor := initTestSHT3xDriverWithStubbedAdaptor()
+func TestSHT3xSetAccuracy(t *testing.T) {
+	d, _ := initTestSHT3xDriverWithStubbedAdaptor()
 
-	gobottest.Assert(t, sht3x.Start(), nil)
+	gobottest.Assert(t, d.Accuracy(), byte(SHT3xAccuracyHigh))
 
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	err := d.SetAccuracy(SHT3xAccuracyMedium)
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, d.Accuracy(), byte(SHT3xAccuracyMedium))
+
+	err = d.SetAccuracy(SHT3xAccuracyLow)
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, d.Accuracy(), byte(SHT3xAccuracyLow))
+
+	err = d.SetAccuracy(0xff)
+	gobottest.Assert(t, err, ErrInvalidAccuracy)
+}
+
+func TestSHT3xSerialNumber(t *testing.T) {
+	d, a := initTestSHT3xDriverWithStubbedAdaptor()
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{0x20, 0x00, 0x5d, 0xbe, 0xef, 0x92})
 		return 6, nil
 	}
 
-	sn, err := sht3x.SerialNumber()
+	sn, err := d.SerialNumber()
 
 	gobottest.Assert(t, err, nil)
 	gobottest.Assert(t, sn, uint32(0x2000beef))

--- a/drivers/i2c/sht3x_driver_test.go
+++ b/drivers/i2c/sht3x_driver_test.go
@@ -30,6 +30,7 @@ func TestNewSHT3xDriver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "SHT3x"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x44)
 }
 
 func TestSHT3xOptions(t *testing.T) {

--- a/drivers/i2c/ssd1306_driver.go
+++ b/drivers/i2c/ssd1306_driver.go
@@ -3,9 +3,9 @@ package i2c
 import (
 	"fmt"
 	"image"
-
-	"gobot.io/x/gobot"
 )
+
+const ssd1306DefaultAddress = 0x3c
 
 // register addresses for the ssd1306
 const (
@@ -14,7 +14,6 @@ const (
 	ssd1306Height       = 64
 	ssd1306ExternalVCC  = false
 	ssd1306SetStartLine = 0x40
-	ssd1306I2CAddress   = 0x3c
 	// fundamental commands
 	ssd1306SetComOutput0 = 0xC0
 	ssd1306SetComOutput1 = 0xC1
@@ -179,11 +178,7 @@ func (d *DisplayBuffer) Set(buf []byte) {
 
 // SSD1306Driver is a Gobot Driver for a SSD1306 Display.
 type SSD1306Driver struct {
-	name       string
-	connector  Connector
-	connection Connection
-	Config
-	gobot.Commander
+	*Driver
 	initSequence  *SSD1306Init
 	displayWidth  int
 	displayHeight int
@@ -195,7 +190,7 @@ type SSD1306Driver struct {
 // NewSSD1306Driver creates a new SSD1306Driver.
 //
 // Params:
-//        conn Connector - the Adaptor to use with this Driver
+//        c Connector - the Adaptor to use with this Driver
 //
 // Optional params:
 //        WithBus(int):    			bus to use with this driver
@@ -204,16 +199,15 @@ type SSD1306Driver struct {
 //        WithSSD1306DisplayHeight(int): 	height of display (defaults to 64)
 //        WithSSD1306ExternalVCC:          set true when using an external OLED supply (defaults to false)
 //
-func NewSSD1306Driver(a Connector, options ...func(Config)) *SSD1306Driver {
+func NewSSD1306Driver(c Connector, options ...func(Config)) *SSD1306Driver {
 	s := &SSD1306Driver{
-		name:          gobot.DefaultName("SSD1306"),
-		Commander:     gobot.NewCommander(),
-		connector:     a,
-		Config:        NewConfig(),
+		Driver:        NewDriver(c, "SSD1306", ssd1306DefaultAddress),
 		displayHeight: ssd1306Height,
 		displayWidth:  ssd1306Width,
 		externalVCC:   ssd1306ExternalVCC,
 	}
+	s.afterStart = s.initialize
+
 	// set options
 	for _, option := range options {
 		option(s)
@@ -253,52 +247,6 @@ func NewSSD1306Driver(a Connector, options ...func(Config)) *SSD1306Driver {
 	})
 	return s
 }
-
-// Name returns the Name for the Driver.
-func (s *SSD1306Driver) Name() string { return s.name }
-
-// SetName sets the Name for the Driver.
-func (s *SSD1306Driver) SetName(n string) { s.name = n }
-
-// Connection returns the connection for the Driver.
-func (s *SSD1306Driver) Connection() gobot.Connection { return s.connector.(gobot.Connection) }
-
-// Start starts the Driver up, and writes start command
-func (s *SSD1306Driver) Start() (err error) {
-	// check device size for supported resolutions
-	switch {
-	case s.displayWidth == 128 && s.displayHeight == 64:
-		s.initSequence = ssd1306Init128x64
-	case s.displayWidth == 128 && s.displayHeight == 32:
-		s.initSequence = ssd1306Init128x32
-	case s.displayWidth == 96 && s.displayHeight == 16:
-		s.initSequence = ssd1306Init96x16
-	default:
-		return fmt.Errorf("%dx%d resolution is unsupported, supported resolutions: 128x64, 128x32, 96x16", s.displayWidth, s.displayHeight)
-	}
-	// check for external vcc
-	if s.externalVCC {
-		s.initSequence.chargePumpSetting = 0x10
-		s.initSequence.contrast = 0x9F
-		s.initSequence.prechargePeriod = 0x22
-	}
-	bus := s.GetBusOrDefault(s.connector.DefaultBus())
-	address := s.GetAddressOrDefault(ssd1306I2CAddress)
-	s.connection, err = s.connector.GetConnection(address, bus)
-	if err != nil {
-		return err
-	}
-	if err = s.Init(); err != nil {
-		return err
-	}
-	if err = s.On(); err != nil {
-		return err
-	}
-	return nil
-}
-
-// Halt returns true if device is halted successfully
-func (s *SSD1306Driver) Halt() (err error) { return nil }
 
 // WithSSD1306DisplayWidth option sets the SSD1306Driver DisplayWidth option.
 func WithSSD1306DisplayWidth(val int) func(Config) {
@@ -424,4 +372,32 @@ func (s *SSD1306Driver) commands(commands []byte) (err error) {
 	}
 	_, err = s.connection.Write(command)
 	return err
+}
+
+func (s *SSD1306Driver) initialize() (err error) {
+	// check device size for supported resolutions
+	switch {
+	case s.displayWidth == 128 && s.displayHeight == 64:
+		s.initSequence = ssd1306Init128x64
+	case s.displayWidth == 128 && s.displayHeight == 32:
+		s.initSequence = ssd1306Init128x32
+	case s.displayWidth == 96 && s.displayHeight == 16:
+		s.initSequence = ssd1306Init96x16
+	default:
+		return fmt.Errorf("%dx%d resolution is unsupported, supported resolutions: 128x64, 128x32, 96x16",
+			s.displayWidth, s.displayHeight)
+	}
+	// check for external vcc
+	if s.externalVCC {
+		s.initSequence.chargePumpSetting = 0x10
+		s.initSequence.contrast = 0x9F
+		s.initSequence.prechargePeriod = 0x22
+	}
+	if err = s.Init(); err != nil {
+		return err
+	}
+	if err = s.On(); err != nil {
+		return err
+	}
+	return nil
 }

--- a/drivers/i2c/ssd1306_driver_test.go
+++ b/drivers/i2c/ssd1306_driver_test.go
@@ -12,7 +12,249 @@ import (
 	"gobot.io/x/gobot/gobottest"
 )
 
+// this ensures that the implementation is based on i2c.Driver, which implements the gobot.Driver
+// and tests all implementations, so no further tests needed here for gobot.Driver interface
 var _ gobot.Driver = (*SSD1306Driver)(nil)
+
+func initTestSSD1306DriverWithStubbedAdaptor(width, height int, externalVCC bool) (*SSD1306Driver, *i2cTestAdaptor) {
+	a := newI2cTestAdaptor()
+	d := NewSSD1306Driver(a, WithSSD1306DisplayWidth(width), WithSSD1306DisplayHeight(height), WithSSD1306ExternalVCC(externalVCC))
+	if err := d.Start(); err != nil {
+		panic(err)
+	}
+	return d, a
+}
+
+func TestNewSSD1306Driver(t *testing.T) {
+	var di interface{} = NewSSD1306Driver(newI2cTestAdaptor())
+	d, ok := di.(*SSD1306Driver)
+	if !ok {
+		t.Errorf("new should have returned a *SSD1306Driver")
+	}
+	gobottest.Assert(t, strings.HasPrefix(d.Name(), "SSD1306"), true)
+}
+
+func TestSSD1306StartDefault(t *testing.T) {
+	const (
+		width       = 128
+		height      = 64
+		externalVCC = false
+	)
+	d := NewSSD1306Driver(newI2cTestAdaptor(),
+		WithSSD1306DisplayWidth(width), WithSSD1306DisplayHeight(height), WithSSD1306ExternalVCC(externalVCC))
+	gobottest.Assert(t, d.Start(), nil)
+}
+
+func TestSSD1306Start128x32(t *testing.T) {
+	const (
+		width       = 128
+		height      = 32
+		externalVCC = false
+	)
+	d := NewSSD1306Driver(newI2cTestAdaptor(),
+		WithSSD1306DisplayWidth(width), WithSSD1306DisplayHeight(height), WithSSD1306ExternalVCC(externalVCC))
+	gobottest.Assert(t, d.Start(), nil)
+}
+
+func TestSSD1306Start96x16(t *testing.T) {
+	const (
+		width       = 96
+		height      = 16
+		externalVCC = false
+	)
+	d := NewSSD1306Driver(newI2cTestAdaptor(),
+		WithSSD1306DisplayWidth(width), WithSSD1306DisplayHeight(height), WithSSD1306ExternalVCC(externalVCC))
+	gobottest.Assert(t, d.Start(), nil)
+}
+
+func TestSSD1306StartExternalVCC(t *testing.T) {
+	const (
+		width       = 128
+		height      = 32
+		externalVCC = true
+	)
+	d := NewSSD1306Driver(newI2cTestAdaptor(),
+		WithSSD1306DisplayWidth(width), WithSSD1306DisplayHeight(height), WithSSD1306ExternalVCC(externalVCC))
+	gobottest.Assert(t, d.Start(), nil)
+}
+
+func TestSSD1306StartSizeError(t *testing.T) {
+	const (
+		width       = 128
+		height      = 54
+		externalVCC = false
+	)
+	d := NewSSD1306Driver(newI2cTestAdaptor(),
+		WithSSD1306DisplayWidth(width), WithSSD1306DisplayHeight(height), WithSSD1306ExternalVCC(externalVCC))
+	gobottest.Assert(t, d.Start(), errors.New("128x54 resolution is unsupported, supported resolutions: 128x64, 128x32, 96x16"))
+}
+
+func TestSSD1306Halt(t *testing.T) {
+	s, _ := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
+	gobottest.Assert(t, s.Halt(), nil)
+}
+
+func TestSSD1306Options(t *testing.T) {
+	s := NewSSD1306Driver(newI2cTestAdaptor(), WithBus(2), WithSSD1306DisplayHeight(32), WithSSD1306DisplayWidth(128))
+	gobottest.Assert(t, s.GetBusOrDefault(1), 2)
+	gobottest.Assert(t, s.displayHeight, 32)
+	gobottest.Assert(t, s.displayWidth, 128)
+}
+
+func TestSSD1306Display(t *testing.T) {
+	s, _ := initTestSSD1306DriverWithStubbedAdaptor(96, 16, false)
+	s.Start()
+	gobottest.Assert(t, s.Display(), nil)
+}
+
+func TestSSD1306ShowImage(t *testing.T) {
+	s, _ := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
+	s.Start()
+	img := image.NewRGBA(image.Rect(0, 0, 640, 480))
+	gobottest.Assert(t, s.ShowImage(img), errors.New("image must match display width and height: 128x64"))
+
+	img = image.NewRGBA(image.Rect(0, 0, 128, 64))
+	gobottest.Assert(t, s.ShowImage(img), nil)
+}
+
+func TestSSD1306Command(t *testing.T) {
+	s, a := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
+	s.Start()
+
+	a.i2cWriteImpl = func(got []byte) (int, error) {
+		expected := []byte{0x80, 0xFF}
+		if !reflect.DeepEqual(got, expected) {
+			t.Logf("sequence error, got %+v, expected %+v", got, expected)
+			return 0, fmt.Errorf("oops")
+		}
+		return 0, nil
+	}
+	err := s.command(0xFF)
+	gobottest.Assert(t, err, nil)
+}
+
+func TestSSD1306Commands(t *testing.T) {
+	s, a := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
+	s.Start()
+
+	a.i2cWriteImpl = func(got []byte) (int, error) {
+		expected := []byte{0x80, 0x00, 0x80, 0xFF}
+		if !reflect.DeepEqual(got, expected) {
+			t.Logf("sequence error, got %+v, expected %+v", got, expected)
+			return 0, fmt.Errorf("oops")
+		}
+		return 0, nil
+	}
+	err := s.commands([]byte{0x00, 0xFF})
+	gobottest.Assert(t, err, nil)
+}
+
+func TestSSD1306On(t *testing.T) {
+	s, a := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
+	s.Start()
+
+	a.i2cWriteImpl = func(got []byte) (int, error) {
+		expected := []byte{0x80, ssd1306SetDisplayOn}
+		if !reflect.DeepEqual(got, expected) {
+			t.Logf("sequence error, got %+v, expected %+v", got, expected)
+			return 0, fmt.Errorf("oops")
+		}
+		return 0, nil
+	}
+	err := s.On()
+	gobottest.Assert(t, err, nil)
+}
+
+func TestSSD1306Off(t *testing.T) {
+	s, a := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
+	s.Start()
+
+	a.i2cWriteImpl = func(got []byte) (int, error) {
+		expected := []byte{0x80, ssd1306SetDisplayOff}
+		if !reflect.DeepEqual(got, expected) {
+			t.Logf("sequence error, got %+v, expected %+v", got, expected)
+			return 0, fmt.Errorf("oops")
+		}
+		return 0, nil
+	}
+	err := s.Off()
+	gobottest.Assert(t, err, nil)
+}
+
+func TestSSD1306Reset(t *testing.T) {
+	s, a := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
+	s.Start()
+
+	a.i2cWriteImpl = func(got []byte) (int, error) {
+		expectedOff := []byte{0x80, ssd1306SetDisplayOff}
+		expectedOn := []byte{0x80, ssd1306SetDisplayOn}
+		if !reflect.DeepEqual(got, expectedOff) && !reflect.DeepEqual(got, expectedOn) {
+			t.Logf("sequence error, got %+v, expected: %+v or %+v", got, expectedOff, expectedOn)
+			return 0, fmt.Errorf("oops")
+		}
+		return 0, nil
+	}
+	err := s.Reset()
+	gobottest.Assert(t, err, nil)
+}
+
+// COMMANDS
+
+func TestSSD1306CommandsDisplay(t *testing.T) {
+	s, _ := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
+	result := s.Command("Display")(map[string]interface{}{})
+	gobottest.Assert(t, result.(map[string]interface{})["err"], nil)
+}
+
+func TestSSD1306CommandsOn(t *testing.T) {
+	s, _ := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
+
+	result := s.Command("On")(map[string]interface{}{})
+	gobottest.Assert(t, result.(map[string]interface{})["err"], nil)
+}
+
+func TestSSD1306CommandsOff(t *testing.T) {
+	s, _ := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
+
+	result := s.Command("Off")(map[string]interface{}{})
+	gobottest.Assert(t, result.(map[string]interface{})["err"], nil)
+}
+
+func TestSSD1306CommandsClear(t *testing.T) {
+	s, _ := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
+
+	result := s.Command("Clear")(map[string]interface{}{})
+	gobottest.Assert(t, result.(map[string]interface{})["err"], nil)
+}
+
+func TestSSD1306CommandsSetContrast(t *testing.T) {
+	s, a := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
+	a.i2cWriteImpl = func(got []byte) (int, error) {
+		expected := []byte{0x80, ssd1306SetContrast, 0x80, 0x10}
+		if !reflect.DeepEqual(got, expected) {
+			t.Logf("sequence error, got %+v, expected %+v", got, expected)
+			return 0, fmt.Errorf("oops")
+		}
+		return 0, nil
+	}
+
+	result := s.Command("SetContrast")(map[string]interface{}{
+		"contrast": byte(0x10),
+	})
+	gobottest.Assert(t, result.(map[string]interface{})["err"], nil)
+}
+
+func TestSSD1306CommandsSet(t *testing.T) {
+	s, _ := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
+
+	gobottest.Assert(t, s.buffer.buffer[0], byte(0))
+	s.Command("Set")(map[string]interface{}{
+		"x": int(0),
+		"y": int(0),
+		"c": int(1),
+	})
+	gobottest.Assert(t, s.buffer.buffer[0], byte(1))
+}
 
 func TestDisplayBuffer(t *testing.T) {
 	width := 128
@@ -42,248 +284,4 @@ func TestDisplayBuffer(t *testing.T) {
 	display.SetPixel(0, 1, 0)
 	gobottest.Assert(t, display.buffer[0], byte(1))
 	gobottest.Assert(t, display.buffer[1], byte(1))
-}
-
-// --------- HELPERS
-func initTestSSD1306Driver(width, height int, externalVCC bool) (driver *SSD1306Driver) {
-	driver, _ = initTestSSD1306DriverWithStubbedAdaptor(width, height, externalVCC)
-	return
-}
-
-func initTestSSD1306DriverWithStubbedAdaptor(width, height int, externalVCC bool) (*SSD1306Driver, *i2cTestAdaptor) {
-	adaptor := newI2cTestAdaptor()
-	return NewSSD1306Driver(adaptor, WithSSD1306DisplayWidth(width), WithSSD1306DisplayHeight(height), WithSSD1306ExternalVCC(externalVCC)), adaptor
-}
-
-// --------- TESTS
-
-func TestNewSSD1306Driver(t *testing.T) {
-	// Does it return a pointer to an instance of SSD1306Driver?
-	var bm interface{} = NewSSD1306Driver(newI2cTestAdaptor())
-	_, ok := bm.(*SSD1306Driver)
-	if !ok {
-		t.Errorf("new should have returned a *SSD1306Driver")
-	}
-
-	b := NewSSD1306Driver(newI2cTestAdaptor())
-	gobottest.Refute(t, b.Connection(), nil)
-}
-
-// Methods
-
-func TestSSD1306DriverStartDefaul(t *testing.T) {
-	s, _ := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
-	gobottest.Assert(t, s.Start(), nil)
-}
-
-func TestSSD1306DriverStart128x32(t *testing.T) {
-	s, _ := initTestSSD1306DriverWithStubbedAdaptor(128, 32, false)
-	gobottest.Assert(t, s.Start(), nil)
-}
-
-func TestSSD1306DriverStart96x16(t *testing.T) {
-	s, _ := initTestSSD1306DriverWithStubbedAdaptor(96, 16, false)
-	gobottest.Assert(t, s.Start(), nil)
-}
-
-func TestSSD1306DriverStartExternalVCC(t *testing.T) {
-	s, _ := initTestSSD1306DriverWithStubbedAdaptor(128, 32, true)
-	gobottest.Assert(t, s.Start(), nil)
-}
-
-func TestSSD1306StartConnectError(t *testing.T) {
-	d, adaptor := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
-	adaptor.Testi2cConnectErr(true)
-	gobottest.Assert(t, d.Start(), errors.New("Invalid i2c connection"))
-}
-
-func TestSSD1306StartSizeError(t *testing.T) {
-	d, _ := initTestSSD1306DriverWithStubbedAdaptor(128, 54, false)
-	//adaptor.Testi2cConnectErr(false)
-	gobottest.Assert(t, d.Start(), errors.New("128x54 resolution is unsupported, supported resolutions: 128x64, 128x32, 96x16"))
-}
-
-func TestSSD1306DriverHalt(t *testing.T) {
-	s := initTestSSD1306Driver(128, 64, false)
-
-	gobottest.Assert(t, s.Halt(), nil)
-}
-
-// Test Name & SetName
-func TestSSD1306DriverName(t *testing.T) {
-	s := initTestSSD1306Driver(96, 16, false)
-
-	gobottest.Assert(t, strings.HasPrefix(s.Name(), "SSD1306"), true)
-	s.SetName("Ole Oled")
-	gobottest.Assert(t, s.Name(), "Ole Oled")
-}
-
-func TestSSD1306DriverOptions(t *testing.T) {
-	s := NewSSD1306Driver(newI2cTestAdaptor(), WithBus(2), WithSSD1306DisplayHeight(32), WithSSD1306DisplayWidth(128))
-	gobottest.Assert(t, s.GetBusOrDefault(1), 2)
-	gobottest.Assert(t, s.displayHeight, 32)
-	gobottest.Assert(t, s.displayWidth, 128)
-}
-
-func TestSSD1306DriverDisplay(t *testing.T) {
-	s, _ := initTestSSD1306DriverWithStubbedAdaptor(96, 16, false)
-	s.Start()
-	gobottest.Assert(t, s.Display(), nil)
-}
-
-func TestSSD1306DriverShowImage(t *testing.T) {
-	s, _ := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
-	s.Start()
-	img := image.NewRGBA(image.Rect(0, 0, 640, 480))
-	gobottest.Assert(t, s.ShowImage(img), errors.New("image must match display width and height: 128x64"))
-
-	img = image.NewRGBA(image.Rect(0, 0, 128, 64))
-	gobottest.Assert(t, s.ShowImage(img), nil)
-}
-
-func TestSSD1306DriverCommand(t *testing.T) {
-	s, adaptor := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
-	s.Start()
-
-	adaptor.i2cWriteImpl = func(got []byte) (int, error) {
-		expected := []byte{0x80, 0xFF}
-		if !reflect.DeepEqual(got, expected) {
-			t.Logf("sequence error, got %+v, expected %+v", got, expected)
-			return 0, fmt.Errorf("oops")
-		}
-		return 0, nil
-	}
-	err := s.command(0xFF)
-	gobottest.Assert(t, err, nil)
-}
-
-func TestSSD1306DriverCommands(t *testing.T) {
-	s, adaptor := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
-	s.Start()
-
-	adaptor.i2cWriteImpl = func(got []byte) (int, error) {
-		expected := []byte{0x80, 0x00, 0x80, 0xFF}
-		if !reflect.DeepEqual(got, expected) {
-			t.Logf("sequence error, got %+v, expected %+v", got, expected)
-			return 0, fmt.Errorf("oops")
-		}
-		return 0, nil
-	}
-	err := s.commands([]byte{0x00, 0xFF})
-	gobottest.Assert(t, err, nil)
-}
-
-func TestSSD1306DriverOn(t *testing.T) {
-	s, adaptor := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
-	s.Start()
-
-	adaptor.i2cWriteImpl = func(got []byte) (int, error) {
-		expected := []byte{0x80, ssd1306SetDisplayOn}
-		if !reflect.DeepEqual(got, expected) {
-			t.Logf("sequence error, got %+v, expected %+v", got, expected)
-			return 0, fmt.Errorf("oops")
-		}
-		return 0, nil
-	}
-	err := s.On()
-	gobottest.Assert(t, err, nil)
-}
-
-func TestSSD1306DriverOff(t *testing.T) {
-	s, adaptor := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
-	s.Start()
-
-	adaptor.i2cWriteImpl = func(got []byte) (int, error) {
-		expected := []byte{0x80, ssd1306SetDisplayOff}
-		if !reflect.DeepEqual(got, expected) {
-			t.Logf("sequence error, got %+v, expected %+v", got, expected)
-			return 0, fmt.Errorf("oops")
-		}
-		return 0, nil
-	}
-	err := s.Off()
-	gobottest.Assert(t, err, nil)
-}
-
-func TestSSD1306Reset(t *testing.T) {
-	s, adaptor := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
-	s.Start()
-
-	adaptor.i2cWriteImpl = func(got []byte) (int, error) {
-		expectedOff := []byte{0x80, ssd1306SetDisplayOff}
-		expectedOn := []byte{0x80, ssd1306SetDisplayOn}
-		if !reflect.DeepEqual(got, expectedOff) && !reflect.DeepEqual(got, expectedOn) {
-			t.Logf("sequence error, got %+v, expected: %+v or %+v", got, expectedOff, expectedOn)
-			return 0, fmt.Errorf("oops")
-		}
-		return 0, nil
-	}
-	err := s.Reset()
-	gobottest.Assert(t, err, nil)
-}
-
-// COMMANDS
-
-func TestSSD1306DriverCommandsDisplay(t *testing.T) {
-	s := initTestSSD1306Driver(128, 64, false)
-	s.Start()
-
-	result := s.Command("Display")(map[string]interface{}{})
-	gobottest.Assert(t, result.(map[string]interface{})["err"], nil)
-}
-
-func TestSSD1306DriverCommandsOn(t *testing.T) {
-	s := initTestSSD1306Driver(128, 64, false)
-	s.Start()
-
-	result := s.Command("On")(map[string]interface{}{})
-	gobottest.Assert(t, result.(map[string]interface{})["err"], nil)
-}
-
-func TestSSD1306DriverCommandsOff(t *testing.T) {
-	s := initTestSSD1306Driver(128, 64, false)
-	s.Start()
-
-	result := s.Command("Off")(map[string]interface{}{})
-	gobottest.Assert(t, result.(map[string]interface{})["err"], nil)
-}
-
-func TestSSD1306DriverCommandsClear(t *testing.T) {
-	s := initTestSSD1306Driver(128, 64, false)
-	s.Start()
-
-	result := s.Command("Clear")(map[string]interface{}{})
-	gobottest.Assert(t, result.(map[string]interface{})["err"], nil)
-}
-
-func TestSSD1306DriverCommandsSetContrast(t *testing.T) {
-	s, adaptor := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
-	s.Start()
-
-	adaptor.i2cWriteImpl = func(got []byte) (int, error) {
-		expected := []byte{0x80, ssd1306SetContrast, 0x80, 0x10}
-		if !reflect.DeepEqual(got, expected) {
-			t.Logf("sequence error, got %+v, expected %+v", got, expected)
-			return 0, fmt.Errorf("oops")
-		}
-		return 0, nil
-	}
-
-	result := s.Command("SetContrast")(map[string]interface{}{
-		"contrast": byte(0x10),
-	})
-	gobottest.Assert(t, result.(map[string]interface{})["err"], nil)
-}
-
-func TestSSD1306DriverCommandsSet(t *testing.T) {
-	s := initTestSSD1306Driver(128, 64, false)
-	s.Start()
-
-	gobottest.Assert(t, s.buffer.buffer[0], byte(0))
-	s.Command("Set")(map[string]interface{}{
-		"x": int(0),
-		"y": int(0),
-		"c": int(1),
-	})
-	gobottest.Assert(t, s.buffer.buffer[0], byte(1))
 }

--- a/drivers/i2c/ssd1306_driver_test.go
+++ b/drivers/i2c/ssd1306_driver_test.go
@@ -31,7 +31,9 @@ func TestNewSSD1306Driver(t *testing.T) {
 	if !ok {
 		t.Errorf("new should have returned a *SSD1306Driver")
 	}
+	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "SSD1306"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x3c)
 }
 
 func TestSSD1306StartDefault(t *testing.T) {

--- a/drivers/i2c/th02_driver.go
+++ b/drivers/i2c/th02_driver.go
@@ -101,11 +101,6 @@ func WithTH02FastMode(val int) func(Config) {
 	}
 }
 
-// SetAddress sets the address of the device (deprecated, use WithAddress() instead)
-func (s *TH02Driver) SetAddress(address int) {
-	WithAddress(address)(s)
-}
-
 // Accuracy returns the accuracy of the sampling (deprecated, use FastMode() instead)
 func (s *TH02Driver) Accuracy() byte {
 	if s.fastMode {

--- a/drivers/i2c/th02_driver_test.go
+++ b/drivers/i2c/th02_driver_test.go
@@ -31,6 +31,7 @@ func TestNewTH02Driver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "TH02"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x40)
 }
 
 func TestTH02Options(t *testing.T) {

--- a/drivers/i2c/tsl2561_driver.go
+++ b/drivers/i2c/tsl2561_driver.go
@@ -3,8 +3,6 @@ package i2c
 import (
 	"fmt"
 	"time"
-
-	"gobot.io/x/gobot"
 )
 
 const (
@@ -114,10 +112,7 @@ const (
 // Ported from the Adafruit driver at https://github.com/adafruit/Adafruit_TSL2561 by
 // K. Townsend
 type TSL2561Driver struct {
-	name       string
-	connector  Connector
-	connection Connection
-	Config
+	*Driver
 	autoGain        bool
 	gain            TSL2561Gain
 	integrationTime TSL2561IntegrationTime
@@ -126,7 +121,7 @@ type TSL2561Driver struct {
 // NewTSL2561Driver creates a new driver for the TSL2561 device.
 //
 // Params:
-//		conn Connector - the Adaptor to use with this Driver
+//		c Connector - the Adaptor to use with this Driver
 //
 // Optional params:
 //		i2c.WithBus(int):		bus to use with this driver
@@ -138,21 +133,20 @@ type TSL2561Driver struct {
 //		i2c.WithTSL2561IntegrationTime101MS: 	sets integration time to 101ms
 //		i2c.WithTSL2561IntegrationTime402MS: 	sets integration time to 402ms
 //
-func NewTSL2561Driver(conn Connector, options ...func(Config)) *TSL2561Driver {
-	driver := &TSL2561Driver{
-		name:            gobot.DefaultName("TSL2561"),
-		connector:       conn,
-		Config:          NewConfig(),
+func NewTSL2561Driver(c Connector, options ...func(Config)) *TSL2561Driver {
+	d := &TSL2561Driver{
+		Driver:          NewDriver(c, "TSL2561", TSL2561AddressFloat),
 		integrationTime: TSL2561IntegrationTime402MS,
 		gain:            TSL2561Gain1X,
 		autoGain:        false,
 	}
+	d.afterStart = d.initialize
 
 	for _, option := range options {
-		option(driver)
+		option(d)
 	}
 
-	return driver
+	return d
 }
 
 // WithTSL2561Gain1X option sets the TSL2561Driver gain to 1X
@@ -212,61 +206,6 @@ func WithTSL2561IntegrationTime101MS(c Config) {
 // to 402ms
 func WithTSL2561IntegrationTime402MS(c Config) {
 	withTSL2561IntegrationTime(TSL2561IntegrationTime402MS)(c)
-}
-
-// Name returns the name of the device.
-func (d *TSL2561Driver) Name() string {
-	return d.name
-}
-
-// SetName sets the name of the device.
-func (d *TSL2561Driver) SetName(name string) {
-	d.name = name
-}
-
-// Connection returns the connection of the device.
-func (d *TSL2561Driver) Connection() gobot.Connection {
-	return d.connector.(gobot.Connection)
-}
-
-// Start initializes the device.
-func (d *TSL2561Driver) Start() (err error) {
-	bus := d.GetBusOrDefault(d.connector.DefaultBus())
-	address := d.GetAddressOrDefault(TSL2561AddressFloat)
-
-	if d.connection, err = d.connector.GetConnection(address, bus); err != nil {
-		return err
-	}
-
-	if err = d.enable(); err != nil {
-		return err
-	}
-
-	var initialized byte
-	if initialized, err = d.connection.ReadByteData(tsl2561RegisterID); err != nil {
-		return err
-	} else if (initialized & 0x0A) == 0 {
-		return fmt.Errorf("TSL2561 device not found (0x%X)", initialized)
-	}
-
-	if err = d.SetIntegrationTime(d.integrationTime); err != nil {
-		return err
-	}
-
-	if err = d.SetGain(d.gain); err != nil {
-		return err
-	}
-
-	if err = d.disable(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// Halt stops the device
-func (d *TSL2561Driver) Halt() error {
-	return nil
 }
 
 // SetIntegrationTime sets integrations time for the TSL2561
@@ -507,4 +446,30 @@ func (d *TSL2561Driver) waitForADC() {
 		time.Sleep(450 * time.Millisecond)
 	}
 	return
+}
+
+func (d *TSL2561Driver) initialize() error {
+	if err := d.enable(); err != nil {
+		return err
+	}
+
+	if initialized, err := d.connection.ReadByteData(tsl2561RegisterID); err != nil {
+		return err
+	} else if (initialized & 0x0A) == 0 {
+		return fmt.Errorf("TSL2561 device not found (0x%X)", initialized)
+	}
+
+	if err := d.SetIntegrationTime(d.integrationTime); err != nil {
+		return err
+	}
+
+	if err := d.SetGain(d.gain); err != nil {
+		return err
+	}
+
+	if err := d.disable(); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/drivers/i2c/tsl2561_driver_test.go
+++ b/drivers/i2c/tsl2561_driver_test.go
@@ -17,7 +17,7 @@ var _ gobot.Driver = (*TSL2561Driver)(nil)
 
 func testIdReader(b []byte) (int, error) {
 	buf := new(bytes.Buffer)
-	// Mock d responding 0xA
+	// Mock device responding 0xA
 	binary.Write(buf, binary.LittleEndian, uint8(0x0A))
 	copy(b, buf.Bytes())
 	return buf.Len(), nil
@@ -41,6 +41,7 @@ func TestNewTSL2561Driver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "TSL2561"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x39)
 	gobottest.Assert(t, d.autoGain, false)
 	gobottest.Assert(t, d.gain, TSL2561Gain(0))
 	gobottest.Assert(t, d.integrationTime, TSL2561IntegrationTime(2))

--- a/drivers/i2c/tsl2561_driver_test.go
+++ b/drivers/i2c/tsl2561_driver_test.go
@@ -11,46 +11,61 @@ import (
 	"gobot.io/x/gobot/gobottest"
 )
 
+// this ensures that the implementation is based on i2c.Driver, which implements the gobot.Driver
+// and tests all implementations, so no further tests needed here for gobot.Driver interface
 var _ gobot.Driver = (*TSL2561Driver)(nil)
 
-func initTestTSL2561Driver() (*TSL2561Driver, *i2cTestAdaptor) {
-	adaptor := newI2cTestAdaptor()
-	return NewTSL2561Driver(adaptor), adaptor
-}
-
-func idReader(b []byte) (int, error) {
+func testIdReader(b []byte) (int, error) {
 	buf := new(bytes.Buffer)
-	// Mock device responding 0xA
+	// Mock d responding 0xA
 	binary.Write(buf, binary.LittleEndian, uint8(0x0A))
 	copy(b, buf.Bytes())
 	return buf.Len(), nil
 }
 
-func TestTSL2561DriverStart(t *testing.T) {
-	d, adaptor := initTestTSL2561Driver()
-	adaptor.i2cReadImpl = idReader
-	gobottest.Assert(t, strings.HasPrefix(d.Name(), "TSL2561"), true)
-	gobottest.Assert(t, d.Start(), nil)
-	gobottest.Refute(t, d.Connection(), nil)
-}
-
-func TestTSL2561StartConnectError(t *testing.T) {
-	d, adaptor := initTestTSL2561Driver()
-	adaptor.Testi2cConnectErr(true)
-	gobottest.Assert(t, d.Start(), errors.New("Invalid i2c connection"))
-}
-
-func TestTSL2561DriverStartError(t *testing.T) {
-	d, adaptor := initTestTSL2561Driver()
-	adaptor.i2cWriteImpl = func([]byte) (int, error) {
-		return 0, errors.New("write error")
+func initTestTSL2561Driver() (*TSL2561Driver, *i2cTestAdaptor) {
+	a := newI2cTestAdaptor()
+	d := NewTSL2561Driver(a)
+	a.i2cReadImpl = testIdReader
+	if err := d.Start(); err != nil {
+		panic(err)
 	}
-	gobottest.Assert(t, d.Start(), errors.New("write error"))
+	return d, a
+}
+
+func TestNewTSL2561Driver(t *testing.T) {
+	var di interface{} = NewTSL2561Driver(newI2cTestAdaptor())
+	d, ok := di.(*TSL2561Driver)
+	if !ok {
+		t.Errorf("NewTSL2561Driver() should have returned a *TSL2561Driver")
+	}
+	gobottest.Refute(t, d.Driver, nil)
+	gobottest.Assert(t, strings.HasPrefix(d.Name(), "TSL2561"), true)
+	gobottest.Assert(t, d.autoGain, false)
+	gobottest.Assert(t, d.gain, TSL2561Gain(0))
+	gobottest.Assert(t, d.integrationTime, TSL2561IntegrationTime(2))
+}
+
+func TestTSL2561DriverOptions(t *testing.T) {
+	// This is a general test, that options are applied in constructor by using the common WithBus() option and
+	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".
+	d := NewTSL2561Driver(newI2cTestAdaptor(), WithBus(2), WithTSL2561AutoGain)
+	gobottest.Assert(t, d.GetBusOrDefault(1), 2)
+	gobottest.Assert(t, d.autoGain, true)
+}
+
+func TestTSL2561DriverStart(t *testing.T) {
+	a := newI2cTestAdaptor()
+	d := NewTSL2561Driver(a)
+	a.i2cReadImpl = testIdReader
+
+	gobottest.Assert(t, d.Start(), nil)
 }
 
 func TestTSL2561DriverStartNotFound(t *testing.T) {
-	d, adaptor := initTestTSL2561Driver()
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a := newI2cTestAdaptor()
+	d := NewTSL2561Driver(a)
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		buf := new(bytes.Buffer)
 		buf.Write([]byte{1})
 		copy(b, buf.Bytes())
@@ -60,22 +75,14 @@ func TestTSL2561DriverStartNotFound(t *testing.T) {
 }
 
 func TestTSL2561DriverHalt(t *testing.T) {
-	d, adaptor := initTestTSL2561Driver()
-	adaptor.i2cReadImpl = idReader
-
-	d.Start()
-	gobottest.Assert(t, strings.HasPrefix(d.Name(), "TSL2561"), true)
+	d, _ := initTestTSL2561Driver()
 	gobottest.Assert(t, d.Halt(), nil)
 }
 
 func TestTSL2561DriverRead16(t *testing.T) {
-	d, adaptor := initTestTSL2561Driver()
-
-	adaptor.i2cReadImpl = idReader
-
-	gobottest.Assert(t, d.Start(), nil)
-
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	d, a := initTestTSL2561Driver()
+	a.i2cReadImpl = testIdReader
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		buf := new(bytes.Buffer)
 		// send low
 		binary.Write(buf, binary.LittleEndian, uint8(0xEA))
@@ -90,75 +97,61 @@ func TestTSL2561DriverRead16(t *testing.T) {
 }
 
 func TestTSL2561DriverValidOptions(t *testing.T) {
-	adaptor := newI2cTestAdaptor()
+	a := newI2cTestAdaptor()
 
-	device := NewTSL2561Driver(adaptor,
+	d := NewTSL2561Driver(a,
 		WithTSL2561IntegrationTime101MS,
 		WithAddress(TSL2561AddressLow),
 		WithTSL2561AutoGain)
 
-	gobottest.Refute(t, device, nil)
-	gobottest.Assert(t, device.autoGain, true)
-	gobottest.Assert(t, device.integrationTime, TSL2561IntegrationTime101MS)
+	gobottest.Refute(t, d, nil)
+	gobottest.Assert(t, d.autoGain, true)
+	gobottest.Assert(t, d.integrationTime, TSL2561IntegrationTime101MS)
 }
 
 func TestTSL2561DriverMoreOptions(t *testing.T) {
-	adaptor := newI2cTestAdaptor()
+	a := newI2cTestAdaptor()
 
-	device := NewTSL2561Driver(adaptor,
+	d := NewTSL2561Driver(a,
 		WithTSL2561IntegrationTime101MS,
 		WithAddress(TSL2561AddressLow),
 		WithTSL2561Gain16X)
 
-	gobottest.Refute(t, device, nil)
-	gobottest.Assert(t, device.autoGain, false)
-	gobottest.Assert(t, device.gain, TSL2561Gain(TSL2561Gain16X))
+	gobottest.Refute(t, d, nil)
+	gobottest.Assert(t, d.autoGain, false)
+	gobottest.Assert(t, d.gain, TSL2561Gain(TSL2561Gain16X))
 }
 
 func TestTSL2561DriverEvenMoreOptions(t *testing.T) {
-	adaptor := newI2cTestAdaptor()
+	a := newI2cTestAdaptor()
 
-	device := NewTSL2561Driver(adaptor,
+	d := NewTSL2561Driver(a,
 		WithTSL2561IntegrationTime13MS,
 		WithAddress(TSL2561AddressLow),
 		WithTSL2561Gain1X)
 
-	gobottest.Refute(t, device, nil)
-	gobottest.Assert(t, device.autoGain, false)
-	gobottest.Assert(t, device.gain, TSL2561Gain(TSL2561Gain1X))
-	gobottest.Assert(t, device.integrationTime, TSL2561IntegrationTime13MS)
+	gobottest.Refute(t, d, nil)
+	gobottest.Assert(t, d.autoGain, false)
+	gobottest.Assert(t, d.gain, TSL2561Gain(TSL2561Gain1X))
+	gobottest.Assert(t, d.integrationTime, TSL2561IntegrationTime13MS)
 }
 
 func TestTSL2561DriverYetEvenMoreOptions(t *testing.T) {
-	adaptor := newI2cTestAdaptor()
+	a := newI2cTestAdaptor()
 
-	device := NewTSL2561Driver(adaptor,
+	d := NewTSL2561Driver(a,
 		WithTSL2561IntegrationTime402MS,
 		WithAddress(TSL2561AddressLow),
 		WithTSL2561AutoGain)
 
-	gobottest.Refute(t, device, nil)
-	gobottest.Assert(t, device.autoGain, true)
-	gobottest.Assert(t, device.integrationTime, TSL2561IntegrationTime402MS)
-}
-
-func TestTSL2561DriverSetName(t *testing.T) {
-	d, _ := initTestTSL2561Driver()
-	d.SetName("TESTME")
-	gobottest.Assert(t, d.Name(), "TESTME")
-}
-
-func TestTSL2561DriverOptions(t *testing.T) {
-	d := NewTSL2561Driver(newI2cTestAdaptor(), WithBus(2))
-	gobottest.Assert(t, d.GetBusOrDefault(1), 2)
+	gobottest.Refute(t, d, nil)
+	gobottest.Assert(t, d.autoGain, true)
+	gobottest.Assert(t, d.integrationTime, TSL2561IntegrationTime402MS)
 }
 
 func TestTSL2561DriverGetDataWriteError(t *testing.T) {
-	d, adaptor := initTestTSL2561Driver()
-	adaptor.i2cReadImpl = idReader
-	gobottest.Assert(t, d.Start(), nil)
-
-	adaptor.i2cWriteImpl = func([]byte) (int, error) {
+	d, a := initTestTSL2561Driver()
+	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
 
@@ -167,11 +160,8 @@ func TestTSL2561DriverGetDataWriteError(t *testing.T) {
 }
 
 func TestTSL2561DriverGetDataReadError(t *testing.T) {
-	d, adaptor := initTestTSL2561Driver()
-	adaptor.i2cReadImpl = idReader
-	gobottest.Assert(t, d.Start(), nil)
-
-	adaptor.i2cReadImpl = func([]byte) (int, error) {
+	d, a := initTestTSL2561Driver()
+	a.i2cReadImpl = func([]byte) (int, error) {
 		return 0, errors.New("read error")
 	}
 
@@ -180,17 +170,14 @@ func TestTSL2561DriverGetDataReadError(t *testing.T) {
 }
 
 func TestTSL2561DriverGetLuminocity(t *testing.T) {
-	d, adaptor := initTestTSL2561Driver()
-
+	d, a := initTestTSL2561Driver()
 	// TODO: obtain real sensor data here for testing
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		buf := new(bytes.Buffer)
 		buf.Write([]byte{77, 48})
 		copy(b, buf.Bytes())
 		return buf.Len(), nil
 	}
-
-	d.Start()
 	bb, ir, err := d.GetLuminocity()
 	gobottest.Assert(t, err, nil)
 	gobottest.Assert(t, bb, uint16(12365))
@@ -199,14 +186,13 @@ func TestTSL2561DriverGetLuminocity(t *testing.T) {
 }
 
 func TestTSL2561DriverGetLuminocityAutoGain(t *testing.T) {
-	adaptor := newI2cTestAdaptor()
-	d := NewTSL2561Driver(adaptor,
+	a := newI2cTestAdaptor()
+	d := NewTSL2561Driver(a,
 		WithTSL2561IntegrationTime402MS,
 		WithAddress(TSL2561AddressLow),
 		WithTSL2561AutoGain)
-
 	// TODO: obtain real sensor data here for testing
-	adaptor.i2cReadImpl = func(b []byte) (int, error) {
+	a.i2cReadImpl = func(b []byte) (int, error) {
 		buf := new(bytes.Buffer)
 		buf.Write([]byte{77, 48})
 		copy(b, buf.Bytes())
@@ -222,26 +208,24 @@ func TestTSL2561DriverGetLuminocityAutoGain(t *testing.T) {
 }
 
 func TestTSL2561SetIntegrationTimeError(t *testing.T) {
-	d, adaptor := initTestTSL2561Driver()
-	d.Start()
-	adaptor.i2cWriteImpl = func([]byte) (int, error) {
+	d, a := initTestTSL2561Driver()
+	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
 	gobottest.Assert(t, d.SetIntegrationTime(TSL2561IntegrationTime101MS), errors.New("write error"))
 }
 
 func TestTSL2561SetGainError(t *testing.T) {
-	d, adaptor := initTestTSL2561Driver()
-	d.Start()
-	adaptor.i2cWriteImpl = func([]byte) (int, error) {
+	d, a := initTestTSL2561Driver()
+	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
 	gobottest.Assert(t, d.SetGain(TSL2561Gain16X), errors.New("write error"))
 }
 
 func TestTSL2561getHiLo13MS(t *testing.T) {
-	adaptor := newI2cTestAdaptor()
-	d := NewTSL2561Driver(adaptor,
+	a := newI2cTestAdaptor()
+	d := NewTSL2561Driver(a,
 		WithTSL2561IntegrationTime13MS,
 		WithTSL2561AutoGain)
 
@@ -251,8 +235,8 @@ func TestTSL2561getHiLo13MS(t *testing.T) {
 }
 
 func TestTSL2561getHiLo101MS(t *testing.T) {
-	adaptor := newI2cTestAdaptor()
-	d := NewTSL2561Driver(adaptor,
+	a := newI2cTestAdaptor()
+	d := NewTSL2561Driver(a,
 		WithTSL2561IntegrationTime101MS,
 		WithTSL2561AutoGain)
 
@@ -262,8 +246,8 @@ func TestTSL2561getHiLo101MS(t *testing.T) {
 }
 
 func TestTSL2561getHiLo402MS(t *testing.T) {
-	adaptor := newI2cTestAdaptor()
-	d := NewTSL2561Driver(adaptor,
+	a := newI2cTestAdaptor()
+	d := NewTSL2561Driver(a,
 		WithTSL2561IntegrationTime402MS,
 		WithTSL2561AutoGain)
 
@@ -273,8 +257,8 @@ func TestTSL2561getHiLo402MS(t *testing.T) {
 }
 
 func TestTSL2561getClipScaling13MS(t *testing.T) {
-	adaptor := newI2cTestAdaptor()
-	d := NewTSL2561Driver(adaptor,
+	a := newI2cTestAdaptor()
+	d := NewTSL2561Driver(a,
 		WithTSL2561IntegrationTime13MS,
 		WithTSL2561AutoGain)
 
@@ -285,8 +269,8 @@ func TestTSL2561getClipScaling13MS(t *testing.T) {
 }
 
 func TestTSL2561getClipScaling101MS(t *testing.T) {
-	adaptor := newI2cTestAdaptor()
-	d := NewTSL2561Driver(adaptor,
+	a := newI2cTestAdaptor()
+	d := NewTSL2561Driver(a,
 		WithTSL2561IntegrationTime101MS,
 		WithTSL2561AutoGain)
 
@@ -297,8 +281,8 @@ func TestTSL2561getClipScaling101MS(t *testing.T) {
 }
 
 func TestTSL2561getClipScaling402MS(t *testing.T) {
-	adaptor := newI2cTestAdaptor()
-	d := NewTSL2561Driver(adaptor,
+	a := newI2cTestAdaptor()
+	d := NewTSL2561Driver(a,
 		WithTSL2561IntegrationTime402MS,
 		WithTSL2561AutoGain)
 
@@ -309,8 +293,8 @@ func TestTSL2561getClipScaling402MS(t *testing.T) {
 }
 
 func TestTSL2561getBM(t *testing.T) {
-	adaptor := newI2cTestAdaptor()
-	d := NewTSL2561Driver(adaptor,
+	a := newI2cTestAdaptor()
+	d := NewTSL2561Driver(a,
 		WithTSL2561IntegrationTime13MS,
 		WithTSL2561AutoGain)
 

--- a/drivers/i2c/wiichuck_driver.go
+++ b/drivers/i2c/wiichuck_driver.go
@@ -18,13 +18,10 @@ const (
 	Z = "z"
 )
 
-const wiichuckAddress = 0x52
+const wiichuckDefaultAddress = 0x52
 
 type WiichuckDriver struct {
-	name       string
-	connector  Connector
-	connection Connection
-	Config
+	*Driver
 	interval  time.Duration
 	pauseTime time.Duration
 	gobot.Eventer
@@ -36,17 +33,15 @@ type WiichuckDriver struct {
 // NewWiichuckDriver creates a WiichuckDriver with specified i2c interface.
 //
 // Params:
-//		conn Connector - the Adaptor to use with this Driver
+//		c Connector - the Adaptor to use with this Driver
 //
 // Optional params:
 //		i2c.WithBus(int):	bus to use with this driver
 //		i2c.WithAddress(int):	address to use with this driver
 //
-func NewWiichuckDriver(a Connector, options ...func(Config)) *WiichuckDriver {
+func NewWiichuckDriver(c Connector, options ...func(Config)) *WiichuckDriver {
 	w := &WiichuckDriver{
-		name:      gobot.DefaultName("Wiichuck"),
-		connector: a,
-		Config:    NewConfig(),
+		Driver:    NewDriver(c, "Wiichuck", wiichuckDefaultAddress),
 		interval:  10 * time.Millisecond,
 		pauseTime: 1 * time.Millisecond,
 		Eventer:   gobot.NewEventer(),
@@ -61,6 +56,7 @@ func NewWiichuckDriver(a Connector, options ...func(Config)) *WiichuckDriver {
 			"c":  0,
 		},
 	}
+	w.afterStart = w.initialize
 
 	for _, option := range options {
 		option(w)
@@ -73,59 +69,6 @@ func NewWiichuckDriver(a Connector, options ...func(Config)) *WiichuckDriver {
 
 	return w
 }
-
-// Name returns the name of the device.
-func (w *WiichuckDriver) Name() string { return w.name }
-
-// SetName sets the name of the device.
-func (w *WiichuckDriver) SetName(n string) { w.name = n }
-
-// Connection returns the connection for the device.
-func (w *WiichuckDriver) Connection() gobot.Connection { return w.connector.(gobot.Connection) }
-
-// Start initilizes i2c and reads from adaptor
-// using specified interval to update with new value
-func (w *WiichuckDriver) Start() (err error) {
-	bus := w.GetBusOrDefault(w.connector.DefaultBus())
-	address := w.GetAddressOrDefault(wiichuckAddress)
-
-	w.connection, err = w.connector.GetConnection(address, bus)
-	if err != nil {
-		return err
-	}
-
-	go func() {
-		for {
-			if _, err := w.connection.Write([]byte{0x40, 0x00}); err != nil {
-				w.Publish(w.Event(Error), err)
-				continue
-			}
-			time.Sleep(w.pauseTime)
-			if _, err := w.connection.Write([]byte{0x00}); err != nil {
-				w.Publish(w.Event(Error), err)
-				continue
-			}
-			time.Sleep(w.pauseTime)
-			newValue := make([]byte, 6)
-			bytesRead, err := w.connection.Read(newValue)
-			if err != nil {
-				w.Publish(w.Event(Error), err)
-				continue
-			}
-			if bytesRead == 6 {
-				if err = w.update(newValue); err != nil {
-					w.Publish(w.Event(Error), err)
-					continue
-				}
-			}
-			time.Sleep(w.interval)
-		}
-	}()
-	return
-}
-
-// Halt returns true if driver is halted successfully
-func (w *WiichuckDriver) Halt() (err error) { return }
 
 // Joystick returns the current value for the joystick
 func (w *WiichuckDriver) Joystick() map[string]float64 {
@@ -209,4 +152,36 @@ func (w *WiichuckDriver) parse(value []byte) {
 	w.data["sy"] = w.decode(value[1])
 	w.data["z"] = float64(uint8(w.decode(value[5])) & 0x01)
 	w.data["c"] = float64(uint8(w.decode(value[5])) & 0x02)
+}
+
+// reads from adaptor using specified interval to update with new value
+func (w *WiichuckDriver) initialize() (err error) {
+	go func() {
+		for {
+			if _, err := w.connection.Write([]byte{0x40, 0x00}); err != nil {
+				w.Publish(w.Event(Error), err)
+				continue
+			}
+			time.Sleep(w.pauseTime)
+			if _, err := w.connection.Write([]byte{0x00}); err != nil {
+				w.Publish(w.Event(Error), err)
+				continue
+			}
+			time.Sleep(w.pauseTime)
+			newValue := make([]byte, 6)
+			bytesRead, err := w.connection.Read(newValue)
+			if err != nil {
+				w.Publish(w.Event(Error), err)
+				continue
+			}
+			if bytesRead == 6 {
+				if err = w.update(newValue); err != nil {
+					w.Publish(w.Event(Error), err)
+					continue
+				}
+			}
+			time.Sleep(w.interval)
+		}
+	}()
+	return
 }

--- a/drivers/i2c/wiichuck_driver_test.go
+++ b/drivers/i2c/wiichuck_driver_test.go
@@ -29,6 +29,7 @@ func TestNewWiichuckDriver(t *testing.T) {
 	}
 	gobottest.Refute(t, d.Driver, nil)
 	gobottest.Assert(t, strings.HasPrefix(d.Name(), "Wiichuck"), true)
+	gobottest.Assert(t, d.defaultAddress, 0x52)
 	gobottest.Assert(t, d.interval, 10*time.Millisecond)
 }
 

--- a/drivers/i2c/wiichuck_driver_test.go
+++ b/drivers/i2c/wiichuck_driver_test.go
@@ -1,7 +1,6 @@
 package i2c
 
 import (
-	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -10,57 +9,46 @@ import (
 	"gobot.io/x/gobot/gobottest"
 )
 
+// this ensures that the implementation is based on i2c.Driver, which implements the gobot.Driver
+// and tests all implementations, so no further tests needed here for gobot.Driver interface
 var _ gobot.Driver = (*WiichuckDriver)(nil)
 
-// --------- HELPERS
-func initTestWiichuckDriver() (driver *WiichuckDriver) {
-	driver, _ = initTestWiichuckDriverWithStubbedAdaptor()
-	return
+func initTestWiichuckDriverWithStubbedAdaptor() *WiichuckDriver {
+	d := NewWiichuckDriver(newI2cTestAdaptor())
+	if err := d.Start(); err != nil {
+		panic(err)
+	}
+	return d
 }
-
-func initTestWiichuckDriverWithStubbedAdaptor() (*WiichuckDriver, *i2cTestAdaptor) {
-	adaptor := newI2cTestAdaptor()
-	return NewWiichuckDriver(adaptor), adaptor
-}
-
-// --------- TESTS
 
 func TestNewWiichuckDriver(t *testing.T) {
-	// Does it return a pointer to an instance of WiichuckDriver?
-	var bm interface{} = NewWiichuckDriver(newI2cTestAdaptor())
-	_, ok := bm.(*WiichuckDriver)
+	var di interface{} = NewWiichuckDriver(newI2cTestAdaptor())
+	d, ok := di.(*WiichuckDriver)
 	if !ok {
 		t.Errorf("NewWiichuckDriver() should have returned a *WiichuckDriver")
 	}
-}
-
-func TestWiichuckDriver(t *testing.T) {
-	wii := initTestWiichuckDriver()
-	gobottest.Refute(t, wii.Connection(), nil)
-	gobottest.Assert(t, wii.interval, 10*time.Millisecond)
-
-	wii = NewWiichuckDriver(newI2cTestAdaptor())
-	gobottest.Assert(t, strings.HasPrefix(wii.Name(), "Wiichuck"), true)
+	gobottest.Refute(t, d.Driver, nil)
+	gobottest.Assert(t, strings.HasPrefix(d.Name(), "Wiichuck"), true)
+	gobottest.Assert(t, d.interval, 10*time.Millisecond)
 }
 
 func TestWiichuckDriverStart(t *testing.T) {
-	sem := make(chan bool)
-	wii, adaptor := initTestWiichuckDriverWithStubbedAdaptor()
-
-	adaptor.Testi2cReadImpl(func(b []byte) (int, error) {
+	a := newI2cTestAdaptor()
+	d := NewWiichuckDriver(a)
+	a.Testi2cReadImpl(func(b []byte) (int, error) {
 		copy(b, []byte{1, 2, 3, 4, 5, 6})
 		return 6, nil
 	})
-
 	numberOfCyclesForEvery := 3
+	d.interval = 1 * time.Millisecond
+	sem := make(chan bool)
 
-	wii.interval = 1 * time.Millisecond
-	gobottest.Assert(t, wii.Start(), nil)
+	gobottest.Assert(t, d.Start(), nil)
 
 	go func() {
 		for {
 			time.Sleep(time.Duration(numberOfCyclesForEvery) * time.Millisecond)
-			j := wii.Joystick()
+			j := d.Joystick()
 			if (j["sy_origin"] == float64(44)) &&
 				(j["sx_origin"] == float64(45)) {
 				sem <- true
@@ -77,60 +65,53 @@ func TestWiichuckDriverStart(t *testing.T) {
 
 }
 
-func TestWiichuckStartConnectError(t *testing.T) {
-	d, adaptor := initTestWiichuckDriverWithStubbedAdaptor()
-	adaptor.Testi2cConnectErr(true)
-	gobottest.Assert(t, d.Start(), errors.New("Invalid i2c connection"))
-}
-
 func TestWiichuckDriverHalt(t *testing.T) {
-	wii := initTestWiichuckDriver()
-
-	gobottest.Assert(t, wii.Halt(), nil)
+	d := initTestWiichuckDriverWithStubbedAdaptor()
+	gobottest.Assert(t, d.Halt(), nil)
 }
 
 func TestWiichuckDriverCanParse(t *testing.T) {
-	wii := initTestWiichuckDriver()
+	d := initTestWiichuckDriverWithStubbedAdaptor()
 
 	// ------ When value is not encrypted
 	decryptedValue := []byte{1, 2, 3, 4, 5, 6}
-	wii.update(decryptedValue)
+	d.update(decryptedValue)
 
 	// - This should be done by WiichuckDriver.parse
-	gobottest.Assert(t, wii.data["sx"], float64(45))
-	gobottest.Assert(t, wii.data["sy"], float64(44))
-	gobottest.Assert(t, wii.data["z"], float64(0))
-	gobottest.Assert(t, wii.data["c"], float64(0))
+	gobottest.Assert(t, d.data["sx"], float64(45))
+	gobottest.Assert(t, d.data["sy"], float64(44))
+	gobottest.Assert(t, d.data["z"], float64(0))
+	gobottest.Assert(t, d.data["c"], float64(0))
 }
 
 func TestWiichuckDriverCanAdjustOrigins(t *testing.T) {
-	wii := initTestWiichuckDriver()
+	d := initTestWiichuckDriverWithStubbedAdaptor()
 
 	// ------ When value is not encrypted
 	decryptedValue := []byte{1, 2, 3, 4, 5, 6}
-	wii.update(decryptedValue)
+	d.update(decryptedValue)
 
 	// - This should be done by WiichuckDriver.adjustOrigins
-	gobottest.Assert(t, wii.Joystick()["sx_origin"], float64(45))
-	gobottest.Assert(t, wii.Joystick()["sy_origin"], float64(44))
+	gobottest.Assert(t, d.Joystick()["sx_origin"], float64(45))
+	gobottest.Assert(t, d.Joystick()["sy_origin"], float64(44))
 }
 
 func TestWiichuckDriverCButton(t *testing.T) {
-	wii := initTestWiichuckDriver()
+	d := initTestWiichuckDriverWithStubbedAdaptor()
 
 	// ------ When value is not encrypted
 	decryptedValue := []byte{1, 2, 3, 4, 5, 6}
-	wii.update(decryptedValue)
+	d.update(decryptedValue)
 
 	// - This should be done by WiichuckDriver.updateButtons
 	done := make(chan bool)
 
-	wii.On(wii.Event(C), func(data interface{}) {
+	d.On(d.Event(C), func(data interface{}) {
 		gobottest.Assert(t, data, true)
 		done <- true
 	})
 
-	wii.update(decryptedValue)
+	d.update(decryptedValue)
 
 	select {
 	case <-done:
@@ -140,20 +121,20 @@ func TestWiichuckDriverCButton(t *testing.T) {
 }
 
 func TestWiichuckDriverZButton(t *testing.T) {
-	wii := initTestWiichuckDriver()
+	d := initTestWiichuckDriverWithStubbedAdaptor()
 
 	// ------ When value is not encrypted
 	decryptedValue := []byte{1, 2, 3, 4, 5, 6}
-	wii.update(decryptedValue)
+	d.update(decryptedValue)
 
 	done := make(chan bool)
 
-	wii.On(wii.Event(Z), func(data interface{}) {
+	d.On(d.Event(Z), func(data interface{}) {
 		gobottest.Assert(t, data, true)
 		done <- true
 	})
 
-	wii.update(decryptedValue)
+	d.update(decryptedValue)
 
 	select {
 	case <-done:
@@ -163,7 +144,7 @@ func TestWiichuckDriverZButton(t *testing.T) {
 }
 
 func TestWiichuckDriverUpdateJoystick(t *testing.T) {
-	wii := initTestWiichuckDriver()
+	d := initTestWiichuckDriverWithStubbedAdaptor()
 
 	// ------ When value is not encrypted
 	decryptedValue := []byte{1, 2, 3, 4, 5, 6}
@@ -176,12 +157,12 @@ func TestWiichuckDriverUpdateJoystick(t *testing.T) {
 
 	done := make(chan bool)
 
-	wii.On(wii.Event(Joystick), func(data interface{}) {
+	d.On(d.Event(Joystick), func(data interface{}) {
 		gobottest.Assert(t, data, expectedData)
 		done <- true
 	})
 
-	wii.update(decryptedValue)
+	d.update(decryptedValue)
 
 	select {
 	case <-done:
@@ -191,125 +172,122 @@ func TestWiichuckDriverUpdateJoystick(t *testing.T) {
 }
 
 func TestWiichuckDriverEncrypted(t *testing.T) {
-	wii := initTestWiichuckDriver()
-
-	// ------ When value is encrypted
-	wii = initTestWiichuckDriver()
+	d := initTestWiichuckDriverWithStubbedAdaptor()
 	encryptedValue := []byte{1, 1, 2, 2, 3, 3}
 
-	wii.update(encryptedValue)
+	d.update(encryptedValue)
 
-	gobottest.Assert(t, wii.data["sx"], float64(0))
-	gobottest.Assert(t, wii.data["sy"], float64(0))
-	gobottest.Assert(t, wii.data["z"], float64(0))
-	gobottest.Assert(t, wii.data["c"], float64(0))
+	gobottest.Assert(t, d.data["sx"], float64(0))
+	gobottest.Assert(t, d.data["sy"], float64(0))
+	gobottest.Assert(t, d.data["z"], float64(0))
+	gobottest.Assert(t, d.data["c"], float64(0))
 
-	gobottest.Assert(t, wii.Joystick()["sx_origin"], float64(-1))
-	gobottest.Assert(t, wii.Joystick()["sy_origin"], float64(-1))
+	gobottest.Assert(t, d.Joystick()["sx_origin"], float64(-1))
+	gobottest.Assert(t, d.Joystick()["sy_origin"], float64(-1))
 }
 
 func TestWiichuckDriverSetJoystickDefaultValue(t *testing.T) {
-	wii := initTestWiichuckDriver()
+	d := initTestWiichuckDriverWithStubbedAdaptor()
 
-	gobottest.Assert(t, wii.Joystick()["sy_origin"], float64(-1))
+	gobottest.Assert(t, d.Joystick()["sy_origin"], float64(-1))
 
-	wii.setJoystickDefaultValue("sy_origin", float64(2))
+	d.setJoystickDefaultValue("sy_origin", float64(2))
 
-	gobottest.Assert(t, wii.Joystick()["sy_origin"], float64(2))
+	gobottest.Assert(t, d.Joystick()["sy_origin"], float64(2))
 
 	// when current default value is not -1 it keeps the current value
-	wii.setJoystickDefaultValue("sy_origin", float64(20))
+	d.setJoystickDefaultValue("sy_origin", float64(20))
 
-	gobottest.Assert(t, wii.Joystick()["sy_origin"], float64(2))
+	gobottest.Assert(t, d.Joystick()["sy_origin"], float64(2))
 }
 
 func TestWiichuckDriverCalculateJoystickValue(t *testing.T) {
-	wii := initTestWiichuckDriver()
+	d := initTestWiichuckDriverWithStubbedAdaptor()
 
-	gobottest.Assert(t, wii.calculateJoystickValue(float64(20), float64(5)), float64(15))
-	gobottest.Assert(t, wii.calculateJoystickValue(float64(1), float64(2)), float64(-1))
-	gobottest.Assert(t, wii.calculateJoystickValue(float64(10), float64(5)), float64(5))
-	gobottest.Assert(t, wii.calculateJoystickValue(float64(5), float64(10)), float64(-5))
+	gobottest.Assert(t, d.calculateJoystickValue(float64(20), float64(5)), float64(15))
+	gobottest.Assert(t, d.calculateJoystickValue(float64(1), float64(2)), float64(-1))
+	gobottest.Assert(t, d.calculateJoystickValue(float64(10), float64(5)), float64(5))
+	gobottest.Assert(t, d.calculateJoystickValue(float64(5), float64(10)), float64(-5))
 }
 
 func TestWiichuckDriverIsEncrypted(t *testing.T) {
-	wii := initTestWiichuckDriver()
+	d := initTestWiichuckDriverWithStubbedAdaptor()
 
 	encryptedValue := []byte{1, 1, 2, 2, 3, 3}
-	gobottest.Assert(t, wii.isEncrypted(encryptedValue), true)
+	gobottest.Assert(t, d.isEncrypted(encryptedValue), true)
 
 	encryptedValue = []byte{42, 42, 24, 24, 30, 30}
-	gobottest.Assert(t, wii.isEncrypted(encryptedValue), true)
+	gobottest.Assert(t, d.isEncrypted(encryptedValue), true)
 
 	decryptedValue := []byte{1, 2, 3, 4, 5, 6}
-	gobottest.Assert(t, wii.isEncrypted(decryptedValue), false)
+	gobottest.Assert(t, d.isEncrypted(decryptedValue), false)
 
 	decryptedValue = []byte{1, 1, 2, 2, 5, 6}
-	gobottest.Assert(t, wii.isEncrypted(decryptedValue), false)
+	gobottest.Assert(t, d.isEncrypted(decryptedValue), false)
 
 	decryptedValue = []byte{1, 1, 2, 3, 3, 3}
-	gobottest.Assert(t, wii.isEncrypted(decryptedValue), false)
+	gobottest.Assert(t, d.isEncrypted(decryptedValue), false)
 }
 
 func TestWiichuckDriverDecode(t *testing.T) {
-	wii := initTestWiichuckDriver()
+	d := initTestWiichuckDriverWithStubbedAdaptor()
 
-	gobottest.Assert(t, wii.decode(byte(0)), float64(46))
-	gobottest.Assert(t, wii.decode(byte(100)), float64(138))
-	gobottest.Assert(t, wii.decode(byte(200)), float64(246))
-	gobottest.Assert(t, wii.decode(byte(254)), float64(0))
+	gobottest.Assert(t, d.decode(byte(0)), float64(46))
+	gobottest.Assert(t, d.decode(byte(100)), float64(138))
+	gobottest.Assert(t, d.decode(byte(200)), float64(246))
+	gobottest.Assert(t, d.decode(byte(254)), float64(0))
 }
 
 func TestWiichuckDriverParse(t *testing.T) {
-	wii := initTestWiichuckDriver()
+	d := initTestWiichuckDriverWithStubbedAdaptor()
 
-	gobottest.Assert(t, wii.data["sx"], float64(0))
-	gobottest.Assert(t, wii.data["sy"], float64(0))
-	gobottest.Assert(t, wii.data["z"], float64(0))
-	gobottest.Assert(t, wii.data["c"], float64(0))
+	gobottest.Assert(t, d.data["sx"], float64(0))
+	gobottest.Assert(t, d.data["sy"], float64(0))
+	gobottest.Assert(t, d.data["z"], float64(0))
+	gobottest.Assert(t, d.data["c"], float64(0))
 
 	// First pass
-	wii.parse([]byte{12, 23, 34, 45, 56, 67})
+	d.parse([]byte{12, 23, 34, 45, 56, 67})
 
-	gobottest.Assert(t, wii.data["sx"], float64(50))
-	gobottest.Assert(t, wii.data["sy"], float64(23))
-	gobottest.Assert(t, wii.data["z"], float64(1))
-	gobottest.Assert(t, wii.data["c"], float64(2))
+	gobottest.Assert(t, d.data["sx"], float64(50))
+	gobottest.Assert(t, d.data["sy"], float64(23))
+	gobottest.Assert(t, d.data["z"], float64(1))
+	gobottest.Assert(t, d.data["c"], float64(2))
 
 	// Second pass
-	wii.parse([]byte{70, 81, 92, 103, 204, 205})
+	d.parse([]byte{70, 81, 92, 103, 204, 205})
 
-	gobottest.Assert(t, wii.data["sx"], float64(104))
-	gobottest.Assert(t, wii.data["sy"], float64(93))
-	gobottest.Assert(t, wii.data["z"], float64(1))
-	gobottest.Assert(t, wii.data["c"], float64(0))
+	gobottest.Assert(t, d.data["sx"], float64(104))
+	gobottest.Assert(t, d.data["sy"], float64(93))
+	gobottest.Assert(t, d.data["z"], float64(1))
+	gobottest.Assert(t, d.data["c"], float64(0))
 }
 
 func TestWiichuckDriverAdjustOrigins(t *testing.T) {
-	wii := initTestWiichuckDriver()
+	d := initTestWiichuckDriverWithStubbedAdaptor()
 
-	gobottest.Assert(t, wii.Joystick()["sy_origin"], float64(-1))
-	gobottest.Assert(t, wii.Joystick()["sx_origin"], float64(-1))
+	gobottest.Assert(t, d.Joystick()["sy_origin"], float64(-1))
+	gobottest.Assert(t, d.Joystick()["sx_origin"], float64(-1))
 
 	// First pass
-	wii.parse([]byte{1, 2, 3, 4, 5, 6})
-	wii.adjustOrigins()
+	d.parse([]byte{1, 2, 3, 4, 5, 6})
+	d.adjustOrigins()
 
-	gobottest.Assert(t, wii.Joystick()["sy_origin"], float64(44))
-	gobottest.Assert(t, wii.Joystick()["sx_origin"], float64(45))
+	gobottest.Assert(t, d.Joystick()["sy_origin"], float64(44))
+	gobottest.Assert(t, d.Joystick()["sx_origin"], float64(45))
 
 	// Second pass
-	wii = initTestWiichuckDriver()
+	d = initTestWiichuckDriverWithStubbedAdaptor()
 
-	wii.parse([]byte{61, 72, 83, 94, 105, 206})
-	wii.adjustOrigins()
+	d.parse([]byte{61, 72, 83, 94, 105, 206})
+	d.adjustOrigins()
 
-	gobottest.Assert(t, wii.Joystick()["sy_origin"], float64(118))
-	gobottest.Assert(t, wii.Joystick()["sx_origin"], float64(65))
+	gobottest.Assert(t, d.Joystick()["sy_origin"], float64(118))
+	gobottest.Assert(t, d.Joystick()["sx_origin"], float64(65))
 }
 
 func TestWiichuckDriverSetName(t *testing.T) {
-	d := initTestWiichuckDriver()
+	d := initTestWiichuckDriverWithStubbedAdaptor()
 	d.SetName("TESTME")
 	gobottest.Assert(t, d.Name(), "TESTME")
 }

--- a/platforms/adaptors/i2cbusadaptor.go
+++ b/platforms/adaptors/i2cbusadaptor.go
@@ -57,8 +57,8 @@ func (a *I2cBusAdaptor) Finalize() error {
 	return err
 }
 
-// GetConnection returns a connection to a device on a specified i2c bus
-func (a *I2cBusAdaptor) GetConnection(address int, busNr int) (connection i2c.Connection, err error) {
+// GetI2cConnection returns a connection to a device on a specified i2c bus
+func (a *I2cBusAdaptor) GetI2cConnection(address int, busNr int) (connection i2c.Connection, err error) {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 
@@ -80,7 +80,7 @@ func (a *I2cBusAdaptor) GetConnection(address int, busNr int) (connection i2c.Co
 	return i2c.NewConnection(bus, address), err
 }
 
-// GetDefaultBus returns the default i2c bus number for this platform.
-func (a *I2cBusAdaptor) DefaultBus() int {
+// DefaultI2cBus returns the default i2c bus number for this platform.
+func (a *I2cBusAdaptor) DefaultI2cBus() int {
 	return a.defaultBusNumber
 }

--- a/platforms/adaptors/i2cbusadaptor_test.go
+++ b/platforms/adaptors/i2cbusadaptor_test.go
@@ -36,7 +36,7 @@ func TestI2cWorkflow(t *testing.T) {
 	a, _ := initTestI2cAdaptorWithMockedFilesystem([]string{i2cBus1})
 	gobottest.Assert(t, len(a.buses), 0)
 
-	con, err := a.GetConnection(0xff, 1)
+	con, err := a.GetI2cConnection(0xff, 1)
 	gobottest.Assert(t, err, nil)
 	gobottest.Assert(t, len(a.buses), 1)
 
@@ -52,22 +52,22 @@ func TestI2cWorkflow(t *testing.T) {
 	gobottest.Assert(t, len(a.buses), 0)
 }
 
-func TestI2cGetConnection(t *testing.T) {
+func TestI2cGetI2cConnection(t *testing.T) {
 	// arrange
 	a, _ := initTestI2cAdaptorWithMockedFilesystem([]string{i2cBus1})
 	// assert working connection
-	c1, e1 := a.GetConnection(0xff, 1)
+	c1, e1 := a.GetI2cConnection(0xff, 1)
 	gobottest.Assert(t, e1, nil)
 	gobottest.Refute(t, c1, nil)
 	gobottest.Assert(t, len(a.buses), 1)
 	// assert invalid bus gets error
-	c2, e2 := a.GetConnection(0x01, 99)
+	c2, e2 := a.GetI2cConnection(0x01, 99)
 	gobottest.Assert(t, e2, fmt.Errorf("99 not valid"))
 	gobottest.Assert(t, c2, nil)
 	gobottest.Assert(t, len(a.buses), 1)
 	// assert unconnected gets error
 	gobottest.Assert(t, a.Finalize(), nil)
-	c3, e3 := a.GetConnection(0x01, 99)
+	c3, e3 := a.GetI2cConnection(0x01, 99)
 	gobottest.Assert(t, e3, fmt.Errorf("not connected"))
 	gobottest.Assert(t, c3, nil)
 	gobottest.Assert(t, len(a.buses), 0)
@@ -80,16 +80,16 @@ func TestI2cFinalize(t *testing.T) {
 	gobottest.Assert(t, a.Finalize(), nil)
 	// arrange
 	gobottest.Assert(t, a.Connect(), nil)
-	a.GetConnection(0xaf, 1)
+	a.GetI2cConnection(0xaf, 1)
 	gobottest.Assert(t, len(a.buses), 1)
-	// assert that Finalize after GetConnection is working and clean up
+	// assert that Finalize after GetI2cConnection is working and clean up
 	gobottest.Assert(t, a.Finalize(), nil)
 	gobottest.Assert(t, len(a.buses), 0)
 	// assert that finalize after finalize is working
 	gobottest.Assert(t, a.Finalize(), nil)
 	// assert that close error is recognized
 	gobottest.Assert(t, a.Connect(), nil)
-	con, _ := a.GetConnection(0xbf, 1)
+	con, _ := a.GetI2cConnection(0xbf, 1)
 	gobottest.Assert(t, len(a.buses), 1)
 	con.Write([]byte{0xbf})
 	fs.WithCloseError = true
@@ -110,5 +110,5 @@ func TestI2cReConnect(t *testing.T) {
 
 func TestI2cGetDefaultBus(t *testing.T) {
 	a := NewI2cBusAdaptor(nil, nil, 2)
-	gobottest.Assert(t, a.DefaultBus(), 2)
+	gobottest.Assert(t, a.DefaultI2cBus(), 2)
 }

--- a/platforms/beaglebone/beaglebone_adaptor_test.go
+++ b/platforms/beaglebone/beaglebone_adaptor_test.go
@@ -228,7 +228,7 @@ func TestPocketName(t *testing.T) {
 
 func TestI2cDefaultBus(t *testing.T) {
 	a := NewAdaptor()
-	gobottest.Assert(t, a.DefaultBus(), 2)
+	gobottest.Assert(t, a.DefaultI2cBus(), 2)
 }
 
 func TestI2cFinalizeWithErrors(t *testing.T) {
@@ -237,7 +237,7 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-2"})
 	gobottest.Assert(t, a.Connect(), nil)
-	con, err := a.GetConnection(0xff, 2)
+	con, err := a.GetI2cConnection(0xff, 2)
 	gobottest.Assert(t, err, nil)
 	_, err = con.Write([]byte{0xbf})
 	gobottest.Assert(t, err, nil)

--- a/platforms/chip/chip_adaptor_test.go
+++ b/platforms/chip/chip_adaptor_test.go
@@ -146,7 +146,7 @@ func TestPWM(t *testing.T) {
 
 func TestI2cDefaultBus(t *testing.T) {
 	a := NewAdaptor()
-	gobottest.Assert(t, a.DefaultBus(), 1)
+	gobottest.Assert(t, a.DefaultI2cBus(), 1)
 }
 
 func TestI2cFinalizeWithErrors(t *testing.T) {
@@ -155,7 +155,7 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-2"})
 	gobottest.Assert(t, a.Connect(), nil)
-	con, err := a.GetConnection(0xff, 2)
+	con, err := a.GetI2cConnection(0xff, 2)
 	gobottest.Assert(t, err, nil)
 	_, err = con.Write([]byte{0xbf})
 	gobottest.Assert(t, err, nil)

--- a/platforms/digispark/digispark_adaptor.go
+++ b/platforms/digispark/digispark_adaptor.go
@@ -93,9 +93,9 @@ func (d *Adaptor) ServoWrite(pin string, angle uint8) (err error) {
 	return d.littleWire.servoUpdateLocation(angle, angle)
 }
 
-// GetConnection returns an i2c connection to a device on a specified bus.
+// GetI2cConnection returns an i2c connection to a device on a specified bus.
 // Only supports bus number 0
-func (d *Adaptor) GetConnection(address int, bus int) (connection i2c.Connection, err error) {
+func (d *Adaptor) GetI2cConnection(address int, bus int) (connection i2c.Connection, err error) {
 	if bus != 0 {
 		return nil, fmt.Errorf("Invalid bus number %d, only 0 is supported", bus)
 	}
@@ -106,7 +106,7 @@ func (d *Adaptor) GetConnection(address int, bus int) (connection i2c.Connection
 	return i2c.Connection(c), nil
 }
 
-// GetDefaultBus returns the default i2c bus for this platform
-func (d *Adaptor) DefaultBus() int {
+// DefaultI2cBus returns the default i2c bus for this platform
+func (d *Adaptor) DefaultI2cBus() int {
 	return 0
 }

--- a/platforms/digispark/digispark_i2c_test.go
+++ b/platforms/digispark/digispark_i2c_test.go
@@ -33,26 +33,26 @@ func initTestAdaptorI2c() *Adaptor {
 	return a
 }
 
-func TestDigisparkAdaptorI2cGetConnection(t *testing.T) {
+func TestDigisparkAdaptorI2cGetI2cConnection(t *testing.T) {
 	// arrange
 	var c i2c.Connection
 	var err error
 	a := initTestAdaptorI2c()
 
 	// act
-	c, err = a.GetConnection(availableI2cAddress, a.DefaultBus())
+	c, err = a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// assert
 	gobottest.Assert(t, err, nil)
 	gobottest.Refute(t, c, nil)
 }
 
-func TestDigisparkAdaptorI2cGetConnectionFailWithInvalidBus(t *testing.T) {
+func TestDigisparkAdaptorI2cGetI2cConnectionFailWithInvalidBus(t *testing.T) {
 	// arrange
 	a := initTestAdaptorI2c()
 
 	// act
-	c, err := a.GetConnection(0x40, 1)
+	c, err := a.GetI2cConnection(0x40, 1)
 
 	// assert
 	gobottest.Assert(t, err, errors.New("Invalid bus number 1, only 0 is supported"))
@@ -63,7 +63,7 @@ func TestDigisparkAdaptorI2cStartFailWithWrongAddress(t *testing.T) {
 	// arrange
 	data := []byte{0, 1, 2, 3, 4}
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(0x39, a.DefaultBus())
+	c, err := a.GetI2cConnection(0x39, a.DefaultI2cBus())
 
 	// act
 	count, err := c.Write(data)
@@ -79,7 +79,7 @@ func TestDigisparkAdaptorI2cWrite(t *testing.T) {
 	data := []byte{0, 1, 2, 3, 4}
 	dataLen := len(data)
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
+	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
 	count, err := c.Write(data)
@@ -99,7 +99,7 @@ func TestDigisparkAdaptorI2cWriteByte(t *testing.T) {
 	// arrange
 	data := byte(0x02)
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
+	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
 	err = c.WriteByte(data)
@@ -119,7 +119,7 @@ func TestDigisparkAdaptorI2cWriteByteData(t *testing.T) {
 	reg := uint8(0x03)
 	data := byte(0x09)
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
+	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
 	err = c.WriteByteData(reg, data)
@@ -139,7 +139,7 @@ func TestDigisparkAdaptorI2cWriteWordData(t *testing.T) {
 	reg := uint8(0x04)
 	data := uint16(0x0508)
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
+	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
 	err = c.WriteWordData(reg, data)
@@ -159,7 +159,7 @@ func TestDigisparkAdaptorI2cWriteBlockData(t *testing.T) {
 	reg := uint8(0x05)
 	data := []byte{0x80, 0x81, 0x82}
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
+	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
 	err = c.WriteBlockData(reg, data)
@@ -179,7 +179,7 @@ func TestDigisparkAdaptorI2cRead(t *testing.T) {
 	data := []byte{0, 1, 2, 3, 4}
 	dataLen := len(data)
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
+	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
 	count, err := c.Read(data)
@@ -198,7 +198,7 @@ func TestDigisparkAdaptorI2cRead(t *testing.T) {
 func TestDigisparkAdaptorI2cReadByte(t *testing.T) {
 	// arrange
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
+	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
 	data, err := c.ReadByte()
@@ -217,7 +217,7 @@ func TestDigisparkAdaptorI2cReadByteData(t *testing.T) {
 	// arrange
 	reg := uint8(0x04)
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
+	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
 	data, err := c.ReadByteData(reg)
@@ -239,7 +239,7 @@ func TestDigisparkAdaptorI2cReadWordData(t *testing.T) {
 	// 2 bytes of i2cData are used swapped
 	expectedValue := uint16(0x0405)
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
+	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
 	data, err := c.ReadWordData(reg)
@@ -261,7 +261,7 @@ func TestDigisparkAdaptorI2cReadBlockData(t *testing.T) {
 	data := []byte{0, 0, 0, 0, 0}
 	dataLen := len(data)
 	a := initTestAdaptorI2c()
-	c, err := a.GetConnection(availableI2cAddress, a.DefaultBus())
+	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
 	err = c.ReadBlockData(reg, data)
@@ -282,7 +282,7 @@ func TestDigisparkAdaptorI2cUpdateDelay(t *testing.T) {
 	var c i2c.Connection
 	var err error
 	a := initTestAdaptorI2c()
-	c, err = a.GetConnection(availableI2cAddress, a.DefaultBus())
+	c, err = a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
 	err = c.(*digisparkI2cConnection).UpdateDelay(uint(100))

--- a/platforms/dragonboard/dragonboard_adaptor_test.go
+++ b/platforms/dragonboard/dragonboard_adaptor_test.go
@@ -80,7 +80,7 @@ func TestFinalizeErrorAfterGPIO(t *testing.T) {
 
 func TestI2cDefaultBus(t *testing.T) {
 	a := initTestAdaptor(t)
-	gobottest.Assert(t, a.DefaultBus(), 0)
+	gobottest.Assert(t, a.DefaultI2cBus(), 0)
 }
 
 func TestI2cFinalizeWithErrors(t *testing.T) {
@@ -89,7 +89,7 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-1"})
 	gobottest.Assert(t, a.Connect(), nil)
-	con, err := a.GetConnection(0xff, 1)
+	con, err := a.GetI2cConnection(0xff, 1)
 	gobottest.Assert(t, err, nil)
 	_, err = con.Write([]byte{0xbf})
 	gobottest.Assert(t, err, nil)

--- a/platforms/firmata/firmata_adaptor.go
+++ b/platforms/firmata/firmata_adaptor.go
@@ -240,9 +240,9 @@ func (f *Adaptor) digitalPin(pin int) int {
 	return pin + 14
 }
 
-// GetConnection returns an i2c connection to a device on a specified bus.
+// GetI2cConnection returns an i2c connection to a device on a specified bus.
 // Only supports bus number 0
-func (f *Adaptor) GetConnection(address int, bus int) (connection i2c.Connection, err error) {
+func (f *Adaptor) GetI2cConnection(address int, bus int) (connection i2c.Connection, err error) {
 	if bus != 0 {
 		return nil, fmt.Errorf("Invalid bus number %d, only 0 is supported", bus)
 	}
@@ -250,7 +250,7 @@ func (f *Adaptor) GetConnection(address int, bus int) (connection i2c.Connection
 	return NewFirmataI2cConnection(f, address), err
 }
 
-// GetDefaultBus returns the default i2c bus for this platform
-func (f *Adaptor) DefaultBus() int {
+// DefaultI2cBus returns the default i2c bus for this platform
+func (f *Adaptor) DefaultI2cBus() int {
 	return 0
 }

--- a/platforms/firmata/firmata_i2c_test.go
+++ b/platforms/firmata/firmata_i2c_test.go
@@ -64,7 +64,7 @@ func newI2cMockFirmataBoard() *i2cMockFirmataBoard {
 func initTestTestAdaptorWithI2cConnection() (i2c.Connection, *i2cMockFirmataBoard) {
 	a := NewAdaptor()
 	a.Board = newI2cMockFirmataBoard()
-	con, err := a.GetConnection(0, 0)
+	con, err := a.GetI2cConnection(0, 0)
 	if err != nil {
 		panic(err)
 	}
@@ -238,11 +238,11 @@ func TestWriteBlockData(t *testing.T) {
 
 func TestDefaultBus(t *testing.T) {
 	a := NewAdaptor()
-	gobottest.Assert(t, a.DefaultBus(), 0)
+	gobottest.Assert(t, a.DefaultI2cBus(), 0)
 }
 
-func TestGetConnectionInvalidBus(t *testing.T) {
+func TestGetI2cConnectionInvalidBus(t *testing.T) {
 	a := NewAdaptor()
-	_, err := a.GetConnection(0x01, 99)
+	_, err := a.GetI2cConnection(0x01, 99)
 	gobottest.Assert(t, err, errors.New("Invalid bus number 99, only 0 is supported"))
 }

--- a/platforms/intel-iot/edison/edison_adaptor_test.go
+++ b/platforms/intel-iot/edison/edison_adaptor_test.go
@@ -231,7 +231,7 @@ func TestName(t *testing.T) {
 func TestConnect(t *testing.T) {
 	a, _ := initTestAdaptorWithMockedFilesystem("arduino")
 
-	gobottest.Assert(t, a.DefaultBus(), 6)
+	gobottest.Assert(t, a.DefaultI2cBus(), 6)
 	gobottest.Assert(t, a.board, "arduino")
 	gobottest.Assert(t, a.Connect(), nil)
 }
@@ -337,7 +337,7 @@ func TestConnectSparkfun(t *testing.T) {
 	a, _ := initTestAdaptorWithMockedFilesystem("sparkfun")
 
 	gobottest.Assert(t, a.Connect(), nil)
-	gobottest.Assert(t, a.DefaultBus(), 1)
+	gobottest.Assert(t, a.DefaultI2cBus(), 1)
 	gobottest.Assert(t, a.board, "sparkfun")
 }
 
@@ -345,7 +345,7 @@ func TestConnectMiniboard(t *testing.T) {
 	a, _ := initTestAdaptorWithMockedFilesystem("miniboard")
 
 	gobottest.Assert(t, a.Connect(), nil)
-	gobottest.Assert(t, a.DefaultBus(), 1)
+	gobottest.Assert(t, a.DefaultI2cBus(), 1)
 	gobottest.Assert(t, a.board, "miniboard")
 }
 
@@ -362,7 +362,7 @@ func TestFinalize(t *testing.T) {
 	a.DigitalWrite("3", 1)
 	a.PwmWrite("5", 100)
 
-	a.GetConnection(0xff, 6)
+	a.GetI2cConnection(0xff, 6)
 	gobottest.Assert(t, a.Finalize(), nil)
 
 	// assert that finalize after finalize is working
@@ -539,7 +539,7 @@ func TestI2cWorkflow(t *testing.T) {
 	a, _ := initTestAdaptorWithMockedFilesystem("arduino")
 	a.sys.UseMockSyscall()
 
-	con, err := a.GetConnection(0xff, 6)
+	con, err := a.GetI2cConnection(0xff, 6)
 	gobottest.Assert(t, err, nil)
 
 	_, err = con.Write([]byte{0x00, 0x01})
@@ -559,7 +559,7 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem(pwmMockPathsMux13ArduinoI2c)
 	gobottest.Assert(t, a.Connect(), nil)
-	con, err := a.GetConnection(0xff, 6)
+	con, err := a.GetI2cConnection(0xff, 6)
 	gobottest.Assert(t, err, nil)
 	_, err = con.Write([]byte{0x0A})
 	gobottest.Assert(t, err, nil)

--- a/platforms/intel-iot/joule/joule_adaptor_test.go
+++ b/platforms/intel-iot/joule/joule_adaptor_test.go
@@ -167,7 +167,7 @@ func TestPwmPinEnableError(t *testing.T) {
 
 func TestI2cDefaultBus(t *testing.T) {
 	a := NewAdaptor()
-	gobottest.Assert(t, a.DefaultBus(), 0)
+	gobottest.Assert(t, a.DefaultI2cBus(), 0)
 }
 
 func TestI2cFinalizeWithErrors(t *testing.T) {
@@ -176,7 +176,7 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-2"})
 	gobottest.Assert(t, a.Connect(), nil)
-	con, err := a.GetConnection(0xff, 2)
+	con, err := a.GetI2cConnection(0xff, 2)
 	gobottest.Assert(t, err, nil)
 	_, err = con.Write([]byte{0xbf})
 	gobottest.Assert(t, err, nil)

--- a/platforms/jetson/jetson_adaptor_test.go
+++ b/platforms/jetson/jetson_adaptor_test.go
@@ -58,7 +58,7 @@ func TestFinalize(t *testing.T) {
 
 	a.DigitalWrite("3", 1)
 
-	a.GetConnection(0xff, 0)
+	a.GetI2cConnection(0xff, 0)
 	gobottest.Assert(t, a.Finalize(), nil)
 }
 
@@ -161,7 +161,7 @@ func TestDigitalPinConcurrency(t *testing.T) {
 
 func TestI2cDefaultBus(t *testing.T) {
 	a := NewAdaptor()
-	gobottest.Assert(t, a.DefaultBus(), 1)
+	gobottest.Assert(t, a.DefaultI2cBus(), 1)
 }
 
 func TestI2cFinalizeWithErrors(t *testing.T) {
@@ -170,7 +170,7 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-1"})
 	gobottest.Assert(t, a.Connect(), nil)
-	con, err := a.GetConnection(0xff, 1)
+	con, err := a.GetI2cConnection(0xff, 1)
 	gobottest.Assert(t, err, nil)
 	_, err = con.Write([]byte{0xbf})
 	gobottest.Assert(t, err, nil)

--- a/platforms/raspi/raspi_adaptor.go
+++ b/platforms/raspi/raspi_adaptor.go
@@ -103,9 +103,9 @@ func (c *Adaptor) Finalize() error {
 	return err
 }
 
-// GetDefaultBus returns the default i2c bus for this platform.
+// DefaultI2cBus returns the default i2c bus for this platform.
 // This overrides the base function due to the revision dependency.
-func (c *Adaptor) DefaultBus() int {
+func (c *Adaptor) DefaultI2cBus() int {
 	rev := c.readRevision()
 	if rev == "2" || rev == "3" {
 		return 1

--- a/platforms/raspi/raspi_adaptor_test.go
+++ b/platforms/raspi/raspi_adaptor_test.go
@@ -79,7 +79,7 @@ func TestGetDefaultBus(t *testing.T) {
 			fs.Files[infoFile].Contents = fmt.Sprintf(contentPattern, tc.revisionPart)
 			gobottest.Assert(t, a.revision, "")
 			//act, will read and refresh the revision
-			gotBus := a.DefaultBus()
+			gotBus := a.DefaultI2cBus()
 			//assert
 			gobottest.Assert(t, a.revision, tc.wantRev)
 			gobottest.Assert(t, gotBus, tc.wantBus)
@@ -102,7 +102,7 @@ func TestFinalize(t *testing.T) {
 	a.DigitalWrite("3", 1)
 	a.PwmWrite("7", 255)
 
-	a.GetConnection(0xff, 0)
+	a.GetI2cConnection(0xff, 0)
 	gobottest.Assert(t, a.Finalize(), nil)
 }
 
@@ -258,10 +258,10 @@ func TestI2cDefaultBus(t *testing.T) {
 	a.sys.UseMockSyscall()
 
 	a.revision = "0"
-	gobottest.Assert(t, a.DefaultBus(), 0)
+	gobottest.Assert(t, a.DefaultI2cBus(), 0)
 
 	a.revision = "2"
-	gobottest.Assert(t, a.DefaultBus(), 1)
+	gobottest.Assert(t, a.DefaultI2cBus(), 1)
 }
 
 func TestI2cFinalizeWithErrors(t *testing.T) {
@@ -270,7 +270,7 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-1"})
 	gobottest.Assert(t, a.Connect(), nil)
-	con, err := a.GetConnection(0xff, 1)
+	con, err := a.GetI2cConnection(0xff, 1)
 	gobottest.Assert(t, err, nil)
 	_, err = con.Write([]byte{0xbf})
 	gobottest.Assert(t, err, nil)

--- a/platforms/tinkerboard/adaptor_test.go
+++ b/platforms/tinkerboard/adaptor_test.go
@@ -201,7 +201,7 @@ func TestFinalizeErrorAfterPWM(t *testing.T) {
 
 func TestI2cDefaultBus(t *testing.T) {
 	a := NewAdaptor()
-	gobottest.Assert(t, a.DefaultBus(), 1)
+	gobottest.Assert(t, a.DefaultI2cBus(), 1)
 }
 
 func TestI2cFinalizeWithErrors(t *testing.T) {
@@ -210,7 +210,7 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-4"})
 	gobottest.Assert(t, a.Connect(), nil)
-	con, err := a.GetConnection(0xff, 4)
+	con, err := a.GetI2cConnection(0xff, 4)
 	gobottest.Assert(t, err, nil)
 	_, err = con.Write([]byte{0xbf})
 	gobottest.Assert(t, err, nil)

--- a/platforms/upboard/up2/adaptor_test.go
+++ b/platforms/upboard/up2/adaptor_test.go
@@ -141,7 +141,7 @@ func TestFinalizeErrorAfterPWM(t *testing.T) {
 
 func TestI2cDefaultBus(t *testing.T) {
 	a := NewAdaptor()
-	gobottest.Assert(t, a.DefaultBus(), 5)
+	gobottest.Assert(t, a.DefaultI2cBus(), 5)
 }
 
 func TestI2cFinalizeWithErrors(t *testing.T) {
@@ -150,7 +150,7 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-5"})
 	gobottest.Assert(t, a.Connect(), nil)
-	con, err := a.GetConnection(0xff, 5)
+	con, err := a.GetI2cConnection(0xff, 5)
 	gobottest.Assert(t, err, nil)
 	_, err = con.Write([]byte{0xbf})
 	gobottest.Assert(t, err, nil)


### PR DESCRIPTION
Use the already existent base i2c_driver also for all remaining drivers, if possible. This reduces the lines of code and simplifies all tests. New tests can be now focused on the real driver implementations.

Interface changes to improve  visual differentiation on adaptor level:
* DefaultBus() --> DefaultI2cBus()
* GetConnection() --> GetI2cConnection()

Interface changes to be more conform with golang style:
* WithBus() --> SetBus()
* WithAddress() --> SetAddress()

Also moved the interfaces to client, to be more conform with golang style.