### PR TITLE
add platform NanoPi NEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ platforms are currently supported:
 - [MegaPi](http://www.makeblock.com/megapi) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/megapi)
 - [Microbit](http://microbit.org/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/microbit)
 - [MQTT](http://mqtt.org/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/mqtt)
+- [NanoPi NEO](https://wiki.friendlyelec.com/wiki/index.php/NanoPi_NEO) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/nanopi)
 - [NATS](http://nats.io/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/nats)
 - [Neurosky](http://neurosky.com/products-markets/eeg-biosensors/hardware/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/neurosky)
 - [OpenCV](http://opencv.org/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/opencv)

--- a/examples/nanopi_direct_pin.go
+++ b/examples/nanopi_direct_pin.go
@@ -1,0 +1,79 @@
+// +build example
+//
+// Do not build by default.
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/drivers/gpio"
+	"gobot.io/x/gobot/platforms/adaptors"
+	"gobot.io/x/gobot/platforms/nanopi"
+)
+
+// Wiring
+// PWR  NanoPi: 1, 17 (+3.3V, VCC); 2, 4 (+5V, VDD); 6, 9, 14, 20 (GND)
+// GPIO NanoPi: header pin 22 is input, pin 23 is normal output, pin 24 is inverted output
+// Button: the input pin is wired with a button to GND, the internal pull up resistor is used
+// LED's: the output pins are wired to the cathode of a LED, the anode is wired with a resistor (70-130Ohm for 20mA) to VCC
+// Expected behavior: always one LED is on, the other in opposite state, if button is pressed for >2 seconds the state changes
+func main() {
+	const (
+		inPinNum          = "22" // 7, 8, 10, 11, 12, 13, 15, 16, 18, 22
+		outPinNum         = "23"
+		outPinInvertedNum = "24"
+		debounceTime      = 2 * time.Second
+	)
+	// note: WithGpiosOpenDrain() is optional, if using WithGpiosOpenSource() the LED's will not light up
+	board := nanopi.NewNeoAdaptor(adaptors.WithGpiosActiveLow(outPinInvertedNum),
+		adaptors.WithGpiosOpenDrain(outPinNum, outPinInvertedNum),
+		adaptors.WithGpiosPullUp(inPinNum),
+		adaptors.WithGpioDebounce(inPinNum, debounceTime))
+
+	inPin := gpio.NewDirectPinDriver(board, inPinNum)
+	outPin := gpio.NewDirectPinDriver(board, outPinNum)
+	outPinInverted := gpio.NewDirectPinDriver(board, outPinInvertedNum)
+
+	work := func() {
+		level := byte(1)
+
+		gobot.Every(500*time.Millisecond, func() {
+			read, err := inPin.DigitalRead()
+			fmt.Printf("pin %s state is %d\n", inPinNum, read)
+			if err != nil {
+				fmt.Println(err)
+			} else {
+				level = byte(read)
+			}
+
+			err = outPin.DigitalWrite(level)
+			fmt.Printf("pin %s is now %d\n", outPinNum, level)
+			if err != nil {
+				fmt.Println(err)
+			}
+
+			err = outPinInverted.DigitalWrite(level)
+			fmt.Printf("pin %s is now not %d\n", outPinInvertedNum, level)
+			if err != nil {
+				fmt.Println(err)
+			}
+
+			if level == 1 {
+				level = 0
+			} else {
+				level = 1
+			}
+		})
+	}
+
+	robot := gobot.NewRobot("pinBot",
+		[]gobot.Connection{board},
+		[]gobot.Device{inPin, outPin, outPinInverted},
+		work,
+	)
+
+	robot.Start()
+}

--- a/examples/nanopi_direct_pin_event.go
+++ b/examples/nanopi_direct_pin_event.go
@@ -1,0 +1,101 @@
+// +build example
+//
+// Do not build by default.
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/platforms/nanopi"
+	"gobot.io/x/gobot/system"
+)
+
+const (
+	inPinNum          = "22" // 7, 8, 10, 11, 12, 13, 15, 16, 18, 22
+	outPinNum         = "23"
+	outPinInvertedNum = "24"
+	debounceTime      = 2 * time.Second
+)
+
+var (
+	outPin         gobot.DigitalPinner
+	outPinInverted gobot.DigitalPinner
+)
+
+// Wiring
+// PWR  NanoPi: 1, 17 (+3.3V, VCC); 2, 4 (+5V, VDD); 6, 9, 14, 20 (GND)
+// GPIO NanoPi: header pin 22 is input, pin 23 is normal output, pin 24 is inverted output
+// Button: the input pin is wired with a button to GND, the internal pull up resistor is used
+// LED's: the output pins are wired to the cathode of a LED, the anode is wired with a resistor (70-130Ohm for 20mA) to VCC
+// Expected behavior: always one LED is on, the other in opposite state, if button is pressed for >2 seconds the state changes
+func main() {
+
+	board := nanopi.NewNeoAdaptor()
+
+	work := func() {
+		inPin, err := board.DigitalPin(inPinNum)
+		if err != nil {
+			fmt.Println(err)
+		}
+		if err := inPin.ApplyOptions(system.WithPinDirectionInput(), system.WithPinPullUp(),
+			system.WithPinDebounce(debounceTime), system.WithPinEventOnBothEdges(buttonEventHandler)); err != nil {
+			fmt.Println(err)
+		}
+
+		// note: WithPinOpenDrain() is optional, if using WithPinOpenSource() the LED's will not light up
+		outPin, err = board.DigitalPin(outPinNum)
+		if err != nil {
+			fmt.Println(err)
+		}
+		if err := outPin.ApplyOptions(system.WithPinDirectionOutput(1), system.WithPinOpenDrain()); err != nil {
+			fmt.Println(err)
+		}
+
+		outPinInverted, err = board.DigitalPin(outPinInvertedNum)
+		if err != nil {
+			fmt.Println(err)
+		}
+		if err := outPinInverted.ApplyOptions(system.WithPinActiveLow(), system.WithPinDirectionOutput(1),
+			system.WithPinOpenDrain()); err != nil {
+			fmt.Println(err)
+		}
+
+		fmt.Printf("\nPlease press and hold the button for at least %s\n", debounceTime)
+	}
+
+	robot := gobot.NewRobot("pinEdgeBot",
+		[]gobot.Connection{board},
+		[]gobot.Device{},
+		work,
+	)
+
+	robot.Start()
+}
+
+func buttonEventHandler(offset int, t time.Duration, et string, sn uint32, lsn uint32) {
+	fmt.Printf("%s: %s detected on line %d with total sequence %d and line sequence %d\n", t, et, offset, sn, lsn)
+	level := 1
+
+	if et == "falling edge" {
+		level = 0
+	}
+
+	if outPin != nil {
+		err := outPin.Write(level)
+		fmt.Printf("pin %s is now %d\n", outPinNum, level)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}
+
+	if outPinInverted != nil {
+		err := outPinInverted.Write(level)
+		fmt.Printf("pin %s is now not %d\n", outPinInvertedNum, level)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}
+}

--- a/examples/nanopi_led_brightness.go
+++ b/examples/nanopi_led_brightness.go
@@ -1,0 +1,47 @@
+// +build example
+//
+// Do not build by default.
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/drivers/gpio"
+	"gobot.io/x/gobot/platforms/nanopi"
+)
+
+// Wiring
+// PWR  NanoPi: 1, 17 (+3.3V, VCC); 2, 4 (+5V, VDD); 6, 9, 14, 20 (GND)
+// GPIO NanoPi: the fourth header pin at inner USB side, count from USB side, is the PWM output
+// LED: the PWM output is NOT able to drive a 20mA LED with full brightness, so a custom driver or low current LED is needed
+// Expected behavior: the LED fades in and out
+func main() {
+	r := nanopi.NewNeoAdaptor()
+	led := gpio.NewLedDriver(r, "PWM")
+
+	work := func() {
+		brightness := uint8(0)
+		fadeAmount := uint8(15)
+
+		gobot.Every(100*time.Millisecond, func() {
+			if err := led.Brightness(brightness); err != nil {
+				fmt.Println(err)
+			}
+			brightness = brightness + fadeAmount
+			if brightness == 0 || brightness == 255 {
+				fadeAmount = -fadeAmount
+			}
+		})
+	}
+
+	robot := gobot.NewRobot("pwmBot",
+		[]gobot.Connection{r},
+		[]gobot.Device{led},
+		work,
+	)
+
+	robot.Start()
+}

--- a/examples/nanopi_pca9533.go
+++ b/examples/nanopi_pca9533.go
@@ -1,0 +1,131 @@
+// +build example
+//
+// Do not build by default.
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/drivers/i2c"
+	"gobot.io/x/gobot/platforms/nanopi"
+)
+
+// Wiring
+// PWR  NanoPi: 1, 17 (+3.3V, VCC); 2, 4 (+5V, VDD); 6, 9, 14, 20 (GND)
+// I2C0 NanoPi: 3 (SDA), 5 (SCL)
+// PCA9533: 8 (VDD, +2.3..5.5V), 4 (VSS, GND), 7 (SDA), 6 (SCL)
+// LED pins: 1 (LED0), 2 (LED1), 3 (LED2), 5 (LED3)
+// LED's directly driven with pull-up resistors to VDD, e.g. 180 Ohm
+// I2C addresses: 0x62 (PCA9533/01), 0x63 (PCA9533/02)
+func main() {
+	board := nanopi.NewNeoAdaptor()
+	pca := i2c.NewPCA953xDriver(board, i2c.WithAddress(0x63))
+
+	led := uint8(0)  // index of LED
+	wVal := uint8(1) // start with LED is "off"
+	rVal := uint8(0)
+
+	work := func() {
+		// LED 2 with 5 Hz 1:1, LED 3 with 1 Hz 1:10
+		initialize(pca, 5, 1)
+
+		gobot.Every(2000*time.Millisecond, func() {
+			fmt.Printf("set LED%d output to %d", led, wVal)
+			err := pca.WriteGPIO(led, wVal)
+			if err != nil {
+				fmt.Println("errW:", err)
+			}
+
+			rVal, err = pca.ReadGPIO(led)
+			if err != nil {
+				fmt.Println("errR:", err)
+			}
+			if rVal == 0 {
+				fmt.Printf(" - LED%d is ON\n", led)
+			} else {
+				fmt.Printf(" - LED%d is OFF\n", led)
+			}
+
+			led = led + 1
+			if led > 1 {
+				led = 0
+				if wVal == 1 {
+					wVal = 0
+				} else {
+					wVal = 1
+				}
+			}
+		})
+	}
+
+	robot := gobot.NewRobot("ledI2c",
+		[]gobot.Connection{board},
+		[]gobot.Device{pca},
+		work,
+	)
+
+	err := robot.Start()
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func initialize(pca *i2c.PCA953xDriver, led2FrequHz float32, led3FrequHz float32) {
+	// prepare PWM0
+	err := pca.WriteFrequency(0, led2FrequHz)
+	if err != nil {
+		fmt.Println("errWF0:", err)
+	}
+	frq, err := pca.ReadFrequency(0)
+	if err != nil {
+		fmt.Println("errRF0:", err)
+	}
+	fmt.Println("get Frq0:", frq)
+
+	err = pca.WriteDutyCyclePercent(0, 50)
+	if err != nil {
+		fmt.Println("errWD0:", err)
+	}
+	dc, err := pca.ReadDutyCyclePercent(0)
+	if err != nil {
+		fmt.Println("errRD0:", err)
+	}
+	fmt.Println("get dc0:", dc)
+
+	// prepare PWM1
+	err = pca.WriteFrequency(1, led3FrequHz)
+	if err != nil {
+		fmt.Println("errWF1:", err)
+	}
+	frq, err = pca.ReadFrequency(1)
+	if err != nil {
+		fmt.Println("errRF1:", err)
+	}
+	fmt.Println("get Frq1:", frq)
+
+	err = pca.WriteDutyCyclePercent(1, 10)
+	if err != nil {
+		fmt.Println("errWD1:", err)
+	}
+	dc, err = pca.ReadDutyCyclePercent(1)
+	if err != nil {
+		fmt.Println("errRD1:", err)
+	}
+	fmt.Println("get dc1:", dc)
+
+	// LED 2
+	fmt.Println("set LED: 2 to: pwm0")
+	err = pca.SetLED(2, i2c.PCA953xModePwm0)
+	if err != nil {
+		fmt.Println("errW:", err)
+	}
+	fmt.Println("set LED: 3 to: pwm1")
+	err = pca.SetLED(3, i2c.PCA953xModePwm1)
+	if err != nil {
+		fmt.Println("errW:", err)
+	}
+
+}

--- a/platforms/nanopi/LICENSE
+++ b/platforms/nanopi/LICENSE
@@ -1,0 +1,13 @@
+Copyright (c) 2014-2018 The Hybrid Group
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/platforms/nanopi/README.md
+++ b/platforms/nanopi/README.md
@@ -1,0 +1,91 @@
+# NanoPi Boards
+
+The FriendlyARM NanoPi Boards are single board SoC computers with different hardware design. It has built-in GPIO, PWM,
+SPI, and I2C interfaces.
+
+For more info about the NanoPi Boards, go to [https://wiki.friendlyelec.com/wiki/index.php/Main_Page](https://wiki.friendlyelec.com/wiki/index.php/Main_Page).
+
+## How to Install
+
+Tested OS:
+
+* [armbian](https://www.armbian.com/nanopi-neo/) with Debian or Ubuntu
+
+You would normally install Go and Gobot on your workstation. Once installed, cross compile your program on your
+workstation, transfer the final executable to your board, and run the program on the board as documented here.
+
+```sh
+go get -d -u gobot.io/x/gobot/...
+```
+
+### System access and configuration basics
+
+Please follow the installation instructions for the chosen OS.
+
+### Enabling hardware drivers
+
+Please follow the configuration instructions for the chosen OS.
+
+E.g. for armbian:
+
+```sh
+sudo armbian-config
+```
+
+After configuration was changed, an reboot is necessary.
+
+```sh
+sudo reboot
+```
+
+## How to Use
+
+The pin numbering used by your Gobot program should match the way your board is labeled right on the board itself.
+
+```go
+r := nanopi.NewNeoAdaptor()
+led := gpio.NewLedDriver(r, "7")
+```
+
+## How to Connect
+
+### Compiling
+
+Compile your Gobot program on your workstation like this:
+
+```sh
+GOARM=7 GOARCH=arm GOOS=linux go build examples/nanopi_blink.go
+```
+
+Once you have compiled your code, you can upload your program and execute it on the board from your workstation
+using the `scp` and `ssh` commands like this:
+
+```sh
+scp nanopi_blink nan@nanopineo:~
+ssh -t nan@nanopineo "./nanopi_blink"
+```
+
+## GPIO's
+
+At least for NEO, nearly all 14 GPIO's supports the advanced pin options "bias", "drive", "debounce" and "edge detection".
+
+> Configure of edge detection will cause an initial event. GPIO header pins 19, 21, 23, 24 - do NOT support "debounce" and
+> "edge detection" for NEO. Using unsupported options leads to reconfigure errors with text "no such device or address".
+
+## PWM
+
+A single PWM output is available at UART0-RX (UART_RXD0, internal PA5). So the UART0 needs to be disabled. The sunxi-
+overlay (e.g. for armbian) disables the UART0 and the kernel console at ttyS0. The related kernel module needs to be
+loaded: `sudo modprobe pwm-sun4i`. The default frequency is 100Hz.
+
+## I2C
+
+The default bus number is set to 0, which is connected to header pins 3 (PA12-SDA) and 5 (PA11-SCL). At least for NEO
+rev.1.4 it is possible to activate bus 1, which is connected to "USB/Audio/IR" header pins 9 "PCM0_CLK/I2S0_BCK"
+(PA19-SDA) and 8 "PCM0_SYNC/I2S0_LRC" (PA18-SCL). Armbian allows to activate bus 2 (PE12-SCL, PE13-SDA), which pins are
+not wired for NEO and NEO2, but we do not block it at adaptor side.
+
+## SPI
+
+There is a known issue on [armbian](https://forum.armbian.com/topic/20033-51525-breaks-spi-on-nanopi-neo-and-does-not-create-devspidev00/)
+for later Kernels.

--- a/platforms/nanopi/doc.go
+++ b/platforms/nanopi/doc.go
@@ -1,0 +1,7 @@
+/*
+Package nanopi contains the Gobot adaptor for the FriendlyARM NanoPi Boards.
+
+For further information refer to nanopi README:
+https://github.com/hybridgroup/gobot/blob/master/platforms/nanopi/README.md
+*/
+package nanopi // import "gobot.io/x/gobot/platforms/nanopi"

--- a/platforms/nanopi/nanopi_adaptor.go
+++ b/platforms/nanopi/nanopi_adaptor.go
@@ -1,0 +1,188 @@
+package nanopi
+
+import (
+	"fmt"
+	"sync"
+
+	multierror "github.com/hashicorp/go-multierror"
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/platforms/adaptors"
+	"gobot.io/x/gobot/system"
+)
+
+const (
+	debug = false
+
+	pwmInvertedIdentifier = "inversed"
+
+	defaultI2cBusNumber = 0
+
+	defaultSpiBusNumber  = 0
+	defaultSpiChipNumber = 0
+	defaultSpiMode       = 0
+	defaultSpiBitsNumber = 8
+	defaultSpiMaxSpeed   = 500000
+)
+
+type cdevPin struct {
+	chip uint8
+	line uint8
+}
+
+type gpioPinDefinition struct {
+	sysfs int
+	cdev  cdevPin
+}
+
+type pwmPinDefinition struct {
+	channel   int
+	dir       string
+	dirRegexp string
+}
+
+// Adaptor represents a Gobot Adaptor for the FriendlyARM NanoPi Boards
+type Adaptor struct {
+	name       string
+	sys        *system.Accesser
+	gpioPinMap map[string]gpioPinDefinition
+	pwmPinMap  map[string]pwmPinDefinition
+	mutex      sync.Mutex
+	*adaptors.DigitalPinsAdaptor
+	*adaptors.PWMPinsAdaptor
+	*adaptors.I2cBusAdaptor
+	*adaptors.SpiBusAdaptor
+}
+
+// NewNeoAdaptor creates a board adaptor for NanoPi NEO
+//
+// Optional parameters:
+//		adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs (still used by default)
+//		adaptors.WithSpiGpioAccess(sclk, nss, mosi, miso):	use GPIO's instead of /dev/spidev#.#
+//    adaptors.WithGpiosActiveLow(pin's): invert the pin behavior
+//    adaptors.WithGpiosPullUp/Down(pin's): sets the internal pull resistor
+//    adaptors.WithGpiosOpenDrain/Source(pin's): sets the output behavior
+//    adaptors.WithGpioDebounce(pin, period): sets the input debouncer
+//    adaptors.WithGpioEventOnFallingEdge/RaisingEdge/BothEdges(pin, handler): activate edge detection
+func NewNeoAdaptor(opts ...func(adaptors.Optioner)) *Adaptor {
+	sys := system.NewAccesser(system.WithDigitalPinGpiodAccess())
+	c := &Adaptor{
+		name:       gobot.DefaultName("NanoPi NEO Board"),
+		sys:        sys,
+		gpioPinMap: neoGpioPins,
+		pwmPinMap:  neoPwmPins,
+	}
+	c.DigitalPinsAdaptor = adaptors.NewDigitalPinsAdaptor(sys, c.translateDigitalPin, opts...)
+	c.PWMPinsAdaptor = adaptors.NewPWMPinsAdaptor(sys, c.translatePWMPin,
+		adaptors.WithPolarityInvertedIdentifier(pwmInvertedIdentifier))
+	c.I2cBusAdaptor = adaptors.NewI2cBusAdaptor(sys, c.validateI2cBusNumber, defaultI2cBusNumber)
+	c.SpiBusAdaptor = adaptors.NewSpiBusAdaptor(sys, c.validateSpiBusNumber, defaultSpiBusNumber, defaultSpiChipNumber,
+		defaultSpiMode, defaultSpiBitsNumber, defaultSpiMaxSpeed)
+	return c
+}
+
+// Name returns the name of the Adaptor
+func (c *Adaptor) Name() string { return c.name }
+
+// SetName sets the name of the Adaptor
+func (c *Adaptor) SetName(n string) { c.name = n }
+
+// Connect create new connection to board and pins.
+func (c *Adaptor) Connect() error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if err := c.SpiBusAdaptor.Connect(); err != nil {
+		return err
+	}
+
+	if err := c.I2cBusAdaptor.Connect(); err != nil {
+		return err
+	}
+
+	if err := c.PWMPinsAdaptor.Connect(); err != nil {
+		return err
+	}
+	return c.DigitalPinsAdaptor.Connect()
+}
+
+// Finalize closes connection to board, pins and bus
+func (c *Adaptor) Finalize() error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	err := c.DigitalPinsAdaptor.Finalize()
+
+	if e := c.PWMPinsAdaptor.Finalize(); e != nil {
+		err = multierror.Append(err, e)
+	}
+
+	if e := c.I2cBusAdaptor.Finalize(); e != nil {
+		err = multierror.Append(err, e)
+	}
+
+	if e := c.SpiBusAdaptor.Finalize(); e != nil {
+		err = multierror.Append(err, e)
+	}
+	return err
+}
+
+func (c *Adaptor) validateSpiBusNumber(busNr int) error {
+	// Valid bus numbers are [0] which corresponds to /dev/spidev0.x
+	// x is the chip number <255
+	if busNr != 0 {
+		return fmt.Errorf("Bus number %d out of range", busNr)
+	}
+	return nil
+}
+
+func (c *Adaptor) validateI2cBusNumber(busNr int) error {
+	// Valid bus number is [0..2] which corresponds to /dev/i2c-0 through /dev/i2c-2.
+	if (busNr < 0) || (busNr > 2) {
+		return fmt.Errorf("Bus number %d out of range", busNr)
+	}
+	return nil
+}
+
+func (c *Adaptor) translateDigitalPin(id string) (string, int, error) {
+	pindef, ok := c.gpioPinMap[id]
+	if !ok {
+		return "", -1, fmt.Errorf("'%s' is not a valid id for a digital pin", id)
+	}
+	if c.sys.IsSysfsDigitalPinAccess() {
+		return "", pindef.sysfs, nil
+	}
+	chip := fmt.Sprintf("gpiochip%d", pindef.cdev.chip)
+	line := int(pindef.cdev.line)
+	return chip, line, nil
+}
+
+func (c *Adaptor) translatePWMPin(id string) (string, int, error) {
+	pinInfo, ok := c.pwmPinMap[id]
+	if !ok {
+		return "", -1, fmt.Errorf("'%s' is not a valid id for a PWM pin", id)
+	}
+	path, err := pinInfo.findPWMDir(c.sys)
+	if err != nil {
+		return "", -1, err
+	}
+	return path, pinInfo.channel, nil
+}
+
+func (p pwmPinDefinition) findPWMDir(sys *system.Accesser) (dir string, err error) {
+	items, _ := sys.Find(p.dir, p.dirRegexp)
+	if items == nil || len(items) == 0 {
+		return "", fmt.Errorf("No path found for PWM directory pattern, '%s' in path '%s'. See README.md for activation",
+			p.dirRegexp, p.dir)
+	}
+
+	dir = items[0]
+	info, err := sys.Stat(dir)
+	if err != nil {
+		return "", fmt.Errorf("Error (%v) on access '%s'", err, dir)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("The item '%s' is not a directory, which is not expected", dir)
+	}
+
+	return
+}

--- a/platforms/nanopi/nanopi_adaptor_test.go
+++ b/platforms/nanopi/nanopi_adaptor_test.go
@@ -1,0 +1,378 @@
+package nanopi
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"gobot.io/x/gobot"
+	"gobot.io/x/gobot/drivers/gpio"
+	"gobot.io/x/gobot/drivers/i2c"
+	"gobot.io/x/gobot/gobottest"
+	"gobot.io/x/gobot/system"
+)
+
+const (
+	gpio203Path = "/sys/class/gpio/gpio203/"
+	gpio199Path = "/sys/class/gpio/gpio199/"
+)
+
+const (
+	pwmDir           = "/sys/devices/platform/soc/1c21400.pwm/pwm/pwmchip0/"
+	pwmPwmDir        = pwmDir + "pwm0/"
+	pwmExportPath    = pwmDir + "export"
+	pwmUnexportPath  = pwmDir + "unexport"
+	pwmEnablePath    = pwmPwmDir + "enable"
+	pwmPeriodPath    = pwmPwmDir + "period"
+	pwmDutyCyclePath = pwmPwmDir + "duty_cycle"
+	pwmPolarityPath  = pwmPwmDir + "polarity"
+)
+
+var pwmMockPaths = []string{
+	pwmExportPath,
+	pwmUnexportPath,
+	pwmEnablePath,
+	pwmPeriodPath,
+	pwmDutyCyclePath,
+	pwmPolarityPath,
+}
+
+var gpioMockPaths = []string{
+	"/sys/class/gpio/export",
+	"/sys/class/gpio/unexport",
+	gpio203Path + "value",
+	gpio203Path + "direction",
+	gpio199Path + "value",
+	gpio199Path + "direction",
+}
+
+// make sure that this Adaptor fulfills all the required interfaces
+var _ gobot.Adaptor = (*Adaptor)(nil)
+var _ gobot.DigitalPinnerProvider = (*Adaptor)(nil)
+var _ gobot.PWMPinnerProvider = (*Adaptor)(nil)
+var _ gpio.DigitalReader = (*Adaptor)(nil)
+var _ gpio.DigitalWriter = (*Adaptor)(nil)
+var _ gpio.PwmWriter = (*Adaptor)(nil)
+var _ gpio.ServoWriter = (*Adaptor)(nil)
+var _ i2c.Connector = (*Adaptor)(nil)
+
+func preparePwmFs(fs *system.MockFilesystem) {
+	fs.Files[pwmEnablePath].Contents = "0"
+	fs.Files[pwmPeriodPath].Contents = "0"
+	fs.Files[pwmDutyCyclePath].Contents = "0"
+	fs.Files[pwmPolarityPath].Contents = pwmInvertedIdentifier
+}
+
+func initTestAdaptorWithMockedFilesystem(mockPaths []string) (*Adaptor, *system.MockFilesystem) {
+	a := NewNeoAdaptor()
+	fs := a.sys.UseMockFilesystem(mockPaths)
+	if err := a.Connect(); err != nil {
+		panic(err)
+	}
+	return a, fs
+}
+
+func TestName(t *testing.T) {
+	a := NewNeoAdaptor()
+	gobottest.Assert(t, strings.HasPrefix(a.Name(), "NanoPi NEO Board"), true)
+	a.SetName("NewName")
+	gobottest.Assert(t, a.Name(), "NewName")
+}
+
+func TestDigitalIO(t *testing.T) {
+	// only basic tests needed, further tests are done in "digitalpinsadaptor.go"
+	a, fs := initTestAdaptorWithMockedFilesystem(gpioMockPaths)
+
+	a.DigitalWrite("7", 1)
+	gobottest.Assert(t, fs.Files[gpio203Path+"value"].Contents, "1")
+
+	fs.Files[gpio199Path+"value"].Contents = "1"
+	i, _ := a.DigitalRead("10")
+	gobottest.Assert(t, i, 1)
+
+	gobottest.Assert(t, a.DigitalWrite("99", 1), fmt.Errorf("'99' is not a valid id for a digital pin"))
+	gobottest.Assert(t, a.Finalize(), nil)
+}
+
+func TestInvalidPWMPin(t *testing.T) {
+	a, fs := initTestAdaptorWithMockedFilesystem(pwmMockPaths)
+	preparePwmFs(fs)
+
+	err := a.PwmWrite("666", 42)
+	gobottest.Assert(t, err.Error(), "'666' is not a valid id for a PWM pin")
+
+	err = a.ServoWrite("666", 120)
+	gobottest.Assert(t, err.Error(), "'666' is not a valid id for a PWM pin")
+
+	err = a.PwmWrite("3", 42)
+	gobottest.Assert(t, err.Error(), "'3' is not a valid id for a PWM pin")
+
+	err = a.ServoWrite("3", 120)
+	gobottest.Assert(t, err.Error(), "'3' is not a valid id for a PWM pin")
+}
+
+func TestPwmWrite(t *testing.T) {
+	a, fs := initTestAdaptorWithMockedFilesystem(pwmMockPaths)
+	preparePwmFs(fs)
+
+	err := a.PwmWrite("PWM", 100)
+	gobottest.Assert(t, err, nil)
+
+	gobottest.Assert(t, fs.Files[pwmExportPath].Contents, "0")
+	gobottest.Assert(t, fs.Files[pwmEnablePath].Contents, "1")
+	gobottest.Assert(t, fs.Files[pwmPeriodPath].Contents, fmt.Sprintf("%d", 10000000))
+	gobottest.Assert(t, fs.Files[pwmDutyCyclePath].Contents, "3921568")
+	gobottest.Assert(t, fs.Files[pwmPolarityPath].Contents, "normal")
+
+	err = a.ServoWrite("PWM", 0)
+	gobottest.Assert(t, err, nil)
+
+	gobottest.Assert(t, fs.Files[pwmDutyCyclePath].Contents, "500000")
+
+	err = a.ServoWrite("PWM", 180)
+	gobottest.Assert(t, err, nil)
+
+	gobottest.Assert(t, fs.Files[pwmDutyCyclePath].Contents, "2000000")
+	gobottest.Assert(t, a.Finalize(), nil)
+}
+
+func TestSetPeriod(t *testing.T) {
+	// arrange
+	a, fs := initTestAdaptorWithMockedFilesystem(pwmMockPaths)
+	preparePwmFs(fs)
+
+	newPeriod := uint32(2550000)
+	// act
+	err := a.SetPeriod("PWM", newPeriod)
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, fs.Files[pwmExportPath].Contents, "0")
+	gobottest.Assert(t, fs.Files[pwmEnablePath].Contents, "1")
+	gobottest.Assert(t, fs.Files[pwmPeriodPath].Contents, fmt.Sprintf("%d", newPeriod))
+	gobottest.Assert(t, fs.Files[pwmDutyCyclePath].Contents, "0")
+	gobottest.Assert(t, fs.Files[pwmPolarityPath].Contents, "normal")
+
+	// arrange test for automatic adjustment of duty cycle to lower value
+	err = a.PwmWrite("PWM", 127) // 127 is a little bit smaller than 50% of period
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, fs.Files[pwmDutyCyclePath].Contents, fmt.Sprintf("%d", 1270000))
+	newPeriod = newPeriod / 10
+
+	// act
+	err = a.SetPeriod("PWM", newPeriod)
+
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, fs.Files[pwmDutyCyclePath].Contents, fmt.Sprintf("%d", 127000))
+
+	// arrange test for automatic adjustment of duty cycle to higher value
+	newPeriod = newPeriod * 20
+
+	// act
+	err = a.SetPeriod("PWM", newPeriod)
+
+	// assert
+	gobottest.Assert(t, err, nil)
+	gobottest.Assert(t, fs.Files[pwmDutyCyclePath].Contents, fmt.Sprintf("%d", 2540000))
+}
+
+func TestFinalizeErrorAfterGPIO(t *testing.T) {
+	a, fs := initTestAdaptorWithMockedFilesystem(gpioMockPaths)
+
+	gobottest.Assert(t, a.DigitalWrite("7", 1), nil)
+
+	fs.WithWriteError = true
+
+	err := a.Finalize()
+	gobottest.Assert(t, strings.Contains(err.Error(), "write error"), true)
+}
+
+func TestFinalizeErrorAfterPWM(t *testing.T) {
+	a, fs := initTestAdaptorWithMockedFilesystem(pwmMockPaths)
+	preparePwmFs(fs)
+
+	gobottest.Assert(t, a.PwmWrite("PWM", 1), nil)
+
+	fs.WithWriteError = true
+
+	err := a.Finalize()
+	gobottest.Assert(t, strings.Contains(err.Error(), "write error"), true)
+}
+
+func TestSpiDefaultValues(t *testing.T) {
+	a := NewNeoAdaptor()
+
+	gobottest.Assert(t, a.SpiDefaultBusNumber(), 0)
+	gobottest.Assert(t, a.SpiDefaultChipNumber(), 0)
+	gobottest.Assert(t, a.SpiDefaultMode(), 0)
+	gobottest.Assert(t, a.SpiDefaultBitCount(), 8)
+	gobottest.Assert(t, a.SpiDefaultMaxSpeed(), int64(500000))
+}
+
+func TestI2cDefaultBus(t *testing.T) {
+	a := NewNeoAdaptor()
+	gobottest.Assert(t, a.DefaultI2cBus(), 0)
+}
+
+func TestI2cFinalizeWithErrors(t *testing.T) {
+	// arrange
+	a := NewNeoAdaptor()
+	a.sys.UseMockSyscall()
+	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-1"})
+	gobottest.Assert(t, a.Connect(), nil)
+	con, err := a.GetI2cConnection(0xff, 1)
+	gobottest.Assert(t, err, nil)
+	_, err = con.Write([]byte{0xbf})
+	gobottest.Assert(t, err, nil)
+	fs.WithCloseError = true
+	// act
+	err = a.Finalize()
+	// assert
+	gobottest.Assert(t, strings.Contains(err.Error(), "close error"), true)
+}
+
+func Test_validateSpiBusNumber(t *testing.T) {
+	var tests = map[string]struct {
+		busNr   int
+		wantErr error
+	}{
+		"number_negative_error": {
+			busNr:   -1,
+			wantErr: fmt.Errorf("Bus number -1 out of range"),
+		},
+		"number_0_ok": {
+			busNr: 0,
+		},
+		"number_1_error": {
+			busNr:   1,
+			wantErr: fmt.Errorf("Bus number 1 out of range"),
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			a := NewNeoAdaptor()
+			// act
+			err := a.validateSpiBusNumber(tc.busNr)
+			// assert
+			gobottest.Assert(t, err, tc.wantErr)
+		})
+	}
+}
+
+func Test_validateI2cBusNumber(t *testing.T) {
+	var tests = map[string]struct {
+		busNr   int
+		wantErr error
+	}{
+		"number_negative_error": {
+			busNr:   -1,
+			wantErr: fmt.Errorf("Bus number -1 out of range"),
+		},
+		"number_0_ok": {
+			busNr: 0,
+		},
+		"number_1_ok": {
+			busNr: 1,
+		},
+		"number_2_ok": {
+			busNr: 2,
+		},
+		"number_3_error": {
+			busNr:   3,
+			wantErr: fmt.Errorf("Bus number 3 out of range"),
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			a := NewNeoAdaptor()
+			// act
+			err := a.validateI2cBusNumber(tc.busNr)
+			// assert
+			gobottest.Assert(t, err, tc.wantErr)
+		})
+	}
+}
+
+func Test_translateDigitalPin(t *testing.T) {
+	var tests = map[string]struct {
+		access   string
+		pin      string
+		wantChip string
+		wantLine int
+		wantErr  error
+	}{
+		"cdev_ok": {
+			access:   "cdev",
+			pin:      "7",
+			wantChip: "gpiochip0",
+			wantLine: 203,
+		},
+		"sysfs_ok": {
+			access:   "sysfs",
+			pin:      "7",
+			wantChip: "",
+			wantLine: 203,
+		},
+		"unknown_pin": {
+			pin:      "99",
+			wantChip: "",
+			wantLine: -1,
+			wantErr:  fmt.Errorf("'99' is not a valid id for a digital pin"),
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			a := NewNeoAdaptor()
+			a.sys.UseDigitalPinAccessWithMockFs(tc.access, []string{})
+			// act
+			chip, line, err := a.translateDigitalPin(tc.pin)
+			// assert
+			gobottest.Assert(t, err, tc.wantErr)
+			gobottest.Assert(t, chip, tc.wantChip)
+			gobottest.Assert(t, line, tc.wantLine)
+		})
+	}
+}
+
+func Test_translatePWMPin(t *testing.T) {
+	basePaths := []string{"/sys/devices/platform/soc/1c21400.pwm/pwm/"}
+	var tests = map[string]struct {
+		pin         string
+		chip        string
+		wantDir     string
+		wantChannel int
+		wantErr     error
+	}{
+		"33_chip0": {
+			pin:         "PWM",
+			chip:        "pwmchip0",
+			wantDir:     "/sys/devices/platform/soc/1c21400.pwm/pwm/pwmchip0",
+			wantChannel: 0,
+		},
+		"invalid_pin": {
+			pin:         "7",
+			wantDir:     "",
+			wantChannel: -1,
+			wantErr:     fmt.Errorf("'7' is not a valid id for a PWM pin"),
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			mockedPaths := []string{}
+			for _, base := range basePaths {
+				mockedPaths = append(mockedPaths, base+tc.chip+"/")
+			}
+			a, _ := initTestAdaptorWithMockedFilesystem(mockedPaths)
+			// act
+			dir, channel, err := a.translatePWMPin(tc.pin)
+			// assert
+			gobottest.Assert(t, err, tc.wantErr)
+			gobottest.Assert(t, dir, tc.wantDir)
+			gobottest.Assert(t, channel, tc.wantChannel)
+		})
+	}
+}

