### PR TITLE
Add(build): golangci-lint workflow configuration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,18 +4,20 @@
 
 ## Manual test
 
-* OS and Version (Win/Mac/Linux):
-* Adaptor(s) and/or driver(s):
+- OS and Version (Win/Mac/Linux):
+- Adaptor(s) and/or driver(s):
 ...
 
 ## Checklist
 
 - [ ] The PR's target branch is 'hybridgroup:dev'
-- [ ] I have performed a self-review of my own code
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes (e.g. by run `make test`)
+- [ ] No linter errors exist locally (e.g. by run `make fmt_check`)
+- [ ] I have performed a self-review of my own code
 
 If this is a new driver or adaptor:
+
 - [ ] I have added the name to the corresponding README.md
 - [ ] I have added an example to see how to setup and use it
 - [ ] I have checked or build at least my new example (e.g. by run `make examples_check`)

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -5,7 +5,6 @@ on:
       - v*
     branches:
       - dev
-      - release
   pull_request:
 permissions:
   contents: read

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,47 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - dev
+      - release
+  pull_request:
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.17'
+          cache: false
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.52.2
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true then the all caching functionality will be complete disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,43 @@
+run:
+  # Timeout for analysis, e.g. 30s, 5m.
+  # gobot is very expensive, on a machine with heavy load it takes some minutes
+  # for first run or after empty the cache by 'golangci-lint cache clean'
+  # Default: 1m
+  timeout: 5m
+
+  # If set we pass it to "go list -mod={option}". From "go help modules":
+  # If invoked with -mod=readonly, the go command is disallowed from the implicit
+  # automatic updating of go.mod described above. Instead, it fails when any changes
+  # to go.mod are needed. This setting is most useful to check that go.mod does
+  # not need updates, such as in a continuous integration and testing system.
+  # If invoked with -mod=vendor, the go command assumes that the vendor
+  # directory holds the correct copies of dependencies and ignores
+  # the dependency descriptions in go.mod.
+  #
+  # Allowed values: readonly|vendor|mod
+  # By default, it isn't set.
+  modules-download-mode: readonly
+
+  # Enables skipping of directories:
+  # - vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  # Default: true
+  skip-dirs-use-default: false
+
+  # note: examples will be currently omitted by the build tag
+  skip-dirs:
+    - platforms/opencv/
+
+linters:
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  # note: typecheck can not be disabled, it is used to check code compilation
+  #
+  # TODO: this default linters needs to be disabled to run successfully, we have to fix
+  #       all issues step by step to enable at least the default linters
+  disable:
+    - errcheck
+    - gosimple
+    #- govet
+    - ineffassign
+    - staticcheck
+    - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,7 @@ run:
 
   # note: examples will be currently omitted by the build tag
   skip-dirs:
-    - platforms/opencv/
+    - platforms/opencv
 
 linters:
   # Enable specific linter

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to Gobot
 
 ## Target Branch
