### PR TITLE
Fix(build): linter findings of "gosimple", "govet" and "staticcheck"

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -30,7 +30,8 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
+          # mostly there is no problem locally, but on server: "could not import C (cgo preprocessing failed) (typecheck)"
+          args: --skip-files platforms/digispark/littleWire.go
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,10 +37,21 @@ linters:
   disable:
     - errcheck
     - ineffassign
-    - staticcheck
+    #- staticcheck
     - unused
 
+  enable:
+    - nolintlint
+
 linters-settings:
+  nolintlint:
+    # Enable to require an explanation of nonzero length after each nolint directive.
+    # Default: false
+    require-explanation: true
+    # Enable to require nolint directives to mention the specific linter being suppressed.
+    # Default: false
+    require-specific: true
+
   revive:
     rules:
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-return

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,3 +41,12 @@ linters:
     - ineffassign
     - staticcheck
     - unused
+
+linters-settings:
+  revive:
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-return
+      # disable this rule, because sometimes it has its justification
+      - name: unexported-return
+        severity: warning
+        disabled: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,8 +36,6 @@ linters:
   #       all issues step by step to enable at least the default linters
   disable:
     - errcheck
-    #- gosimple
-    #- govet
     - ineffassign
     - staticcheck
     - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,7 @@ linters:
   #       all issues step by step to enable at least the default linters
   disable:
     - errcheck
-    - gosimple
+    #- gosimple
     #- govet
     - ineffassign
     - staticcheck