--- a/platforms/nanopi/nanopineo_pin_map.go
+++ b/platforms/nanopi/nanopineo_pin_map.go
@@ -1,0 +1,25 @@
+package nanopi
+
+// pin definition for NanoPi NEO
+// pins: A=0+Nr, C=64+Nr, G=192+Nr
+var neoGpioPins = map[string]gpioPinDefinition{
+	"11": gpioPinDefinition{sysfs: 0, cdev: cdevPin{chip: 0, line: 0}},     // UART2_TX/GPIOA0
+	"22": gpioPinDefinition{sysfs: 1, cdev: cdevPin{chip: 0, line: 1}},     // UART2_RX/GPIOA1
+	"13": gpioPinDefinition{sysfs: 2, cdev: cdevPin{chip: 0, line: 2}},     // UART2_RTS/GPIOA2
+	"15": gpioPinDefinition{sysfs: 3, cdev: cdevPin{chip: 0, line: 3}},     // UART2_CTS/GPIOA3
+	"12": gpioPinDefinition{sysfs: 6, cdev: cdevPin{chip: 0, line: 6}},     // GPIOA6
+	"19": gpioPinDefinition{sysfs: 64, cdev: cdevPin{chip: 0, line: 64}},   // SPI0_MOSI/GPIOC0
+	"21": gpioPinDefinition{sysfs: 65, cdev: cdevPin{chip: 0, line: 65}},   // SPI0_MISO/GPIOC1
+	"23": gpioPinDefinition{sysfs: 66, cdev: cdevPin{chip: 0, line: 66}},   // SPI0_CLK/GPIOC2
+	"24": gpioPinDefinition{sysfs: 67, cdev: cdevPin{chip: 0, line: 67}},   // SPI0_CS/GPIOC3
+	"8":  gpioPinDefinition{sysfs: 198, cdev: cdevPin{chip: 0, line: 198}}, // UART1_TX/GPIOG6
+	"10": gpioPinDefinition{sysfs: 199, cdev: cdevPin{chip: 0, line: 199}}, // UART1_RX/GPIOG7
+	"16": gpioPinDefinition{sysfs: 200, cdev: cdevPin{chip: 0, line: 200}}, // UART1_RTS/GPIOG8
+	"18": gpioPinDefinition{sysfs: 201, cdev: cdevPin{chip: 0, line: 201}}, // UART1_CTS/GPIOG9
+	"7":  gpioPinDefinition{sysfs: 203, cdev: cdevPin{chip: 0, line: 203}}, // GPIOG11
+}
+
+var neoPwmPins = map[string]pwmPinDefinition{
+	// UART_RXD0, GPIOA5, PWM
+	"PWM": pwmPinDefinition{dir: "/sys/devices/platform/soc/1c21400.pwm/pwm/", dirRegexp: "pwmchip[0]$", channel: 0},
+}


### PR DESCRIPTION
This adapter supports NanoPi NEO and most likely NEO2 (except for header pins 3 and 5, which are shared with I2C0 and not mapped in the adapter). It was tested with NEO together with all provided examples (GPIO, PWM, I2C).