+
 **Please open all non-hotfix PRs against the `dev` branch!**
 
 Gobot follows a ["git flow"](http://nvie.com/posts/a-successful-git-branching-model/)-style model for managing development.
@@ -19,23 +20,27 @@ This document will guide you through the contribution process.
 
 What do you want to contribute?
 
-- I want to otherwise correct or improve the docs or examples
-- I want to report a bug
-- I want to add some feature or functionality to an existing hardware platform
-- I want to add support for a new hardware platform
+* I want to otherwise correct or improve the docs or examples
+* I want to report a bug
+* I want to add some feature or functionality to an existing hardware platform
+* I want to add support for a new hardware platform
 
 Descriptions for each of these will eventually be provided below.
 
 ## General Guidelines
 
-* All active development is in the `dev` branch. New or updated features must be added to the `dev` branch. Hotfixes will be considered on the `master` branch in situations where it does not alter behaviour or features, only fixes a bug.
+* All active development is in the `dev` branch. New or updated features must be added to the `dev` branch. Hotfixes
+  will be considered on the `master` branch in situations where it does not alter behavior or features, only fixes a bug.
 * All patches must be provided under the Apache 2.0 License
-* Please use the -S option in git to "sign off" that the commit is your work and you are providing it under the Apache 2.0 License
+* Please use the -S option in git to "sign off" that the commit is your work and you are providing it under the
+  Apache 2.0 License
 * Submit a Github Pull Request to the appropriate branch and ideally discuss the changes with us in IRC.
 * We will look at the patch, test it out, and give you feedback.
-* Avoid doing minor whitespace changes, renamings, etc. along with merged content. These will be done by the maintainers from time to time but they can complicate merges and should be done seperately.
+* Avoid doing minor whitespace changes, renamings, etc. along with merged content. These will be done by the maintainers
+  from time to time but they can complicate merges and should be done separately.
 * Take care to maintain the existing coding style.
-* `golint` and `go fmt` your code.
+* `golangci-lint` your code, see [instruction for local installation](https://golangci-lint.run/usage/install/#local-installation)
+* `go fmt` your code (with the go version of go.mod)
 * Add unit tests for any new or changed functionality.
 * All pull requests should be "fast forward"
   * If there are commits after yours use “git rebase -i <new_head_branch>”
@@ -43,6 +48,7 @@ Descriptions for each of these will eventually be provided below.
   * For git help see [progit](http://git-scm.com/book) which is an awesome (and free) book on git
 
 ## Creating Pull Requests
+
 Because Gobot makes use of self-referencing import paths, you will want
 to implement the local copy of your fork as a remote on your copy of the
 original Gobot repo. Katrina Owen has [an excellent post on this workflow](https://splice.com/blog/contributing-open-source-git-repositories-go/).
@@ -53,34 +59,38 @@ The basics are as follows:
 
 2. `go get` the upstream repo and set it up as the `upstream` remote and your own repo as the `origin` remote:
 
-`go get gobot.io/x/gobot`
-`cd $GOPATH/src/gobot.io/x/gobot`
-`git remote rename origin upstream`
-`git remote add origin git@github.com/YOUR_GITHUB_NAME/gobot`
+    `go get gobot.io/x/gobot`
+    `cd $GOPATH/src/gobot.io/x/gobot`
+    `git remote rename origin upstream`
+    `git remote add origin git@github.com/YOUR_GITHUB_NAME/gobot`
 
-All import paths should now work fine assuming that you've got the
-proper branch checked out.
+    All import paths should now work fine assuming that you've got the
+    proper branch checked out.
 
-3. Get all the needed gobot's dependencies each of them at their needed version. Gobot uses [dep (Dependency management for Go)](https://golang.github.io/dep/) to manage the project's dependencies. To get all the correct dependencies:
+3. Get all the needed gobot's dependencies each of them at their needed version. Gobot uses
+   [dep (Dependency management for Go)](https://golang.github.io/dep/) to manage the project's dependencies. To get all
+   the correct dependencies:
 
-* Install dep tool. Follow the dep [installation](https://golang.github.io/dep/docs/installation.html) instructions in case you don't have it already installed.
-* `cd $GOPATH/src/gobot.io/x/gobot` 
-* `dep ensure` will fetch  all the dependencies at their needed version.
+   * Install dep tool. Follow the dep [installation](https://golang.github.io/dep/docs/installation.html) instructions in
+     case you don't have it already installed.
+   * `cd $GOPATH/src/gobot.io/x/gobot`
+   * `dep ensure` will fetch  all the dependencies at their needed version.
 
 ## Landing Pull Requests
+
 (This is for committers only. If you are unsure whether you are a committer, you are not.)
 
 1. Set the contributor's fork as an upstream on your checkout
 
-`git remote add contrib1 https://github.com/contrib1/gobot`
+   `git remote add contrib1 https://github.com/contrib1/gobot`
 
 2. Fetch the contributor's repo
 
-`git fetch contrib1`
+   `git fetch contrib1`
 
 3. Checkout a copy of the PR branch
 
-`git checkout pr-1234 --track contrib1/branch-for-pr-1234`
+   `git checkout pr-1234 --track contrib1/branch-for-pr-1234`
 
 4. Review the PR as normal
 
@@ -104,7 +114,8 @@ By making a contribution to this project, I certify that:
 
 ## Code of Conduct
 
-Gobot is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms. [You can read about it here](CODE_OF_CONDUCT.md).
+Gobot is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms.
+[You can read about it here](CODE_OF_CONDUCT.md).
 
 ## Origins
 

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,12 @@
 ALL_EXAMPLES := $(shell grep -l -r --include "*.go" 'build example' ./)
 # prevent examples with gocv (opencv) dependencies
 EXAMPLES_NO_GOCV := $(shell grep -L 'gocv' $(ALL_EXAMPLES))
+# prevent examples with joystick (sdl2) dependencies
+EXAMPLES_NO_JOYSTICK := $(shell grep -L 'joystick' $(ALL_EXAMPLES))
 # prevent examples with joystick (sdl2) and gocv (opencv) dependencies
 EXAMPLES_NO_GOCV_JOYSTICK := $(shell grep -L 'joystick' $$(grep -L 'gocv' $(EXAMPLES_NO_GOCV)))
 # used examples
-EXAMPLES := $(EXAMPLES_NO_GOCV)
+EXAMPLES := $(EXAMPLES_NO_GOCV_JOYSTICK)
 
 .PHONY: test test_race test_cover robeaux version_check fmt_check fmt_fix examples examples_check $(EXAMPLES)
 
@@ -54,8 +56,8 @@ version_check:
 
 # Check for bad code style and other issues
 fmt_check:
-	gofmt -l ./
-	go vet ./...
+	gofmt -l ./	
+	golangci-lint run -v
 
 # Fix bad code style (will only be executed, on version match)
 fmt_fix: version_check


### PR DESCRIPTION
## Solved issues and/or description of the change

Try to solve the #544 in several steps in a state of the art way: [golangci-lint](https://github.com/golangci/golangci-lint). This is the first step by introducing the linter itself with most features disabled to make it pass. Afterwards some features will be enabled step by step together with resolving the existing issues.

## Manual test

* OS and Version (Win/Mac/Linux): Linux - golangci-lint has version 1.52.2 built with go1.20.2 from da04413a on 2023-03-25T18:11:28Z

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] No linter errors exist with CI --> changed it to **exactly one** error occur for test purposes
- [x] No linter errors exist locally (make fmt_check) --> changed it to **exactly one** error occur for test purposes
- [x] Documentation is updated
- [x] I have performed a self-review of my own code
- [x] Adjust PR checklist related to linter issues