--- a/api/api.go
+++ b/api/api.go
@@ -109,7 +109,6 @@ func (a *API) Start() {
 
 // StartWithoutDefaults initializes the api without setting up the default routes.
 // Good for custom web interfaces.
-//
 func (a *API) StartWithoutDefaults() {
 	a.start(a)
 }
@@ -117,7 +116,6 @@ func (a *API) StartWithoutDefaults() {
 // AddC3PIORoutes adds all of the standard C3PIO routes to the API.
 // For more information, please see:
 // http://cppp.io/
-//
 func (a *API) AddC3PIORoutes() {
 	mcpCommandRoute := "/api/commands/:command"
 	robotDeviceCommandRoute := "/api/robots/:robot/devices/:device/commands/:command"
@@ -250,10 +248,8 @@ func (a *API) robotDevice(res http.ResponseWriter, req *http.Request) {
 
 func (a *API) robotDeviceEvent(res http.ResponseWriter, req *http.Request) {
 	f, _ := res.(http.Flusher)
-	c, _ := res.(http.CloseNotifier)
 
 	dataChan := make(chan string)
-	closer := c.CloseNotify()
 
 	res.Header().Set("Content-Type", "text/event-stream")
 	res.Header().Set("Cache-Control", "no-cache")
@@ -275,7 +271,7 @@ func (a *API) robotDeviceEvent(res http.ResponseWriter, req *http.Request) {
 			case data := <-dataChan:
 				fmt.Fprintf(res, "data: %v\n\n", data)
 				f.Flush()
-			case <-closer:
+			case <-req.Context().Done():
 				log.Println("Closing connection")
 				return
 			}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -81,7 +81,7 @@ func TestIndex(t *testing.T) {
 	a.ServeHTTP(response, request)
 
 	gobottest.Assert(t, http.StatusMovedPermanently, response.Code)
-	gobottest.Assert(t, "/index.html", response.HeaderMap["Location"][0])
+	gobottest.Assert(t, "/index.html", response.Header()["Location"][0])
 }
 
 func TestMcp(t *testing.T) {

--- a/cli/generate.go
+++ b/cli/generate.go
@@ -30,7 +30,7 @@ func Generate() cli.Command {
 					valid = true
 				}
 			}
-			if valid == false {
+			if !valid {
 				fmt.Println("Invalid/no subcommand supplied.")
 				fmt.Println("Usage:")
 				fmt.Println(" gobot generate adaptor <name> [package] # generate a new Gobot adaptor")
@@ -149,11 +149,11 @@ func generatePlatform(c config) error {
 
 	c.dir = dir
 
-	if exp, err := ioutil.ReadFile(exampleDir + "/main.go"); err != nil {
+	exp, err := ioutil.ReadFile(exampleDir + "/main.go")
+	if err != nil {
 		return err
-	} else {
-		c.Example = string(exp)
 	}
+	c.Example = string(exp)
 
 	return generate(c, "README.md", readme())
 }

--- a/cli/generate.go
+++ b/cli/generate.go
@@ -102,7 +102,7 @@ func generate(c config, file string, tmpl string) error {
 	fmt.Println("Creating", fileLocation)
 
 	f, err := os.Create(fileLocation)
-	defer f.Close()
+	defer f.Close() //nolint:staticcheck // for historical reasons
 	if err != nil {
 		return err
 	}

--- a/commander.go
+++ b/commander.go
@@ -22,10 +22,9 @@ func NewCommander() Commander {
 	}
 }
 
-// Command returns the command interface whene passed a valid command name
-func (c *commander) Command(name string) (command func(map[string]interface{}) interface{}) {
-	command, _ = c.commands[name]
-	return
+// Command returns the command interface when passed a valid command name
+func (c *commander) Command(name string) func(map[string]interface{}) interface{} {
+	return c.commands[name]
 }
 
 // Commands returns the entire map of valid commands

--- a/drivers/common/mfrc522/mfrc522_pcd.go
+++ b/drivers/common/mfrc522/mfrc522_pcd.go
@@ -328,6 +328,9 @@ func (d *MFRC522Common) writeFifo(fifoData []byte) error {
 
 func (d *MFRC522Common) readFifo(backData []byte) (uint8, error) {
 	n, err := d.readByteData(regFIFOLevel) // Number of bytes in the FIFO
+	if err != nil {
+		return 0, err
+	}
 	if n > uint8(len(backData)) {
 		return 0, fmt.Errorf("more data in FIFO (%d) than expected (%d)", n, len(backData))
 	}

--- a/drivers/gpio/button_driver_test.go
+++ b/drivers/gpio/button_driver_test.go
@@ -35,7 +35,7 @@ func TestButtonDriver(t *testing.T) {
 }
 
 func TestButtonDriverStart(t *testing.T) {
-	sem := make(chan bool, 0)
+	sem := make(chan bool)
 	a := newGpioTestAdaptor()
 	d := NewButtonDriver(a, "1")
 
@@ -107,7 +107,7 @@ func TestButtonDriverStart(t *testing.T) {
 }
 
 func TestButtonDriverDefaultState(t *testing.T) {
-	sem := make(chan bool, 0)
+	sem := make(chan bool)
 	a := newGpioTestAdaptor()
 	d := NewButtonDriver(a, "1")
 	d.DefaultState = 1

--- a/drivers/gpio/pir_motion_driver_test.go
+++ b/drivers/gpio/pir_motion_driver_test.go
@@ -35,7 +35,7 @@ func TestPIRMotionDriver(t *testing.T) {
 }
 
 func TestPIRMotionDriverStart(t *testing.T) {
-	sem := make(chan bool, 0)
+	sem := make(chan bool)
 	a := newGpioTestAdaptor()
 	d := NewPIRMotionDriver(a, "1")
 

--- a/drivers/gpio/servo_driver.go
+++ b/drivers/gpio/servo_driver.go
@@ -65,7 +65,7 @@ func (s *ServoDriver) Halt() (err error) { return }
 
 // Move sets the servo to the specified angle. Acceptable angles are 0-180
 func (s *ServoDriver) Move(angle uint8) (err error) {
-	if !(angle >= 0 && angle <= 180) {
+	if angle > 180 {
 		return ErrServoOutOfRange
 	}
 	s.CurrentAngle = angle

--- a/drivers/gpio/stepper_driver.go
+++ b/drivers/gpio/stepper_driver.go
@@ -111,7 +111,7 @@ func (s *StepperDriver) Start() (err error) { return }
 // Run continuously runs the stepper
 func (s *StepperDriver) Run() (err error) {
 	//halt if already moving
-	if s.moving == true {
+	if s.moving {
 		s.Halt()
 	}
 
@@ -123,7 +123,7 @@ func (s *StepperDriver) Run() (err error) {
 
 	go func() {
 		for {
-			if s.moving == false {
+			if !s.moving {
 				break
 			}
 			s.step()
@@ -191,7 +191,7 @@ func (s *StepperDriver) Move(stepsToMove int) error {
 		return s.Halt()
 	}
 
-	if s.moving == true {
+	if s.moving {
 		//stop previous motion
 		s.Halt()
 	}

--- a/drivers/gpio/stepper_driver_test.go
+++ b/drivers/gpio/stepper_driver_test.go
@@ -58,7 +58,7 @@ func TestStepperDriverDefaultDirection(t *testing.T) {
 func TestStepperDriverInvalidDirection(t *testing.T) {
 	d := initStepperMotorDriver()
 	err := d.SetDirection("reverse")
-	gobottest.Assert(t, err.(error), errors.New("Invalid direction. Value should be forward or backward"))
+	gobottest.Assert(t, err, errors.New("Invalid direction. Value should be forward or backward"))
 }
 
 func TestStepperDriverMoveForward(t *testing.T) {

--- a/drivers/i2c/ads1x15_driver.go
+++ b/drivers/i2c/ads1x15_driver.go
@@ -348,16 +348,12 @@ func (d *ADS1x15Driver) AnalogRead(pin string) (value int, err error) {
 	switch pin {
 	case "0-1":
 		channel = 0
-		break
 	case "0-3":
 		channel = 1
-		break
 	case "1-3":
 		channel = 2
-		break
 	case "2-3":
 		channel = 3
-		break
 	default:
 		// read the voltage at a specific pin, compared to the ground
 		channel, err = strconv.Atoi(pin)

--- a/drivers/i2c/ads1x15_driver_1015_test.go
+++ b/drivers/i2c/ads1x15_driver_1015_test.go
@@ -103,7 +103,7 @@ func TestADS1015AnalogRead(t *testing.T) {
 	gobottest.Assert(t, val, 32767)
 	gobottest.Assert(t, err, nil)
 
-	val, err = d.AnalogRead("3-2")
+	_, err = d.AnalogRead("3-2")
 	gobottest.Refute(t, err.Error(), nil)
 }
 

--- a/drivers/i2c/ads1x15_driver_1115_test.go
+++ b/drivers/i2c/ads1x15_driver_1115_test.go
@@ -103,7 +103,7 @@ func TestADS1115AnalogRead(t *testing.T) {
 	gobottest.Assert(t, val, 32767)
 	gobottest.Assert(t, err, nil)
 
-	val, err = d.AnalogRead("3-2")
+	_, err = d.AnalogRead("3-2")
 	gobottest.Refute(t, err.Error(), nil)
 }
 

--- a/drivers/i2c/ads1x15_driver_test.go
+++ b/drivers/i2c/ads1x15_driver_test.go
@@ -96,9 +96,9 @@ func TestADS1x15CommandsAnalogRead(t *testing.T) {
 }
 
 func TestADS1x15_ads1x15BestGainForVoltage(t *testing.T) {
-	g, err := ads1x15BestGainForVoltage(1.5)
+	g, _ := ads1x15BestGainForVoltage(1.5)
 	gobottest.Assert(t, g, 2)
 
-	g, err = ads1x15BestGainForVoltage(20.0)
+	_, err := ads1x15BestGainForVoltage(20.0)
 	gobottest.Assert(t, err, errors.New("The maximum voltage which can be read is 6.144000"))
 }

--- a/drivers/i2c/blinkm_driver_test.go
+++ b/drivers/i2c/blinkm_driver_test.go
@@ -124,7 +124,7 @@ func TestBlinkMFirmwareVersion(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 
-	version, err := d.FirmwareVersion()
+	_, err := d.FirmwareVersion()
 	gobottest.Assert(t, err, errors.New("write error"))
 }
 
@@ -152,7 +152,7 @@ func TestBlinkMColor(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 
-	color, err := d.Color()
+	_, err := d.Color()
 	gobottest.Assert(t, err, errors.New("write error"))
 
 }

--- a/drivers/i2c/ccs811_driver.go
+++ b/drivers/i2c/ccs811_driver.go
@@ -12,10 +12,10 @@ type CCS811DriveMode uint8
 // Operating modes which dictate how often measurements are being made. If 0x00 is used as an operating mode, measurements will be disabled
 const (
 	CCS811DriveModeIdle  CCS811DriveMode = 0x00
-	CCS811DriveMode1Sec                  = 0x01
-	CCS811DriveMode10Sec                 = 0x02
-	CCS811DriveMode60Sec                 = 0x03
-	CCS811DriveMode250MS                 = 0x04
+	CCS811DriveMode1Sec  CCS811DriveMode = 0x01
+	CCS811DriveMode10Sec CCS811DriveMode = 0x02
+	CCS811DriveMode60Sec CCS811DriveMode = 0x03
+	CCS811DriveMode250MS CCS811DriveMode = 0x04
 )
 
 const (

--- a/drivers/i2c/drv2605l_driver.go
+++ b/drivers/i2c/drv2605l_driver.go
@@ -6,13 +6,13 @@ type DRV2605Mode uint8
 // Operating modes, for use in SetMode()
 const (
 	DRV2605ModeIntTrig     DRV2605Mode = 0x00
-	DRV2605ModeExtTrigEdge             = 0x01
-	DRV2605ModeExtTrigLvl              = 0x02
-	DRV2605ModePWMAnalog               = 0x03
-	DRV2605ModeAudioVibe               = 0x04
-	DRV2605ModeRealtime                = 0x05
-	DRV2605ModeDiagnose                = 0x06
-	DRV2605ModeAutocal                 = 0x07
+	DRV2605ModeExtTrigEdge DRV2605Mode = 0x01
+	DRV2605ModeExtTrigLvl  DRV2605Mode = 0x02
+	DRV2605ModePWMAnalog   DRV2605Mode = 0x03
+	DRV2605ModeAudioVibe   DRV2605Mode = 0x04
+	DRV2605ModeRealtime    DRV2605Mode = 0x05
+	DRV2605ModeDiagnose    DRV2605Mode = 0x06
+	DRV2605ModeAutocal     DRV2605Mode = 0x07
 )
 
 const (

--- a/drivers/i2c/grovepi_driver.go
+++ b/drivers/i2c/grovepi_driver.go
@@ -267,7 +267,7 @@ func (d *GrovePiDriver) SetPinMode(pin byte, mode string) error {
 func getPin(pin string) string {
 	if len(pin) > 1 {
 		if strings.ToUpper(pin[0:1]) == "A" || strings.ToUpper(pin[0:1]) == "D" {
-			return pin[1:len(pin)]
+			return pin[1:]
 		}
 	}
 

--- a/drivers/i2c/i2c_connection.go
+++ b/drivers/i2c/i2c_connection.go
@@ -30,7 +30,7 @@ type bitState uint8
 
 const (
 	clear bitState = 0x00
-	set            = 0x01
+	set   bitState = 0x01
 )
 
 // Connection is a connection to an I2C device with a specified address

--- a/drivers/i2c/mcp23017_driver_test.go
+++ b/drivers/i2c/mcp23017_driver_test.go
@@ -536,19 +536,19 @@ func TestMCP23017SetGPIOPolarityErr(t *testing.T) {
 
 func TestMCP23017_write(t *testing.T) {
 	// clear bit
-	d, a := initTestMCP23017WithStubbedAdaptor(0)
+	d, _ := initTestMCP23017WithStubbedAdaptor(0)
 	port := d.getPort("A")
 	err := d.write(port.IODIR, uint8(7), 0)
 	gobottest.Assert(t, err, nil)
 
 	// set bit
-	d, a = initTestMCP23017WithStubbedAdaptor(0)
+	d, _ = initTestMCP23017WithStubbedAdaptor(0)
 	port = d.getPort("B")
 	err = d.write(port.IODIR, uint8(7), 1)
 	gobottest.Assert(t, err, nil)
 
 	// write error
-	d, a = initTestMCP23017WithStubbedAdaptor(0)
+	d, a := initTestMCP23017WithStubbedAdaptor(0)
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}

--- a/drivers/i2c/sht2x_driver.go
+++ b/drivers/i2c/sht2x_driver.go
@@ -211,13 +211,13 @@ func (d *SHT2xDriver) initialize() error {
 	return nil
 }
 
-func (d *SHT2xDriver) sendAccuracy() (err error) {
-	if err = d.connection.WriteByte(SHT2xReadUserReg); err != nil {
-		return
+func (d *SHT2xDriver) sendAccuracy() error {
+	if err := d.connection.WriteByte(SHT2xReadUserReg); err != nil {
+		return err
 	}
 	userRegister, err := d.connection.ReadByte()
 	if err != nil {
-		return
+		return err
 	}
 
 	userRegister &= 0x7e //Turn off the resolution bits
@@ -226,15 +226,13 @@ func (d *SHT2xDriver) sendAccuracy() (err error) {
 	userRegister |= acc //Mask in the requested resolution bits
 
 	//Request a write to user register
-	_, err = d.connection.Write([]byte{SHT2xWriteUserReg, userRegister})
-	if err != nil {
-		return
+	if _, err := d.connection.Write([]byte{SHT2xWriteUserReg, userRegister}); err != nil {
+		return err
 	}
 
-	userRegister, err = d.connection.ReadByte()
-	if err != nil {
-		return
+	if _, err := d.connection.ReadByte(); err != nil {
+		return err
 	}
 
-	return
+	return nil
 }

--- a/drivers/i2c/sht3x_driver.go
+++ b/drivers/i2c/sht3x_driver.go
@@ -44,7 +44,9 @@ const SHT3xAccuracyMedium = 0x0b
 const SHT3xAccuracyHigh = 0x00
 
 var (
-	crc8Params         = crc8.Params{0x31, 0xff, false, false, 0x00, 0xf7, "CRC-8/SENSIRON"}
+	crc8Params = crc8.Params{
+		Poly: 0x31, Init: 0xff, RefIn: false, RefOut: false, XorOut: 0x00, Check: 0xf7, Name: "CRC-8/SENSIRON",
+	}
 	ErrInvalidAccuracy = errors.New("Invalid accuracy")
 	ErrInvalidCrc      = errors.New("Invalid crc")
 	ErrInvalidTemp     = errors.New("Invalid temperature units")
@@ -128,7 +130,7 @@ func (s *SHT3xDriver) Heater() (status bool, err error) {
 // SetHeater enables or disables the heater on the device
 func (s *SHT3xDriver) SetHeater(enabled bool) (err error) {
 	out := []byte{0x30, 0x66}
-	if true == enabled {
+	if enabled {
 		out[1] = 0x6d
 	}
 	_, err = s.connection.Write(out)

--- a/drivers/i2c/sht3x_driver_test.go
+++ b/drivers/i2c/sht3x_driver_test.go
@@ -174,7 +174,7 @@ func TestSHT3xHeater(t *testing.T) {
 		return 3, nil
 	}
 
-	status, err = d.Heater()
+	_, err = d.Heater()
 	gobottest.Assert(t, err, ErrInvalidCrc)
 
 	// heater read failed
@@ -183,7 +183,7 @@ func TestSHT3xHeater(t *testing.T) {
 		return 2, nil
 	}
 
-	status, err = d.Heater()
+	_, err = d.Heater()
 	gobottest.Refute(t, err, nil)
 }
 

--- a/drivers/i2c/tsl2561_driver.go
+++ b/drivers/i2c/tsl2561_driver.go
@@ -326,11 +326,9 @@ func (d *TSL2561Driver) CalculateLux(broadband uint16, ir uint16) (lux uint32) {
 	ratio := (ratio1 + 1) / 2
 
 	b, m := d.getBM(ratio)
-	temp := (channel0 * b) - (channel1 * m)
-
-	// Negative lux not allowed
-	if temp < 0 {
-		temp = 0
+	var temp uint32
+	if (channel0 * b) > (channel1 * m) {
+		temp = (channel0 * b) - (channel1 * m)
 	}
 
 	// Round lsb (2^(LUX_SCALE+1))
@@ -408,7 +406,7 @@ func (d *TSL2561Driver) getClipScaling() (clipThreshold uint16, chScale uint32) 
 
 func (d *TSL2561Driver) getBM(ratio uint32) (b uint32, m uint32) {
 	switch {
-	case (ratio >= 0) && (ratio <= tsl2561LuxK1T):
+	case ratio <= tsl2561LuxK1T:
 		b = tsl2561LuxB1T
 		m = tsl2561LuxM1T
 	case (ratio <= tsl2561LuxK2T):

--- a/drivers/i2c/tsl2561_driver.go
+++ b/drivers/i2c/tsl2561_driver.go
@@ -445,7 +445,6 @@ func (d *TSL2561Driver) waitForADC() {
 	case TSL2561IntegrationTime402MS:
 		time.Sleep(450 * time.Millisecond)
 	}
-	return
 }
 
 func (d *TSL2561Driver) initialize() error {

--- a/drivers/spi/helpers_test.go
+++ b/drivers/spi/helpers_test.go
@@ -50,4 +50,4 @@ func (a *spiTestAdaptor) SpiDefaultMaxSpeed() int64 { return 0 }
 func (a *spiTestAdaptor) Connect() error  { return nil }
 func (a *spiTestAdaptor) Finalize() error { return nil }
 func (a *spiTestAdaptor) Name() string    { return "board name" }
-func (a *spiTestAdaptor) SetName(string)  { return }
+func (a *spiTestAdaptor) SetName(string)  {}

--- a/drivers/spi/ssd1306_driver.go
+++ b/drivers/spi/ssd1306_driver.go
@@ -282,9 +282,6 @@ func (s *SSD1306Driver) SetBufferAndDisplay(buf []byte) error {
 
 // SetContrast sets the display contrast (0-255).
 func (s *SSD1306Driver) SetContrast(contrast byte) error {
-	if contrast < 0 || contrast > 255 {
-		return fmt.Errorf("contrast value must be between 0-255")
-	}
 	if err := s.command(ssd1306SetContrast); err != nil {
 		return err
 	}

--- a/eventer.go
+++ b/eventer.go
@@ -63,14 +63,12 @@ func NewEventer() Eventer {
 	// goroutine to cascade "in" events to all "out" event channels
 	go func() {
 		for {
-			select {
-			case evt := <-evtr.in:
-				evtr.eventsMutex.Lock()
-				for _, out := range evtr.outs {
-					out <- evt
-				}
-				evtr.eventsMutex.Unlock()
+			evt := <-evtr.in
+			evtr.eventsMutex.Lock()
+			for _, out := range evtr.outs {
+				out <- evt
 			}
+			evtr.eventsMutex.Unlock()
 		}
 	}()
 
@@ -125,11 +123,9 @@ func (e *eventer) On(n string, f func(s interface{})) (err error) {
 	out := e.Subscribe()
 	go func() {
 		for {
-			select {
-			case evt := <-out:
-				if evt.Name == n {
-					f(evt.Data)
-				}
+			evt := <-out
+			if evt.Name == n {
+				f(evt.Data)
 			}
 		}
 	}()

--- a/platforms/adaptors/digitalpinsadaptor_test.go
+++ b/platforms/adaptors/digitalpinsadaptor_test.go
@@ -101,7 +101,7 @@ func TestDigitalPinsFinalize(t *testing.T) {
 	gobottest.Assert(t, a.DigitalWrite("3", 2), nil)
 	delete(fs.Files, "/sys/class/gpio/unexport")
 	err = a.Finalize()
-	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/gpio/unexport: No such file"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/gpio/unexport: no such file"), true)
 }
 
 func TestDigitalPinsReConnect(t *testing.T) {

--- a/platforms/adaptors/pwmpinsadaptor_test.go
+++ b/platforms/adaptors/pwmpinsadaptor_test.go
@@ -145,7 +145,7 @@ func TestPWMPinsFinalize(t *testing.T) {
 	gobottest.Assert(t, a.PwmWrite("33", 2), nil)
 	delete(fs.Files, pwmUnexportPath)
 	err = a.Finalize()
-	gobottest.Assert(t, strings.Contains(err.Error(), pwmUnexportPath+": No such file"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), pwmUnexportPath+": no such file"), true)
 	// arrange write error
 	gobottest.Assert(t, a.Connect(), nil)
 	gobottest.Assert(t, a.PwmWrite("33", 2), nil)
@@ -283,14 +283,14 @@ func Test_PWMPin(t *testing.T) {
 			mockPaths: []string{},
 			translate: translator,
 			pin:       "33",
-			wantErr:   "Export() failed for id 44 with  : /sys/devices/platform/ff680020.pwm/pwm/pwmchip3/export: No such file.",
+			wantErr:   "Export() failed for id 44 with  : /sys/devices/platform/ff680020.pwm/pwm/pwmchip3/export: no such file",
 		},
 		"init_setenabled_error": {
 			mockPaths: []string{pwmExportPath, pwmPeriodPath},
 			period:    "1000",
 			translate: translator,
 			pin:       "33",
-			wantErr:   "SetEnabled(false) failed for id 44 with  : /sys/devices/platform/ff680020.pwm/pwm/pwmchip3/pwm44/enable: No such file.",
+			wantErr:   "SetEnabled(false) failed for id 44 with  : /sys/devices/platform/ff680020.pwm/pwm/pwmchip3/pwm44/enable: no such file",
 		},
 		"init_setperiod_dutycycle_no_error": {
 			mockPaths: []string{pwmExportPath, pwmEnablePath, pwmPeriodPath, pwmPolarityPath},
@@ -301,13 +301,13 @@ func Test_PWMPin(t *testing.T) {
 			mockPaths: []string{pwmExportPath, pwmEnablePath},
 			translate: translator,
 			pin:       "33",
-			wantErr:   "SetPeriod(10000000) failed for id 44 with  : /sys/devices/platform/ff680020.pwm/pwm/pwmchip3/pwm44/period: No such file.",
+			wantErr:   "SetPeriod(10000000) failed for id 44 with  : /sys/devices/platform/ff680020.pwm/pwm/pwmchip3/pwm44/period: no such file",
 		},
 		"init_setpolarity_error": {
 			mockPaths: []string{pwmExportPath, pwmEnablePath, pwmPeriodPath, pwmDutyCyclePath},
 			translate: translator,
 			pin:       "33",
-			wantErr:   "SetPolarity(normal) failed for id 44 with  : /sys/devices/platform/ff680020.pwm/pwm/pwmchip3/pwm44/polarity: No such file.",
+			wantErr:   "SetPolarity(normal) failed for id 44 with  : /sys/devices/platform/ff680020.pwm/pwm/pwmchip3/pwm44/polarity: no such file",
 		},
 		"translate_error": {
 			translate: func(string) (string, int, error) { return "", -1, fmt.Errorf(translateErr) },

--- a/platforms/audio/audio_driver.go
+++ b/platforms/audio/audio_driver.go
@@ -29,7 +29,7 @@ func NewDriver(a *Adaptor, filename string) *Driver {
 		connection: a,
 		interval:   500 * time.Millisecond,
 		filename:   filename,
-		halt:       make(chan bool, 0),
+		halt:       make(chan bool),
 		Eventer:    gobot.NewEventer(),
 		Commander:  gobot.NewCommander(),
 	}

--- a/platforms/beaglebone/beaglebone_adaptor.go
+++ b/platforms/beaglebone/beaglebone_adaptor.go
@@ -50,8 +50,9 @@ type Adaptor struct {
 // NewAdaptor returns a new Beaglebone Black/Green Adaptor
 //
 // Optional parameters:
-//		adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs
-//		adaptors.WithSpiGpioAccess(sclk, nss, mosi, miso):	use GPIO's instead of /dev/spidev#.#
+//
+//	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs
+//	adaptors.WithSpiGpioAccess(sclk, nss, mosi, miso):	use GPIO's instead of /dev/spidev#.#
 func NewAdaptor(opts ...func(adaptors.Optioner)) *Adaptor {
 	sys := system.NewAccesser()
 	c := &Adaptor{
@@ -127,7 +128,7 @@ func (c *Adaptor) DigitalWrite(id string, val byte) error {
 
 	if strings.Contains(id, "usr") {
 		fi, e := c.sys.OpenFile(c.usrLed+id+"/brightness", os.O_WRONLY|os.O_APPEND, 0666)
-		defer fi.Close()
+		defer fi.Close() //nolint:staticcheck // for historical reasons
 		if e != nil {
 			return e
 		}
@@ -145,7 +146,7 @@ func (c *Adaptor) AnalogRead(pin string) (val int, err error) {
 		return
 	}
 	fi, err := c.sys.OpenFile(fmt.Sprintf("%v/%v", c.analogPath, analogPin), os.O_RDONLY, 0644)
-	defer fi.Close()
+	defer fi.Close() //nolint:staticcheck // for historical reasons
 
 	if err != nil {
 		return
@@ -238,7 +239,7 @@ func (p pwmPinData) findPWMDir(sys *system.Accesser) (dir string, err error) {
 func (c *Adaptor) muxPin(pin, cmd string) error {
 	path := fmt.Sprintf("/sys/devices/platform/ocp/ocp:%s_pinmux/state", pin)
 	fi, e := c.sys.OpenFile(path, os.O_WRONLY, 0666)
-	defer fi.Close()
+	defer fi.Close() //nolint:staticcheck // for historical reasons
 	if e != nil {
 		return e
 	}

--- a/platforms/beaglebone/beaglebone_adaptor.go
+++ b/platforms/beaglebone/beaglebone_adaptor.go
@@ -219,7 +219,7 @@ func (c *Adaptor) translateAndMuxPWMPin(id string) (string, int, error) {
 
 func (p pwmPinData) findPWMDir(sys *system.Accesser) (dir string, err error) {
 	items, _ := sys.Find(p.dir, p.dirRegexp)
-	if items == nil || len(items) == 0 {
+	if len(items) == 0 {
 		return "", fmt.Errorf("No path found for PWM directory pattern, '%s' in path '%s'", p.dirRegexp, p.dir)
 	}
 

--- a/platforms/beaglebone/beaglebone_adaptor_test.go
+++ b/platforms/beaglebone/beaglebone_adaptor_test.go
@@ -135,7 +135,7 @@ func TestDigitalIO(t *testing.T) {
 
 	// no such LED
 	err := a.DigitalWrite("usr10101", 1)
-	gobottest.Assert(t, err.Error(), " : /sys/class/leds/beaglebone:green:usr10101/brightness: No such file.")
+	gobottest.Assert(t, err.Error(), " : /sys/class/leds/beaglebone:green:usr10101/brightness: no such file")
 
 	a.DigitalWrite("P9_12", 1)
 	gobottest.Assert(t, fs.Files["/sys/class/gpio/gpio60/value"].Contents, "1")
@@ -168,7 +168,7 @@ func TestAnalogReadFileError(t *testing.T) {
 	a, _ := initTestAdaptorWithMockedFilesystem(mockPaths)
 
 	_, err := a.AnalogRead("P9_40")
-	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/bus/iio/devices/iio:device0/in_voltage1_raw: No such file."), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/bus/iio/devices/iio:device0/in_voltage1_raw: no such file"), true)
 }
 
 func TestDigitalPinDirectionFileError(t *testing.T) {
@@ -181,7 +181,7 @@ func TestDigitalPinDirectionFileError(t *testing.T) {
 	a, _ := initTestAdaptorWithMockedFilesystem(mockPaths)
 
 	err := a.DigitalWrite("P9_12", 1)
-	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/gpio/gpio60/direction: No such file."), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/gpio/gpio60/direction: no such file"), true)
 
 	// no pin added after previous problem, so no pin to unexport in finalize
 	err = a.Finalize()
@@ -202,7 +202,7 @@ func TestDigitalPinFinalizeFileError(t *testing.T) {
 	gobottest.Assert(t, err, nil)
 
 	err = a.Finalize()
-	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/gpio/unexport: No such file."), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/gpio/unexport: no such file"), true)
 }
 
 func TestPocketName(t *testing.T) {

--- a/platforms/ble/ble_client_adaptor.go
+++ b/platforms/ble/ble_client_adaptor.go
@@ -100,12 +100,10 @@ func (b *ClientAdaptor) Connect() (err error) {
 	}
 
 	// wait to connect to peripheral device
-	select {
-	case result := <-ch:
-		b.device, err = b.adpt.Connect(result.Address, bluetooth.ConnectionParams{})
-		if err != nil {
-			return err
-		}
+	result := <-ch
+	b.device, err = b.adpt.Connect(result.Address, bluetooth.ConnectionParams{})
+	if err != nil {
+		return err
 	}
 
 	// get all services/characteristics

--- a/platforms/dexter/gopigo3/driver.go
+++ b/platforms/dexter/gopigo3/driver.go
@@ -138,10 +138,10 @@ type GroveType int
 
 const (
 	CUSTOM        GroveType = 1
-	IR_DI_REMOTE            = 2
-	IR_EV3_REMOTE           = 3
-	US                      = 4
-	I2C                     = 5
+	IR_DI_REMOTE  GroveType = 2
+	IR_EV3_REMOTE GroveType = 3
+	US            GroveType = 4
+	I2C           GroveType = 5
 )
 
 // GroveState contains the state of a grove device.
@@ -336,9 +336,6 @@ func (g *Driver) ServoWrite(port string, angle byte) error {
 	if angle > 180 {
 		angle = 180
 	}
-	if angle < 0 {
-		angle = 0
-	}
 	pulseWidth := ((1500 - (pulseWidthRange / 2)) + ((pulseWidthRange / 180) * int(angle)))
 	return g.SetServo(srvo, uint16(pulseWidth))
 }
@@ -419,19 +416,19 @@ func (g *Driver) GetMotorStatus(motor Motor) (flags uint8, power uint16, encoder
 	enc[1] = response[8]
 	enc[0] = response[9]
 	e := binary.LittleEndian.Uint32(enc)
+	encoder = int(e)
 	if e&0x80000000 == 0x80000000 {
 		encoder = int(uint64(e) - 0x100000000)
 	}
-	encoder = int(e)
 	//get dps
 	d := make([]byte, 4)
 	d[1] = response[10]
 	d[0] = response[11]
 	ds := binary.LittleEndian.Uint32(d)
+	dps = int(ds)
 	if ds&0x8000 == 0x8000 {
 		dps = int(ds - 0x10000)
 	}
-	dps = int(ds)
 	return flags, power, encoder / MOTOR_TICKS_PER_DEGREE, dps / MOTOR_TICKS_PER_DEGREE, nil
 }
 
@@ -489,9 +486,6 @@ func (g *Driver) SetGroveMode(port Grove, mode GroveMode) error {
 
 // SetPWMDuty sets the pwm duty cycle for the given pin/port.
 func (g *Driver) SetPWMDuty(port Grove, duty uint16) (err error) {
-	if duty < 0 {
-		duty = 0
-	}
 	if duty > 100 {
 		duty = 100
 	}

--- a/platforms/dexter/gopigo3/driver.go
+++ b/platforms/dexter/gopigo3/driver.go
@@ -234,7 +234,7 @@ func (g *Driver) GetManufacturerName() (mName string, err error) {
 	}
 	mf := response[4:23]
 	mf = bytes.Trim(mf, "\x00")
-	return fmt.Sprintf("%s", string(mf)), nil
+	return string(mf), nil
 }
 
 // GetBoardName returns the board name from the firmware.
@@ -249,7 +249,7 @@ func (g *Driver) GetBoardName() (bName string, err error) {
 	}
 	mf := response[4:23]
 	mf = bytes.Trim(mf, "\x00")
-	return fmt.Sprintf("%s", string(mf)), nil
+	return string(mf), nil
 }
 
 // GetHardwareVersion returns the hardware version from the firmware.

--- a/platforms/digispark/digispark_i2c_test.go
+++ b/platforms/digispark/digispark_i2c_test.go
@@ -63,7 +63,7 @@ func TestDigisparkAdaptorI2cStartFailWithWrongAddress(t *testing.T) {
 	// arrange
 	data := []byte{0, 1, 2, 3, 4}
 	a := initTestAdaptorI2c()
-	c, err := a.GetI2cConnection(0x39, a.DefaultI2cBus())
+	c, _ := a.GetI2cConnection(0x39, a.DefaultI2cBus())
 
 	// act
 	count, err := c.Write(data)
@@ -79,7 +79,7 @@ func TestDigisparkAdaptorI2cWrite(t *testing.T) {
 	data := []byte{0, 1, 2, 3, 4}
 	dataLen := len(data)
 	a := initTestAdaptorI2c()
-	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
+	c, _ := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
 	count, err := c.Write(data)
@@ -99,10 +99,10 @@ func TestDigisparkAdaptorI2cWriteByte(t *testing.T) {
 	// arrange
 	data := byte(0x02)
 	a := initTestAdaptorI2c()
-	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
+	c, _ := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
-	err = c.WriteByte(data)
+	err := c.WriteByte(data)
 
 	// assert
 	gobottest.Assert(t, err, nil)
@@ -119,10 +119,10 @@ func TestDigisparkAdaptorI2cWriteByteData(t *testing.T) {
 	reg := uint8(0x03)
 	data := byte(0x09)
 	a := initTestAdaptorI2c()
-	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
+	c, _ := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
-	err = c.WriteByteData(reg, data)
+	err := c.WriteByteData(reg, data)
 
 	// assert
 	gobottest.Assert(t, err, nil)
@@ -139,10 +139,10 @@ func TestDigisparkAdaptorI2cWriteWordData(t *testing.T) {
 	reg := uint8(0x04)
 	data := uint16(0x0508)
 	a := initTestAdaptorI2c()
-	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
+	c, _ := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
-	err = c.WriteWordData(reg, data)
+	err := c.WriteWordData(reg, data)
 
 	// assert
 	gobottest.Assert(t, err, nil)
@@ -159,10 +159,10 @@ func TestDigisparkAdaptorI2cWriteBlockData(t *testing.T) {
 	reg := uint8(0x05)
 	data := []byte{0x80, 0x81, 0x82}
 	a := initTestAdaptorI2c()
-	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
+	c, _ := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
-	err = c.WriteBlockData(reg, data)
+	err := c.WriteBlockData(reg, data)
 
 	// assert
 	gobottest.Assert(t, err, nil)
@@ -179,7 +179,7 @@ func TestDigisparkAdaptorI2cRead(t *testing.T) {
 	data := []byte{0, 1, 2, 3, 4}
 	dataLen := len(data)
 	a := initTestAdaptorI2c()
-	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
+	c, _ := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
 	count, err := c.Read(data)
@@ -198,7 +198,7 @@ func TestDigisparkAdaptorI2cRead(t *testing.T) {
 func TestDigisparkAdaptorI2cReadByte(t *testing.T) {
 	// arrange
 	a := initTestAdaptorI2c()
-	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
+	c, _ := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
 	data, err := c.ReadByte()
@@ -217,7 +217,7 @@ func TestDigisparkAdaptorI2cReadByteData(t *testing.T) {
 	// arrange
 	reg := uint8(0x04)
 	a := initTestAdaptorI2c()
-	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
+	c, _ := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
 	data, err := c.ReadByteData(reg)
@@ -239,7 +239,7 @@ func TestDigisparkAdaptorI2cReadWordData(t *testing.T) {
 	// 2 bytes of i2cData are used swapped
 	expectedValue := uint16(0x0405)
 	a := initTestAdaptorI2c()
-	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
+	c, _ := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
 	data, err := c.ReadWordData(reg)
@@ -261,10 +261,10 @@ func TestDigisparkAdaptorI2cReadBlockData(t *testing.T) {
 	data := []byte{0, 0, 0, 0, 0}
 	dataLen := len(data)
 	a := initTestAdaptorI2c()
-	c, err := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
+	c, _ := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
-	err = c.ReadBlockData(reg, data)
+	err := c.ReadBlockData(reg, data)
 
 	// assert
 	gobottest.Assert(t, err, nil)
@@ -279,13 +279,11 @@ func TestDigisparkAdaptorI2cReadBlockData(t *testing.T) {
 
 func TestDigisparkAdaptorI2cUpdateDelay(t *testing.T) {
 	// arrange
-	var c i2c.Connection
-	var err error
 	a := initTestAdaptorI2c()
-	c, err = a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
+	c, _ := a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// act
-	err = c.(*digisparkI2cConnection).UpdateDelay(uint(100))
+	err := c.(*digisparkI2cConnection).UpdateDelay(uint(100))
 
 	// assert
 	gobottest.Assert(t, err, nil)

--- a/platforms/firmata/firmata_adaptor.go
+++ b/platforms/firmata/firmata_adaptor.go
@@ -70,11 +70,11 @@ func NewAdaptor(args ...interface{}) *Adaptor {
 	}
 
 	for _, arg := range args {
-		switch arg.(type) {
+		switch a := arg.(type) {
 		case string:
-			f.port = arg.(string)
+			f.port = a
 		case io.ReadWriteCloser:
-			f.conn = arg.(io.ReadWriteCloser)
+			f.conn = a
 		}
 	}
 

--- a/platforms/intel-iot/curie/imu_driver_test.go
+++ b/platforms/intel-iot/curie/imu_driver_test.go
@@ -120,10 +120,10 @@ func TestIMUDriverReadAccelerometer(t *testing.T) {
 }
 
 func TestIMUDriverReadAccelerometerData(t *testing.T) {
-	result, err := parseAccelerometerData([]byte{})
+	_, err := parseAccelerometerData([]byte{})
 	gobottest.Assert(t, err, errors.New("Invalid data"))
 
-	result, err = parseAccelerometerData([]byte{0xF0, 0x11, 0x00, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7})
+	result, err := parseAccelerometerData([]byte{0xF0, 0x11, 0x00, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7})
 	gobottest.Assert(t, err, nil)
 	gobottest.Assert(t, result, &AccelerometerData{X: 1920, Y: 1920, Z: 1920})
 }
@@ -135,10 +135,10 @@ func TestIMUDriverReadGyroscope(t *testing.T) {
 }
 
 func TestIMUDriverReadGyroscopeData(t *testing.T) {
-	result, err := parseGyroscopeData([]byte{})
+	_, err := parseGyroscopeData([]byte{})
 	gobottest.Assert(t, err, errors.New("Invalid data"))
 
-	result, err = parseGyroscopeData([]byte{0xF0, 0x11, 0x01, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7})
+	result, err := parseGyroscopeData([]byte{0xF0, 0x11, 0x01, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7})
 	gobottest.Assert(t, err, nil)
 	gobottest.Assert(t, result, &GyroscopeData{X: 1920, Y: 1920, Z: 1920})
 }
@@ -150,10 +150,10 @@ func TestIMUDriverReadTemperature(t *testing.T) {
 }
 
 func TestIMUDriverReadTemperatureData(t *testing.T) {
-	result, err := parseTemperatureData([]byte{})
+	_, err := parseTemperatureData([]byte{})
 	gobottest.Assert(t, err, errors.New("Invalid data"))
 
-	result, err = parseTemperatureData([]byte{0xF0, 0x11, 0x02, 0x00, 0x02, 0x03, 0x04, 0xf7})
+	result, err := parseTemperatureData([]byte{0xF0, 0x11, 0x02, 0x00, 0x02, 0x03, 0x04, 0xf7})
 	gobottest.Assert(t, err, nil)
 	gobottest.Assert(t, result, float32(31.546875))
 }
@@ -165,10 +165,10 @@ func TestIMUDriverEnableShockDetection(t *testing.T) {
 }
 
 func TestIMUDriverShockDetectData(t *testing.T) {
-	result, err := parseShockData([]byte{})
+	_, err := parseShockData([]byte{})
 	gobottest.Assert(t, err, errors.New("Invalid data"))
 
-	result, err = parseShockData([]byte{0xF0, 0x11, 0x03, 0x00, 0x02, 0xf7})
+	result, err := parseShockData([]byte{0xF0, 0x11, 0x03, 0x00, 0x02, 0xf7})
 	gobottest.Assert(t, err, nil)
 	gobottest.Assert(t, result, &ShockData{Axis: 0, Direction: 2})
 }
@@ -180,10 +180,10 @@ func TestIMUDriverEnableStepCounter(t *testing.T) {
 }
 
 func TestIMUDriverStepCountData(t *testing.T) {
-	result, err := parseStepData([]byte{})
+	_, err := parseStepData([]byte{})
 	gobottest.Assert(t, err, errors.New("Invalid data"))
 
-	result, err = parseStepData([]byte{0xF0, 0x11, 0x04, 0x00, 0x02, 0xf7})
+	result, err := parseStepData([]byte{0xF0, 0x11, 0x04, 0x00, 0x02, 0xf7})
 	gobottest.Assert(t, err, nil)
 	gobottest.Assert(t, result, int16(256))
 }
@@ -195,10 +195,10 @@ func TestIMUDriverEnableTapDetection(t *testing.T) {
 }
 
 func TestIMUDriverTapDetectData(t *testing.T) {
-	result, err := parseTapData([]byte{})
+	_, err := parseTapData([]byte{})
 	gobottest.Assert(t, err, errors.New("Invalid data"))
 
-	result, err = parseTapData([]byte{0xF0, 0x11, 0x05, 0x00, 0x02, 0xf7})
+	result, err := parseTapData([]byte{0xF0, 0x11, 0x05, 0x00, 0x02, 0xf7})
 	gobottest.Assert(t, err, nil)
 	gobottest.Assert(t, result, &TapData{Axis: 0, Direction: 2})
 }
@@ -210,10 +210,10 @@ func TestIMUDriverEnableReadMotion(t *testing.T) {
 }
 
 func TestIMUDriverReadMotionData(t *testing.T) {
-	result, err := parseMotionData([]byte{})
+	_, err := parseMotionData([]byte{})
 	gobottest.Assert(t, err, errors.New("Invalid data"))
 
-	result, err = parseMotionData([]byte{0xF0, 0x11, 0x06, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7})
+	result, err := parseMotionData([]byte{0xF0, 0x11, 0x06, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7})
 	gobottest.Assert(t, err, nil)
 	gobottest.Assert(t, result, &MotionData{AX: 1920, AY: 1920, AZ: 1920, GX: 1920, GY: 1920, GZ: 1920})
 }

--- a/platforms/intel-iot/edison/edison_adaptor.go
+++ b/platforms/intel-iot/edison/edison_adaptor.go
@@ -263,7 +263,7 @@ func (c *Adaptor) arduinoI2CSetup() error {
 
 func (c *Adaptor) readFile(path string) ([]byte, error) {
 	file, err := c.sys.OpenFile(path, os.O_RDONLY, 0644)
-	defer file.Close()
+	defer file.Close() //nolint:staticcheck // for historical reasons
 	if err != nil {
 		return make([]byte, 0), err
 	}
@@ -379,7 +379,7 @@ func (c *Adaptor) newExportedDigitalPin(pin int, o ...func(gobot.DigitalPinOptio
 // changePinMode writes pin mode to current_pinmux file
 func (c *Adaptor) changePinMode(pin, mode string) error {
 	file, err := c.sys.OpenFile("/sys/kernel/debug/gpio_debug/gpio"+pin+"/current_pinmux", os.O_WRONLY, 0644)
-	defer file.Close()
+	defer file.Close() //nolint:staticcheck // for historical reasons
 	if err != nil {
 		return err
 	}

--- a/platforms/intel-iot/edison/edison_adaptor_test.go
+++ b/platforms/intel-iot/edison/edison_adaptor_test.go
@@ -241,7 +241,7 @@ func TestArduinoSetupFail263(t *testing.T) {
 	delete(fs.Files, "/sys/class/gpio/gpio263/direction")
 
 	err := a.arduinoSetup()
-	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/gpio/gpio263/direction: No such file"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/gpio/gpio263/direction: no such file"), true)
 }
 
 func TestArduinoSetupFail240(t *testing.T) {
@@ -249,7 +249,7 @@ func TestArduinoSetupFail240(t *testing.T) {
 	delete(fs.Files, "/sys/class/gpio/gpio240/direction")
 
 	err := a.arduinoSetup()
-	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/gpio/gpio240/direction: No such file"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/gpio/gpio240/direction: no such file"), true)
 }
 
 func TestArduinoSetupFail111(t *testing.T) {
@@ -257,7 +257,7 @@ func TestArduinoSetupFail111(t *testing.T) {
 	delete(fs.Files, "/sys/kernel/debug/gpio_debug/gpio111/current_pinmux")
 
 	err := a.arduinoSetup()
-	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/kernel/debug/gpio_debug/gpio111/current_pinmux: No such file"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/kernel/debug/gpio_debug/gpio111/current_pinmux: no such file"), true)
 }
 
 func TestArduinoSetupFail131(t *testing.T) {
@@ -265,7 +265,7 @@ func TestArduinoSetupFail131(t *testing.T) {
 	delete(fs.Files, "/sys/kernel/debug/gpio_debug/gpio131/current_pinmux")
 
 	err := a.arduinoSetup()
-	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/kernel/debug/gpio_debug/gpio131/current_pinmux: No such file"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/kernel/debug/gpio_debug/gpio131/current_pinmux: no such file"), true)
 }
 
 func TestArduinoI2CSetupFailTristate(t *testing.T) {
@@ -284,7 +284,7 @@ func TestArduinoI2CSetupFail14(t *testing.T) {
 	delete(fs.Files, "/sys/class/gpio/gpio14/direction")
 
 	err := a.arduinoI2CSetup()
-	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/gpio/gpio14/direction: No such file"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/gpio/gpio14/direction: no such file"), true)
 }
 
 func TestArduinoI2CSetupUnexportFail(t *testing.T) {
@@ -294,7 +294,7 @@ func TestArduinoI2CSetupUnexportFail(t *testing.T) {
 	delete(fs.Files, "/sys/class/gpio/unexport")
 
 	err := a.arduinoI2CSetup()
-	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/gpio/unexport: No such file"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/gpio/unexport: no such file"), true)
 }
 
 func TestArduinoI2CSetupFail236(t *testing.T) {
@@ -304,7 +304,7 @@ func TestArduinoI2CSetupFail236(t *testing.T) {
 	delete(fs.Files, "/sys/class/gpio/gpio236/direction")
 
 	err := a.arduinoI2CSetup()
-	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/gpio/gpio236/direction: No such file"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/gpio/gpio236/direction: no such file"), true)
 }
 
 func TestArduinoI2CSetupFail28(t *testing.T) {
@@ -314,7 +314,7 @@ func TestArduinoI2CSetupFail28(t *testing.T) {
 	delete(fs.Files, "/sys/kernel/debug/gpio_debug/gpio28/current_pinmux")
 
 	err := a.arduinoI2CSetup()
-	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/kernel/debug/gpio_debug/gpio28/current_pinmux: No such file"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/kernel/debug/gpio_debug/gpio28/current_pinmux: no such file"), true)
 }
 
 func TestConnectArduinoError(t *testing.T) {
@@ -410,7 +410,7 @@ func TestDigitalPinInFileError(t *testing.T) {
 	a.Connect()
 
 	_, err := a.DigitalPin("13")
-	gobottest.Assert(t, strings.Contains(err.Error(), "No such file"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "no such file"), true)
 
 }
 
@@ -422,7 +422,7 @@ func TestDigitalPinInResistorFileError(t *testing.T) {
 	a.Connect()
 
 	_, err := a.DigitalPin("13")
-	gobottest.Assert(t, strings.Contains(err.Error(), "No such file"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "no such file"), true)
 }
 
 func TestDigitalPinInLevelShifterFileError(t *testing.T) {
@@ -433,7 +433,7 @@ func TestDigitalPinInLevelShifterFileError(t *testing.T) {
 	a.Connect()
 
 	_, err := a.DigitalPin("13")
-	gobottest.Assert(t, strings.Contains(err.Error(), "No such file"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "no such file"), true)
 }
 
 func TestDigitalPinInMuxFileError(t *testing.T) {
@@ -444,7 +444,7 @@ func TestDigitalPinInMuxFileError(t *testing.T) {
 	a.Connect()
 
 	_, err := a.DigitalPin("13")
-	gobottest.Assert(t, strings.Contains(err.Error(), "No such file"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "no such file"), true)
 }
 
 func TestDigitalWriteError(t *testing.T) {
@@ -482,7 +482,7 @@ func TestPwmExportError(t *testing.T) {
 	gobottest.Assert(t, err, nil)
 
 	err = a.PwmWrite("5", 100)
-	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/pwm/pwmchip0/export: No such file"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/pwm/pwmchip0/export: no such file"), true)
 }
 
 func TestPwmEnableError(t *testing.T) {
@@ -492,7 +492,7 @@ func TestPwmEnableError(t *testing.T) {
 	a.Connect()
 
 	err := a.PwmWrite("5", 100)
-	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/pwm/pwmchip0/pwm1/enable: No such file"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/pwm/pwmchip0/pwm1/enable: no such file"), true)
 }
 
 func TestPwmWritePinError(t *testing.T) {

--- a/platforms/intel-iot/joule/joule_adaptor_test.go
+++ b/platforms/intel-iot/joule/joule_adaptor_test.go
@@ -154,7 +154,7 @@ func TestPwmPinExportError(t *testing.T) {
 	delete(fs.Files, "/sys/class/pwm/pwmchip0/export")
 
 	err := a.PwmWrite("J12_26", 100)
-	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/pwm/pwmchip0/export: No such file"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/pwm/pwmchip0/export: no such file"), true)
 }
 
 func TestPwmPinEnableError(t *testing.T) {
@@ -162,7 +162,7 @@ func TestPwmPinEnableError(t *testing.T) {
 	delete(fs.Files, "/sys/class/pwm/pwmchip0/pwm0/enable")
 
 	err := a.PwmWrite("J12_26", 100)
-	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/pwm/pwmchip0/pwm0/enable: No such file"), true)
+	gobottest.Assert(t, strings.Contains(err.Error(), "/sys/class/pwm/pwmchip0/pwm0/enable: no such file"), true)
 }
 
 func TestI2cDefaultBus(t *testing.T) {

--- a/platforms/jetson/pwm_pin.go
+++ b/platforms/jetson/pwm_pin.go
@@ -127,7 +127,7 @@ func (p *PWMPin) SetDutyCycle(duty uint32) error {
 func (p *PWMPin) writeFile(subpath string, value string) error {
 	sysfspath := path.Join(p.path, subpath)
 	fi, err := p.sys.OpenFile(sysfspath, os.O_WRONLY|os.O_APPEND, 0644)
-	defer fi.Close()
+	defer fi.Close() //nolint:staticcheck // for historical reasons
 
 	if err != nil {
 		return err

--- a/platforms/jetson/pwm_pin_test.go
+++ b/platforms/jetson/pwm_pin_test.go
@@ -31,12 +31,12 @@ func TestPwmPin(t *testing.T) {
 	val, _ = pin.Polarity()
 	gobottest.Assert(t, val, true)
 
-	period, err := pin.Period()
+	_, err := pin.Period()
 	gobottest.Assert(t, err, errors.New("Jetson PWM pin period not set"))
 	gobottest.Assert(t, pin.SetDutyCycle(10000), errors.New("Jetson PWM pin period not set"))
 
 	gobottest.Assert(t, pin.SetPeriod(20000000), nil)
-	period, _ = pin.Period()
+	period, _ := pin.Period()
 	gobottest.Assert(t, period, uint32(20000000))
 	gobottest.Assert(t, pin.SetPeriod(10000000), errors.New("Cannot set the period of individual PWM pins on Jetson"))
 

--- a/platforms/joystick/joystick_driver.go
+++ b/platforms/joystick/joystick_driver.go
@@ -90,7 +90,7 @@ func NewDriver(a *Adaptor, config string, v ...time.Duration) *Driver {
 			return sdl.PollEvent()
 		},
 		interval: 10 * time.Millisecond,
-		halt:     make(chan bool, 0),
+		halt:     make(chan bool),
 	}
 
 	if len(v) > 0 {

--- a/platforms/mavlink/mavlink_driver_test.go
+++ b/platforms/mavlink/mavlink_driver_test.go
@@ -42,9 +42,9 @@ func TestMavlinkDriverName(t *testing.T) {
 
 func TestMavlinkDriverStart(t *testing.T) {
 	d := initTestMavlinkDriver()
-	err := make(chan error, 0)
-	packet := make(chan *common.MAVLinkPacket, 0)
-	message := make(chan common.MAVLinkMessage, 0)
+	err := make(chan error)
+	packet := make(chan *common.MAVLinkPacket)
+	message := make(chan common.MAVLinkMessage)
 
 	d.On(PacketEvent, func(data interface{}) {
 		packet <- data.(*common.MAVLinkPacket)

--- a/platforms/microbit/accelerometer_driver_test.go
+++ b/platforms/microbit/accelerometer_driver_test.go
@@ -30,7 +30,7 @@ func TestAccelerometerDriverStartAndHalt(t *testing.T) {
 }
 
 func TestAccelerometerDriverReadData(t *testing.T) {
-	sem := make(chan bool, 0)
+	sem := make(chan bool)
 	a := NewBleTestAdaptor()
 	d := NewAccelerometerDriver(a)
 	d.Start()

--- a/platforms/microbit/button_driver_test.go
+++ b/platforms/microbit/button_driver_test.go
@@ -30,7 +30,7 @@ func TestButtonDriverStartAndHalt(t *testing.T) {
 }
 
 func TestButtonDriverReadData(t *testing.T) {
-	sem := make(chan bool, 0)
+	sem := make(chan bool)
 	a := NewBleTestAdaptor()
 	d := NewButtonDriver(a)
 	d.Start()

--- a/platforms/microbit/helpers_test.go
+++ b/platforms/microbit/helpers_test.go
@@ -40,6 +40,7 @@ func (t *bleTestClientAdaptor) WriteCharacteristic(cUUID string, data []byte) (e
 	return t.testWriteCharacteristic(cUUID, data)
 }
 
+//nolint:revive // in tests it is be helpful to see the meaning of the parameters by name
 func (t *bleTestClientAdaptor) Subscribe(cUUID string, f func([]byte, error)) (err error) {
 	t.testSubscribe = f
 	return
@@ -72,8 +73,6 @@ func NewBleTestAdaptor() *bleTestClientAdaptor {
 		testWriteCharacteristic: func(cUUID string, data []byte) (e error) {
 			return
 		},
-		testSubscribe: func([]byte, error) {
-			return
-		},
+		testSubscribe: func([]byte, error) {},
 	}
 }

--- a/platforms/microbit/magnetometer_driver_test.go
+++ b/platforms/microbit/magnetometer_driver_test.go
@@ -30,7 +30,7 @@ func TestMagnetometerDriverStartAndHalt(t *testing.T) {
 }
 
 func TestMagnetometerDriverReadData(t *testing.T) {
-	sem := make(chan bool, 0)
+	sem := make(chan bool)
 	a := NewBleTestAdaptor()
 	d := NewMagnetometerDriver(a)
 	d.Start()

--- a/platforms/microbit/temperature_driver_test.go
+++ b/platforms/microbit/temperature_driver_test.go
@@ -30,7 +30,7 @@ func TestTemperatureDriverStartAndHalt(t *testing.T) {
 }
 
 func TestTemperatureDriverReadData(t *testing.T) {
-	sem := make(chan bool, 0)
+	sem := make(chan bool)
 	a := NewBleTestAdaptor()
 	d := NewTemperatureDriver(a)
 	d.Start()

--- a/platforms/mqtt/mqtt_adaptor.go
+++ b/platforms/mqtt/mqtt_adaptor.go
@@ -138,11 +138,7 @@ func (a *Adaptor) Finalize() (err error) {
 // Publish a message under a specific topic
 func (a *Adaptor) Publish(topic string, message []byte) bool {
 	_, err := a.PublishWithQOS(topic, a.qos, message)
-	if err != nil {
-		return false
-	}
-
-	return true
+	return err == nil
 }
 
 // PublishAndRetain publishes a message under a specific topic with retain flag
@@ -181,10 +177,7 @@ func (a *Adaptor) OnWithQOS(event string, qos int, f func(msg Message)) (paho.To
 // On subscribes to a topic, and then calls the message handler function when data is received
 func (a *Adaptor) On(event string, f func(msg Message)) bool {
 	_, err := a.OnWithQOS(event, a.qos, f)
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 func (a *Adaptor) createClientOptions() *paho.ClientOptions {

--- a/platforms/nanopi/nanopi_adaptor.go
+++ b/platforms/nanopi/nanopi_adaptor.go
@@ -170,7 +170,7 @@ func (c *Adaptor) translatePWMPin(id string) (string, int, error) {
 
 func (p pwmPinDefinition) findPWMDir(sys *system.Accesser) (dir string, err error) {
 	items, _ := sys.Find(p.dir, p.dirRegexp)
-	if items == nil || len(items) == 0 {
+	if len(items) == 0 {
 		return "", fmt.Errorf("No path found for PWM directory pattern, '%s' in path '%s'. See README.md for activation",
 			p.dirRegexp, p.dir)
 	}

--- a/platforms/neurosky/neurosky_driver_test.go
+++ b/platforms/neurosky/neurosky_driver_test.go
@@ -36,7 +36,7 @@ func TestNeuroskyDriverName(t *testing.T) {
 }
 
 func TestNeuroskyDriverStart(t *testing.T) {
-	sem := make(chan bool, 0)
+	sem := make(chan bool)
 
 	rwc := &NullReadWriteCloser{}
 	a := NewAdaptor("/dev/null")

--- a/platforms/particle/adaptor.go
+++ b/platforms/particle/adaptor.go
@@ -175,11 +175,9 @@ func (s *Adaptor) EventStream(source string, name string) (event *gobot.Event, e
 
 	go func() {
 		for {
-			select {
-			case ev := <-events:
-				if ev.Event() != "" && ev.Data() != "" {
-					s.Publish(ev.Event(), ev.Data())
-				}
+			ev := <-events
+			if ev.Event() != "" && ev.Data() != "" {
+				s.Publish(ev.Event(), ev.Data())
 			}
 		}
 	}()
@@ -195,14 +193,13 @@ func (s *Adaptor) Variable(name string) (result string, err error) {
 		return
 	}
 
-	val := resp["result"]
-	switch val.(type) {
+	switch val := resp["result"].(type) {
 	case bool:
-		result = strconv.FormatBool(val.(bool))
+		result = strconv.FormatBool(val)
 	case float64:
-		result = strconv.FormatFloat(val.(float64), 'f', -1, 64)
+		result = strconv.FormatFloat(val, 'f', -1, 64)
 	case string:
-		result = val.(string)
+		result = val
 	}
 
 	return

--- a/platforms/particle/adaptor_test.go
+++ b/platforms/particle/adaptor_test.go
@@ -404,8 +404,8 @@ func TestAdaptorEventStream(t *testing.T) {
 	_, err = a.EventStream("devices", "")
 	gobottest.Assert(t, err.Error(), "error connecting sse")
 
-	eventChan := make(chan eventsource.Event, 0)
-	errorChan := make(chan error, 0)
+	eventChan := make(chan eventsource.Event)
+	errorChan := make(chan error)
 
 	eventSource = func(u string) (chan eventsource.Event, chan error, error) {
 		return eventChan, errorChan, nil

--- a/platforms/raspi/pwm_pin.go
+++ b/platforms/raspi/pwm_pin.go
@@ -108,7 +108,7 @@ func (p *PWMPin) SetDutyCycle(duty uint32) error {
 
 func (p *PWMPin) writeValue(data string) (err error) {
 	fi, err := p.sys.OpenFile(p.path, os.O_WRONLY|os.O_APPEND, 0644)
-	defer fi.Close()
+	defer fi.Close() //nolint:staticcheck // for historical reasons
 
 	if err != nil {
 		return err

--- a/platforms/raspi/pwm_pin_test.go
+++ b/platforms/raspi/pwm_pin_test.go
@@ -29,12 +29,12 @@ func TestPwmPin(t *testing.T) {
 	val, _ = pin.Polarity()
 	gobottest.Assert(t, val, true)
 
-	period, err := pin.Period()
+	_, err := pin.Period()
 	gobottest.Assert(t, err, errors.New("Raspi PWM pin period not set"))
 	gobottest.Assert(t, pin.SetDutyCycle(10000), errors.New("Raspi PWM pin period not set"))
 
 	gobottest.Assert(t, pin.SetPeriod(20000000), nil)
-	period, _ = pin.Period()
+	period, _ := pin.Period()
 	gobottest.Assert(t, period, uint32(20000000))
 	gobottest.Assert(t, pin.SetPeriod(10000000), errors.New("Cannot set the period of individual PWM pins on Raspi"))
 

--- a/platforms/raspi/raspi_adaptor_test.go
+++ b/platforms/raspi/raspi_adaptor_test.go
@@ -230,7 +230,7 @@ func TestPWMPinsReConnect(t *testing.T) {
 	// assert
 	gobottest.Assert(t, err, nil)
 	gobottest.Assert(t, len(a.pwmPins), 0)
-	_, err = a.PWMPin("35")
+	_, _ = a.PWMPin("35")
 	_, err = a.PWMPin("36")
 	gobottest.Assert(t, err, nil)
 	gobottest.Assert(t, len(a.pwmPins), 2)

--- a/platforms/tinkerboard/adaptor.go
+++ b/platforms/tinkerboard/adaptor.go
@@ -156,7 +156,7 @@ func (c *Adaptor) translatePWMPin(id string) (string, int, error) {
 
 func (p pwmPinDefinition) findPWMDir(sys *system.Accesser) (dir string, err error) {
 	items, _ := sys.Find(p.dir, p.dirRegexp)
-	if items == nil || len(items) == 0 {
+	if len(items) == 0 {
 		return "", fmt.Errorf("No path found for PWM directory pattern, '%s' in path '%s'. See README.md for activation",
 			p.dirRegexp, p.dir)
 	}

--- a/platforms/upboard/up2/adaptor.go
+++ b/platforms/upboard/up2/adaptor.go
@@ -52,8 +52,9 @@ type Adaptor struct {
 // NewAdaptor creates a UP2 Adaptor
 //
 // Optional parameters:
-//		adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs
-//		adaptors.WithSpiGpioAccess(sclk, nss, mosi, miso):	use GPIO's instead of /dev/spidev#.#
+//
+//	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs
+//	adaptors.WithSpiGpioAccess(sclk, nss, mosi, miso):	use GPIO's instead of /dev/spidev#.#
 func NewAdaptor(opts ...func(adaptors.Optioner)) *Adaptor {
 	sys := system.NewAccesser()
 	c := &Adaptor{
@@ -125,7 +126,7 @@ func (c *Adaptor) DigitalWrite(id string, val byte) error {
 	if id == LEDRed || id == LEDBlue || id == LEDGreen || id == LEDYellow {
 		pinPath := fmt.Sprintf(c.ledPath, id)
 		fi, err := c.sys.OpenFile(pinPath, os.O_WRONLY|os.O_APPEND, 0666)
-		defer fi.Close()
+		defer fi.Close() //nolint:staticcheck // for historical reasons
 		if err != nil {
 			return err
 		}

--- a/robot_work_test.go
+++ b/robot_work_test.go
@@ -94,7 +94,7 @@ func TestRobotAutomationFunctions(t *testing.T) {
 
 func collectStringKeysFromWorkRegistry(rwr *RobotWorkRegistry) []string {
 	keys := make([]string, len(rwr.r))
-	for k, _ := range rwr.r {
+	for k := range rwr.r {
 		keys = append(keys, k)
 	}
 	return keys

--- a/system/digitalpin_gpiod.go
+++ b/system/digitalpin_gpiod.go
@@ -193,7 +193,7 @@ func digitalPinGpiodReconfigureLine(d *digitalPinGpiod, forceInput bool) error {
 	if d.direction == IN || forceInput {
 		if systemGpiodDebug {
 			log.Printf("input (%s): debounce %s, edge %d, handler %t, inverse %t, bias %d",
-				id, d.debouncePeriod, d.edge, d.edgeEventHandler != nil, d.activeLow == true, d.bias)
+				id, d.debouncePeriod, d.edge, d.edgeEventHandler != nil, d.activeLow, d.bias)
 		}
 		opts = append(opts, gpiod.AsInput)
 		if !forceInput && d.drive != digitalPinDrivePushPull && systemGpiodDebug {
@@ -219,7 +219,7 @@ func digitalPinGpiodReconfigureLine(d *digitalPinGpiod, forceInput bool) error {
 	} else {
 		if systemGpiodDebug {
 			log.Printf("ouput (%s): ini-state %d, drive %d, inverse %t, bias %d",
-				id, d.outInitialState, d.drive, d.activeLow == true, d.bias)
+				id, d.outInitialState, d.drive, d.activeLow, d.bias)
 		}
 		opts = append(opts, gpiod.AsOutput(d.outInitialState))
 		switch d.drive {

--- a/system/digitalpin_mock.go
+++ b/system/digitalpin_mock.go
@@ -20,7 +20,6 @@ func (h *mockDigitalPinAccess) createPin(chip string, pin int,
 
 func (h *mockDigitalPinAccess) setFs(fs filesystem) {
 	// do nothing
-	return
 }
 
 func (d *digitalPinMock) ApplyOptions(options ...func(gobot.DigitalPinOptioner) bool) error {

--- a/system/digitalpin_sysfs.go
+++ b/system/digitalpin_sysfs.go
@@ -3,6 +3,7 @@ package system
 import (
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"strconv"
@@ -238,7 +239,7 @@ var readFile = func(f File) ([]byte, error) {
 	// TODO: Examine if seek is needed if full buffer is read from sysfs file.
 
 	buf := make([]byte, 2)
-	_, err := f.Seek(0, os.SEEK_SET)
+	_, err := f.Seek(0, io.SeekStart)
 	if err == nil {
 		_, err = f.Read(buf)
 	}

--- a/system/digitalpin_sysfs_test.go
+++ b/system/digitalpin_sysfs_test.go
@@ -108,7 +108,7 @@ func TestDigitalPinExportError(t *testing.T) {
 	}
 
 	err := pin.Export()
-	gobottest.Assert(t, err.Error(), " : /sys/class/gpio/gpio10/direction: No such file.")
+	gobottest.Assert(t, err.Error(), " : /sys/class/gpio/gpio10/direction: no such file")
 }
 
 func TestDigitalPinUnexportError(t *testing.T) {

--- a/system/fs_mock.go
+++ b/system/fs_mock.go
@@ -118,7 +118,7 @@ func newMockFilesystem(items []string) *MockFilesystem {
 }
 
 // OpenFile opens file name from fs.Files, if the file does not exist it returns an os.PathError
-func (fs *MockFilesystem) openFile(name string, flag int, perm os.FileMode) (file File, err error) {
+func (fs *MockFilesystem) openFile(name string, _ int, _ os.FileMode) (file File, err error) {
 	f, ok := fs.Files[name]
 	if ok {
 		f.Opened = true
@@ -126,7 +126,7 @@ func (fs *MockFilesystem) openFile(name string, flag int, perm os.FileMode) (fil
 		return f, nil
 	}
 
-	return (*MockFile)(nil), &os.PathError{Err: fmt.Errorf("%s: No such file.", name)}
+	return (*MockFile)(nil), &os.PathError{Err: fmt.Errorf("%s: no such file", name)}
 }
 
 // Stat returns a generic FileInfo for all files in fs.Files.
@@ -158,7 +158,7 @@ func (fs *MockFilesystem) stat(name string) (os.FileInfo, error) {
 		}
 	}
 
-	return nil, &os.PathError{Err: fmt.Errorf("%s: No such file.", name)}
+	return nil, &os.PathError{Err: fmt.Errorf("%s: no such file", name)}
 }
 
 // Find returns all items (files or folders) below the given directory matching the given pattern.
@@ -173,10 +173,8 @@ func (fs *MockFilesystem) find(baseDir string, pattern string) ([]string, error)
 		if !strings.HasPrefix(name, baseDir) {
 			continue
 		}
-		item := name[len(baseDir):]
-		if strings.HasPrefix(item, "/") {
-			item = item[1:]
-		}
+		item := strings.TrimPrefix(name[len(baseDir):], "/")
+
 		firstItem := strings.Split(item, "/")[0]
 		if reg.MatchString(firstItem) {
 			found = append(found, path.Join(baseDir, firstItem))
@@ -193,7 +191,7 @@ func (fs *MockFilesystem) readFile(name string) ([]byte, error) {
 
 	f, ok := fs.Files[name]
 	if !ok {
-		return nil, &os.PathError{Err: fmt.Errorf("%s: No such file.", name)}
+		return nil, &os.PathError{Err: fmt.Errorf("%s: no such file", name)}
 	}
 	return []byte(f.Contents), nil
 }

--- a/system/fs_mock_test.go
+++ b/system/fs_mock_test.go
@@ -20,7 +20,7 @@ func TestMockFilesystemOpen(t *testing.T) {
 	gobottest.Assert(t, err, nil)
 
 	_, err = fs.openFile("bar", 0, 0666)
-	gobottest.Assert(t, err.Error(), " : bar: No such file.")
+	gobottest.Assert(t, err.Error(), " : bar: no such file")
 
 	fs.Add("bar")
 	f4, _ := fs.openFile("bar", 0, 0666)
@@ -39,7 +39,7 @@ func TestMockFilesystemStat(t *testing.T) {
 	gobottest.Assert(t, dirStat.IsDir(), true)
 
 	_, err = fs.stat("plonk")
-	gobottest.Assert(t, err.Error(), " : plonk: No such file.")
+	gobottest.Assert(t, err.Error(), " : plonk: no such file")
 }
 
 func TestMockFilesystemFind(t *testing.T) {

--- a/system/fs_test.go
+++ b/system/fs_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestFilesystemOpen(t *testing.T) {
 	fs := &nativeFilesystem{}
-	file, err := fs.openFile(os.DevNull, os.O_RDONLY, 666)
+	file, err := fs.openFile(os.DevNull, os.O_RDONLY, 0666)
 	gobottest.Assert(t, err, nil)
 	var _ File = file
 }

--- a/system/i2c_device_test.go
+++ b/system/i2c_device_test.go
@@ -548,7 +548,7 @@ func Test_queryFunctionality(t *testing.T) {
 		"dev_null_error": {
 			dev:         os.DevNull,
 			syscallImpl: getSyscallFuncImpl(0x00),
-			wantErr:     " : /dev/null: No such file.",
+			wantErr:     " : /dev/null: no such file",
 		},
 		"query_funcs_error": {
 			dev:         dev,

--- a/system/pwmpin_sysfs.go
+++ b/system/pwmpin_sysfs.go
@@ -223,7 +223,7 @@ func (p *pwmPinSysFs) pwmPolarityPath() string {
 
 func writePwmFile(fs filesystem, path string, data []byte) (int, error) {
 	file, err := fs.openFile(path, os.O_WRONLY, 0644)
-	defer file.Close()
+	defer file.Close() //nolint:staticcheck // for historical reasons
 	if err != nil {
 		return 0, err
 	}
@@ -233,7 +233,7 @@ func writePwmFile(fs filesystem, path string, data []byte) (int, error) {
 
 func readPwmFile(fs filesystem, path string) ([]byte, error) {
 	file, err := fs.openFile(path, os.O_RDONLY, 0644)
-	defer file.Close()
+	defer file.Close() //nolint:staticcheck // for historical reasons
 	if err != nil {
 		return make([]byte, 0), err
 	}

--- a/system/pwmpin_sysfs.go
+++ b/system/pwmpin_sysfs.go
@@ -260,7 +260,7 @@ func (p *pwmPinSysFs) printState() {
 	fmt.Printf("DutyCycle: %v, ", duty)
 	var powerPercent float64
 	if enabled {
-		if polarity == true {
+		if polarity {
 			powerPercent = float64(duty) / float64(period) * 100
 		} else {
 			powerPercent = float64(period) / float64(duty) * 100

--- a/utils.go
+++ b/utils.go
@@ -17,10 +17,8 @@ func Every(t time.Duration, f func()) *time.Ticker {
 
 	go func() {
 		for {
-			select {
-			case <-ticker.C:
-				f()
-			}
+			<-ticker.C
+			f()
 		}
 	}()
 


### PR DESCRIPTION
## Solved issues and/or description of the change

Fix encoder and dps overflow in gopigo3 "GetMotorStatus()". Problem found by "staticcheck".

Activated linters: 
* gosimple
* govet
* staticcheck
* nolintlint

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test`)