### PR TITLE
mavlink: fix linter issues of errcheck

### DIFF
--- a/platforms/mavlink/README.md
+++ b/platforms/mavlink/README.md
@@ -1,6 +1,6 @@
 # Mavlink
 
-For information on the MAVlink communication protocol click [here](http://qgroundcontrol.org/mavlink/start).
+For information on the MAVlink communication protocol click [here](https://mavlink.io/).
 
 This package supports Mavlink over serial (such as a
 [SiK modem](http://ardupilot.org/copter/docs/common-sik-telemetry-radio.html))
@@ -13,6 +13,8 @@ multiple simultaneous clients such as the robot and
 As at 2018-04, this package supports Mavlink 1.0 only.  If the robot
 doesn't receiving data then check that the other devices are
 configured to send version 1.0 frames.
+
+For Mavlink 2.0 please refer to [gomavlib](https://github.com/bluenviron/gomavlib).
 
 ## How to Install
 

--- a/platforms/mavlink/common/common.go
+++ b/platforms/mavlink/common/common.go
@@ -1,4 +1,3 @@
-//nolint:errcheck // to much code to fix it immediately
 package mavlink
 
 //
@@ -681,24 +680,48 @@ func (*Heartbeat) Crc() uint8 {
 // Pack returns a packed byte array which represents a Heartbeat payload
 func (m *Heartbeat) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.CUSTOM_MODE)
-	binary.Write(data, binary.LittleEndian, m.TYPE)
-	binary.Write(data, binary.LittleEndian, m.AUTOPILOT)
-	binary.Write(data, binary.LittleEndian, m.BASE_MODE)
-	binary.Write(data, binary.LittleEndian, m.SYSTEM_STATUS)
-	binary.Write(data, binary.LittleEndian, m.MAVLINK_VERSION)
+	if err := binary.Write(data, binary.LittleEndian, m.CUSTOM_MODE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TYPE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.AUTOPILOT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.BASE_MODE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SYSTEM_STATUS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.MAVLINK_VERSION); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the Heartbeat
 func (m *Heartbeat) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.CUSTOM_MODE)
-	binary.Read(data, binary.LittleEndian, &m.TYPE)
-	binary.Read(data, binary.LittleEndian, &m.AUTOPILOT)
-	binary.Read(data, binary.LittleEndian, &m.BASE_MODE)
-	binary.Read(data, binary.LittleEndian, &m.SYSTEM_STATUS)
-	binary.Read(data, binary.LittleEndian, &m.MAVLINK_VERSION)
+	if err := binary.Read(data, binary.LittleEndian, &m.CUSTOM_MODE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TYPE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.AUTOPILOT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.BASE_MODE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SYSTEM_STATUS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.MAVLINK_VERSION); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE SYS_STATUS
@@ -761,38 +784,90 @@ func (*SysStatus) Crc() uint8 {
 // Pack returns a packed byte array which represents a SysStatus payload
 func (m *SysStatus) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.ONBOARD_CONTROL_SENSORS_PRESENT)
-	binary.Write(data, binary.LittleEndian, m.ONBOARD_CONTROL_SENSORS_ENABLED)
-	binary.Write(data, binary.LittleEndian, m.ONBOARD_CONTROL_SENSORS_HEALTH)
-	binary.Write(data, binary.LittleEndian, m.LOAD)
-	binary.Write(data, binary.LittleEndian, m.VOLTAGE_BATTERY)
-	binary.Write(data, binary.LittleEndian, m.CURRENT_BATTERY)
-	binary.Write(data, binary.LittleEndian, m.DROP_RATE_COMM)
-	binary.Write(data, binary.LittleEndian, m.ERRORS_COMM)
-	binary.Write(data, binary.LittleEndian, m.ERRORS_COUNT1)
-	binary.Write(data, binary.LittleEndian, m.ERRORS_COUNT2)
-	binary.Write(data, binary.LittleEndian, m.ERRORS_COUNT3)
-	binary.Write(data, binary.LittleEndian, m.ERRORS_COUNT4)
-	binary.Write(data, binary.LittleEndian, m.BATTERY_REMAINING)
+	if err := binary.Write(data, binary.LittleEndian, m.ONBOARD_CONTROL_SENSORS_PRESENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ONBOARD_CONTROL_SENSORS_ENABLED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ONBOARD_CONTROL_SENSORS_HEALTH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LOAD); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VOLTAGE_BATTERY); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CURRENT_BATTERY); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.DROP_RATE_COMM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ERRORS_COMM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ERRORS_COUNT1); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ERRORS_COUNT2); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ERRORS_COUNT3); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ERRORS_COUNT4); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.BATTERY_REMAINING); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the SysStatus
 func (m *SysStatus) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.ONBOARD_CONTROL_SENSORS_PRESENT)
-	binary.Read(data, binary.LittleEndian, &m.ONBOARD_CONTROL_SENSORS_ENABLED)
-	binary.Read(data, binary.LittleEndian, &m.ONBOARD_CONTROL_SENSORS_HEALTH)
-	binary.Read(data, binary.LittleEndian, &m.LOAD)
-	binary.Read(data, binary.LittleEndian, &m.VOLTAGE_BATTERY)
-	binary.Read(data, binary.LittleEndian, &m.CURRENT_BATTERY)
-	binary.Read(data, binary.LittleEndian, &m.DROP_RATE_COMM)
-	binary.Read(data, binary.LittleEndian, &m.ERRORS_COMM)
-	binary.Read(data, binary.LittleEndian, &m.ERRORS_COUNT1)
-	binary.Read(data, binary.LittleEndian, &m.ERRORS_COUNT2)
-	binary.Read(data, binary.LittleEndian, &m.ERRORS_COUNT3)
-	binary.Read(data, binary.LittleEndian, &m.ERRORS_COUNT4)
-	binary.Read(data, binary.LittleEndian, &m.BATTERY_REMAINING)
+	if err := binary.Read(data, binary.LittleEndian, &m.ONBOARD_CONTROL_SENSORS_PRESENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ONBOARD_CONTROL_SENSORS_ENABLED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ONBOARD_CONTROL_SENSORS_HEALTH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LOAD); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VOLTAGE_BATTERY); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CURRENT_BATTERY); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.DROP_RATE_COMM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ERRORS_COMM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ERRORS_COUNT1); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ERRORS_COUNT2); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ERRORS_COUNT3); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ERRORS_COUNT4); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.BATTERY_REMAINING); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE SYSTEM_TIME
@@ -833,16 +908,24 @@ func (*SystemTime) Crc() uint8 {
 // Pack returns a packed byte array which represents a SystemTime payload
 func (m *SystemTime) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_UNIX_USEC)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_UNIX_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the SystemTime
 func (m *SystemTime) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_UNIX_USEC)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_UNIX_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE PING
@@ -887,20 +970,36 @@ func (*Ping) Crc() uint8 {
 // Pack returns a packed byte array which represents a Ping payload
 func (m *Ping) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_USEC)
-	binary.Write(data, binary.LittleEndian, m.SEQ)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SEQ); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the Ping
 func (m *Ping) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_USEC)
-	binary.Read(data, binary.LittleEndian, &m.SEQ)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SEQ); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE CHANGE_OPERATOR_CONTROL
@@ -945,20 +1044,36 @@ func (*ChangeOperatorControl) Crc() uint8 {
 // Pack returns a packed byte array which represents a ChangeOperatorControl payload
 func (m *ChangeOperatorControl) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.CONTROL_REQUEST)
-	binary.Write(data, binary.LittleEndian, m.VERSION)
-	binary.Write(data, binary.LittleEndian, m.PASSKEY)
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CONTROL_REQUEST); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VERSION); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PASSKEY); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the ChangeOperatorControl
 func (m *ChangeOperatorControl) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.CONTROL_REQUEST)
-	binary.Read(data, binary.LittleEndian, &m.VERSION)
-	binary.Read(data, binary.LittleEndian, &m.PASSKEY)
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CONTROL_REQUEST); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VERSION); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PASSKEY); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -1005,18 +1120,30 @@ func (*ChangeOperatorControlAck) Crc() uint8 {
 // Pack returns a packed byte array which represents a ChangeOperatorControlAck payload
 func (m *ChangeOperatorControlAck) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.GCS_SYSTEM_ID)
-	binary.Write(data, binary.LittleEndian, m.CONTROL_REQUEST)
-	binary.Write(data, binary.LittleEndian, m.ACK)
+	if err := binary.Write(data, binary.LittleEndian, m.GCS_SYSTEM_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CONTROL_REQUEST); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ACK); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the ChangeOperatorControlAck
 func (m *ChangeOperatorControlAck) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.GCS_SYSTEM_ID)
-	binary.Read(data, binary.LittleEndian, &m.CONTROL_REQUEST)
-	binary.Read(data, binary.LittleEndian, &m.ACK)
+	if err := binary.Read(data, binary.LittleEndian, &m.GCS_SYSTEM_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CONTROL_REQUEST); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ACK); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE AUTH_KEY
@@ -1055,14 +1182,18 @@ func (*AuthKey) Crc() uint8 {
 // Pack returns a packed byte array which represents a AuthKey payload
 func (m *AuthKey) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.KEY)
+	if err := binary.Write(data, binary.LittleEndian, m.KEY); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the AuthKey
 func (m *AuthKey) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.KEY)
+	if err := binary.Read(data, binary.LittleEndian, &m.KEY); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -1109,18 +1240,30 @@ func (*SetMode) Crc() uint8 {
 // Pack returns a packed byte array which represents a SetMode payload
 func (m *SetMode) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.CUSTOM_MODE)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.BASE_MODE)
+	if err := binary.Write(data, binary.LittleEndian, m.CUSTOM_MODE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.BASE_MODE); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the SetMode
 func (m *SetMode) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.CUSTOM_MODE)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.BASE_MODE)
+	if err := binary.Read(data, binary.LittleEndian, &m.CUSTOM_MODE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.BASE_MODE); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE PARAM_REQUEST_READ
@@ -1165,20 +1308,36 @@ func (*ParamRequestRead) Crc() uint8 {
 // Pack returns a packed byte array which represents a ParamRequestRead payload
 func (m *ParamRequestRead) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.PARAM_INDEX)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
-	binary.Write(data, binary.LittleEndian, m.PARAM_ID)
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM_INDEX); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM_ID); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the ParamRequestRead
 func (m *ParamRequestRead) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.PARAM_INDEX)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
-	binary.Read(data, binary.LittleEndian, &m.PARAM_ID)
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM_INDEX); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM_ID); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -1223,16 +1382,24 @@ func (*ParamRequestList) Crc() uint8 {
 // Pack returns a packed byte array which represents a ParamRequestList payload
 func (m *ParamRequestList) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the ParamRequestList
 func (m *ParamRequestList) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE PARAM_VALUE
@@ -1279,22 +1446,42 @@ func (*ParamValue) Crc() uint8 {
 // Pack returns a packed byte array which represents a ParamValue payload
 func (m *ParamValue) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.PARAM_VALUE)
-	binary.Write(data, binary.LittleEndian, m.PARAM_COUNT)
-	binary.Write(data, binary.LittleEndian, m.PARAM_INDEX)
-	binary.Write(data, binary.LittleEndian, m.PARAM_ID)
-	binary.Write(data, binary.LittleEndian, m.PARAM_TYPE)
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM_VALUE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM_COUNT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM_INDEX); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM_TYPE); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the ParamValue
 func (m *ParamValue) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.PARAM_VALUE)
-	binary.Read(data, binary.LittleEndian, &m.PARAM_COUNT)
-	binary.Read(data, binary.LittleEndian, &m.PARAM_INDEX)
-	binary.Read(data, binary.LittleEndian, &m.PARAM_ID)
-	binary.Read(data, binary.LittleEndian, &m.PARAM_TYPE)
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM_VALUE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM_COUNT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM_INDEX); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM_TYPE); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -1345,22 +1532,42 @@ func (*ParamSet) Crc() uint8 {
 // Pack returns a packed byte array which represents a ParamSet payload
 func (m *ParamSet) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.PARAM_VALUE)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
-	binary.Write(data, binary.LittleEndian, m.PARAM_ID)
-	binary.Write(data, binary.LittleEndian, m.PARAM_TYPE)
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM_VALUE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM_TYPE); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the ParamSet
 func (m *ParamSet) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.PARAM_VALUE)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
-	binary.Read(data, binary.LittleEndian, &m.PARAM_ID)
-	binary.Read(data, binary.LittleEndian, &m.PARAM_TYPE)
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM_VALUE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM_TYPE); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -1421,32 +1628,72 @@ func (*GpsRawInt) Crc() uint8 {
 // Pack returns a packed byte array which represents a GpsRawInt payload
 func (m *GpsRawInt) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_USEC)
-	binary.Write(data, binary.LittleEndian, m.LAT)
-	binary.Write(data, binary.LittleEndian, m.LON)
-	binary.Write(data, binary.LittleEndian, m.ALT)
-	binary.Write(data, binary.LittleEndian, m.EPH)
-	binary.Write(data, binary.LittleEndian, m.EPV)
-	binary.Write(data, binary.LittleEndian, m.VEL)
-	binary.Write(data, binary.LittleEndian, m.COG)
-	binary.Write(data, binary.LittleEndian, m.FIX_TYPE)
-	binary.Write(data, binary.LittleEndian, m.SATELLITES_VISIBLE)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.EPH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.EPV); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VEL); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.COG); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FIX_TYPE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SATELLITES_VISIBLE); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the GpsRawInt
 func (m *GpsRawInt) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_USEC)
-	binary.Read(data, binary.LittleEndian, &m.LAT)
-	binary.Read(data, binary.LittleEndian, &m.LON)
-	binary.Read(data, binary.LittleEndian, &m.ALT)
-	binary.Read(data, binary.LittleEndian, &m.EPH)
-	binary.Read(data, binary.LittleEndian, &m.EPV)
-	binary.Read(data, binary.LittleEndian, &m.VEL)
-	binary.Read(data, binary.LittleEndian, &m.COG)
-	binary.Read(data, binary.LittleEndian, &m.FIX_TYPE)
-	binary.Read(data, binary.LittleEndian, &m.SATELLITES_VISIBLE)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.EPH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.EPV); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VEL); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.COG); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FIX_TYPE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SATELLITES_VISIBLE); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE GPS_STATUS
@@ -1495,24 +1742,48 @@ func (*GpsStatus) Crc() uint8 {
 // Pack returns a packed byte array which represents a GpsStatus payload
 func (m *GpsStatus) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.SATELLITES_VISIBLE)
-	binary.Write(data, binary.LittleEndian, m.SATELLITE_PRN)
-	binary.Write(data, binary.LittleEndian, m.SATELLITE_USED)
-	binary.Write(data, binary.LittleEndian, m.SATELLITE_ELEVATION)
-	binary.Write(data, binary.LittleEndian, m.SATELLITE_AZIMUTH)
-	binary.Write(data, binary.LittleEndian, m.SATELLITE_SNR)
+	if err := binary.Write(data, binary.LittleEndian, m.SATELLITES_VISIBLE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SATELLITE_PRN); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SATELLITE_USED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SATELLITE_ELEVATION); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SATELLITE_AZIMUTH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SATELLITE_SNR); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the GpsStatus
 func (m *GpsStatus) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.SATELLITES_VISIBLE)
-	binary.Read(data, binary.LittleEndian, &m.SATELLITE_PRN)
-	binary.Read(data, binary.LittleEndian, &m.SATELLITE_USED)
-	binary.Read(data, binary.LittleEndian, &m.SATELLITE_ELEVATION)
-	binary.Read(data, binary.LittleEndian, &m.SATELLITE_AZIMUTH)
-	binary.Read(data, binary.LittleEndian, &m.SATELLITE_SNR)
+	if err := binary.Read(data, binary.LittleEndian, &m.SATELLITES_VISIBLE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SATELLITE_PRN); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SATELLITE_USED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SATELLITE_ELEVATION); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SATELLITE_AZIMUTH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SATELLITE_SNR); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -1577,32 +1848,72 @@ func (*ScaledImu) Crc() uint8 {
 // Pack returns a packed byte array which represents a ScaledImu payload
 func (m *ScaledImu) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.XACC)
-	binary.Write(data, binary.LittleEndian, m.YACC)
-	binary.Write(data, binary.LittleEndian, m.ZACC)
-	binary.Write(data, binary.LittleEndian, m.XGYRO)
-	binary.Write(data, binary.LittleEndian, m.YGYRO)
-	binary.Write(data, binary.LittleEndian, m.ZGYRO)
-	binary.Write(data, binary.LittleEndian, m.XMAG)
-	binary.Write(data, binary.LittleEndian, m.YMAG)
-	binary.Write(data, binary.LittleEndian, m.ZMAG)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZMAG); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the ScaledImu
 func (m *ScaledImu) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.XACC)
-	binary.Read(data, binary.LittleEndian, &m.YACC)
-	binary.Read(data, binary.LittleEndian, &m.ZACC)
-	binary.Read(data, binary.LittleEndian, &m.XGYRO)
-	binary.Read(data, binary.LittleEndian, &m.YGYRO)
-	binary.Read(data, binary.LittleEndian, &m.ZGYRO)
-	binary.Read(data, binary.LittleEndian, &m.XMAG)
-	binary.Read(data, binary.LittleEndian, &m.YMAG)
-	binary.Read(data, binary.LittleEndian, &m.ZMAG)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZMAG); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE RAW_IMU
@@ -1659,32 +1970,72 @@ func (*RawImu) Crc() uint8 {
 // Pack returns a packed byte array which represents a RawImu payload
 func (m *RawImu) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_USEC)
-	binary.Write(data, binary.LittleEndian, m.XACC)
-	binary.Write(data, binary.LittleEndian, m.YACC)
-	binary.Write(data, binary.LittleEndian, m.ZACC)
-	binary.Write(data, binary.LittleEndian, m.XGYRO)
-	binary.Write(data, binary.LittleEndian, m.YGYRO)
-	binary.Write(data, binary.LittleEndian, m.ZGYRO)
-	binary.Write(data, binary.LittleEndian, m.XMAG)
-	binary.Write(data, binary.LittleEndian, m.YMAG)
-	binary.Write(data, binary.LittleEndian, m.ZMAG)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZMAG); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the RawImu
 func (m *RawImu) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_USEC)
-	binary.Read(data, binary.LittleEndian, &m.XACC)
-	binary.Read(data, binary.LittleEndian, &m.YACC)
-	binary.Read(data, binary.LittleEndian, &m.ZACC)
-	binary.Read(data, binary.LittleEndian, &m.XGYRO)
-	binary.Read(data, binary.LittleEndian, &m.YGYRO)
-	binary.Read(data, binary.LittleEndian, &m.ZGYRO)
-	binary.Read(data, binary.LittleEndian, &m.XMAG)
-	binary.Read(data, binary.LittleEndian, &m.YMAG)
-	binary.Read(data, binary.LittleEndian, &m.ZMAG)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZMAG); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE RAW_PRESSURE
@@ -1731,22 +2082,42 @@ func (*RawPressure) Crc() uint8 {
 // Pack returns a packed byte array which represents a RawPressure payload
 func (m *RawPressure) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_USEC)
-	binary.Write(data, binary.LittleEndian, m.PRESS_ABS)
-	binary.Write(data, binary.LittleEndian, m.PRESS_DIFF1)
-	binary.Write(data, binary.LittleEndian, m.PRESS_DIFF2)
-	binary.Write(data, binary.LittleEndian, m.TEMPERATURE)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PRESS_ABS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PRESS_DIFF1); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PRESS_DIFF2); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TEMPERATURE); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the RawPressure
 func (m *RawPressure) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_USEC)
-	binary.Read(data, binary.LittleEndian, &m.PRESS_ABS)
-	binary.Read(data, binary.LittleEndian, &m.PRESS_DIFF1)
-	binary.Read(data, binary.LittleEndian, &m.PRESS_DIFF2)
-	binary.Read(data, binary.LittleEndian, &m.TEMPERATURE)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PRESS_ABS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PRESS_DIFF1); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PRESS_DIFF2); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TEMPERATURE); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE SCALED_PRESSURE
@@ -1791,20 +2162,36 @@ func (*ScaledPressure) Crc() uint8 {
 // Pack returns a packed byte array which represents a ScaledPressure payload
 func (m *ScaledPressure) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.PRESS_ABS)
-	binary.Write(data, binary.LittleEndian, m.PRESS_DIFF)
-	binary.Write(data, binary.LittleEndian, m.TEMPERATURE)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PRESS_ABS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PRESS_DIFF); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TEMPERATURE); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the ScaledPressure
 func (m *ScaledPressure) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.PRESS_ABS)
-	binary.Read(data, binary.LittleEndian, &m.PRESS_DIFF)
-	binary.Read(data, binary.LittleEndian, &m.TEMPERATURE)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PRESS_ABS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PRESS_DIFF); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TEMPERATURE); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE ATTITUDE
@@ -1855,26 +2242,54 @@ func (*Attitude) Crc() uint8 {
 // Pack returns a packed byte array which represents a Attitude payload
 func (m *Attitude) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.ROLL)
-	binary.Write(data, binary.LittleEndian, m.PITCH)
-	binary.Write(data, binary.LittleEndian, m.YAW)
-	binary.Write(data, binary.LittleEndian, m.ROLLSPEED)
-	binary.Write(data, binary.LittleEndian, m.PITCHSPEED)
-	binary.Write(data, binary.LittleEndian, m.YAWSPEED)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROLLSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCHSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAWSPEED); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the Attitude
 func (m *Attitude) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.ROLL)
-	binary.Read(data, binary.LittleEndian, &m.PITCH)
-	binary.Read(data, binary.LittleEndian, &m.YAW)
-	binary.Read(data, binary.LittleEndian, &m.ROLLSPEED)
-	binary.Read(data, binary.LittleEndian, &m.PITCHSPEED)
-	binary.Read(data, binary.LittleEndian, &m.YAWSPEED)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLLSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCHSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAWSPEED); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE ATTITUDE_QUATERNION
@@ -1927,28 +2342,60 @@ func (*AttitudeQuaternion) Crc() uint8 {
 // Pack returns a packed byte array which represents a AttitudeQuaternion payload
 func (m *AttitudeQuaternion) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.Q1)
-	binary.Write(data, binary.LittleEndian, m.Q2)
-	binary.Write(data, binary.LittleEndian, m.Q3)
-	binary.Write(data, binary.LittleEndian, m.Q4)
-	binary.Write(data, binary.LittleEndian, m.ROLLSPEED)
-	binary.Write(data, binary.LittleEndian, m.PITCHSPEED)
-	binary.Write(data, binary.LittleEndian, m.YAWSPEED)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Q1); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Q2); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Q3); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Q4); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROLLSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCHSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAWSPEED); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the AttitudeQuaternion
 func (m *AttitudeQuaternion) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.Q1)
-	binary.Read(data, binary.LittleEndian, &m.Q2)
-	binary.Read(data, binary.LittleEndian, &m.Q3)
-	binary.Read(data, binary.LittleEndian, &m.Q4)
-	binary.Read(data, binary.LittleEndian, &m.ROLLSPEED)
-	binary.Read(data, binary.LittleEndian, &m.PITCHSPEED)
-	binary.Read(data, binary.LittleEndian, &m.YAWSPEED)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Q1); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Q2); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Q3); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Q4); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLLSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCHSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAWSPEED); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE LOCAL_POSITION_NED
@@ -1999,26 +2446,54 @@ func (*LocalPositionNed) Crc() uint8 {
 // Pack returns a packed byte array which represents a LocalPositionNed payload
 func (m *LocalPositionNed) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.X)
-	binary.Write(data, binary.LittleEndian, m.Y)
-	binary.Write(data, binary.LittleEndian, m.Z)
-	binary.Write(data, binary.LittleEndian, m.VX)
-	binary.Write(data, binary.LittleEndian, m.VY)
-	binary.Write(data, binary.LittleEndian, m.VZ)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VX); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VY); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VZ); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the LocalPositionNed
 func (m *LocalPositionNed) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.X)
-	binary.Read(data, binary.LittleEndian, &m.Y)
-	binary.Read(data, binary.LittleEndian, &m.Z)
-	binary.Read(data, binary.LittleEndian, &m.VX)
-	binary.Read(data, binary.LittleEndian, &m.VY)
-	binary.Read(data, binary.LittleEndian, &m.VZ)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VX); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VY); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VZ); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE GLOBAL_POSITION_INT
@@ -2073,30 +2548,66 @@ func (*GlobalPositionInt) Crc() uint8 {
 // Pack returns a packed byte array which represents a GlobalPositionInt payload
 func (m *GlobalPositionInt) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.LAT)
-	binary.Write(data, binary.LittleEndian, m.LON)
-	binary.Write(data, binary.LittleEndian, m.ALT)
-	binary.Write(data, binary.LittleEndian, m.RELATIVE_ALT)
-	binary.Write(data, binary.LittleEndian, m.VX)
-	binary.Write(data, binary.LittleEndian, m.VY)
-	binary.Write(data, binary.LittleEndian, m.VZ)
-	binary.Write(data, binary.LittleEndian, m.HDG)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.RELATIVE_ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VX); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VY); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VZ); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.HDG); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the GlobalPositionInt
 func (m *GlobalPositionInt) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.LAT)
-	binary.Read(data, binary.LittleEndian, &m.LON)
-	binary.Read(data, binary.LittleEndian, &m.ALT)
-	binary.Read(data, binary.LittleEndian, &m.RELATIVE_ALT)
-	binary.Read(data, binary.LittleEndian, &m.VX)
-	binary.Read(data, binary.LittleEndian, &m.VY)
-	binary.Read(data, binary.LittleEndian, &m.VZ)
-	binary.Read(data, binary.LittleEndian, &m.HDG)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.RELATIVE_ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VX); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VY); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VZ); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.HDG); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE RC_CHANNELS_SCALED
@@ -2155,34 +2666,78 @@ func (*RcChannelsScaled) Crc() uint8 {
 // Pack returns a packed byte array which represents a RcChannelsScaled payload
 func (m *RcChannelsScaled) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.CHAN1_SCALED)
-	binary.Write(data, binary.LittleEndian, m.CHAN2_SCALED)
-	binary.Write(data, binary.LittleEndian, m.CHAN3_SCALED)
-	binary.Write(data, binary.LittleEndian, m.CHAN4_SCALED)
-	binary.Write(data, binary.LittleEndian, m.CHAN5_SCALED)
-	binary.Write(data, binary.LittleEndian, m.CHAN6_SCALED)
-	binary.Write(data, binary.LittleEndian, m.CHAN7_SCALED)
-	binary.Write(data, binary.LittleEndian, m.CHAN8_SCALED)
-	binary.Write(data, binary.LittleEndian, m.PORT)
-	binary.Write(data, binary.LittleEndian, m.RSSI)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN1_SCALED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN2_SCALED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN3_SCALED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN4_SCALED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN5_SCALED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN6_SCALED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN7_SCALED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN8_SCALED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PORT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.RSSI); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the RcChannelsScaled
 func (m *RcChannelsScaled) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.CHAN1_SCALED)
-	binary.Read(data, binary.LittleEndian, &m.CHAN2_SCALED)
-	binary.Read(data, binary.LittleEndian, &m.CHAN3_SCALED)
-	binary.Read(data, binary.LittleEndian, &m.CHAN4_SCALED)
-	binary.Read(data, binary.LittleEndian, &m.CHAN5_SCALED)
-	binary.Read(data, binary.LittleEndian, &m.CHAN6_SCALED)
-	binary.Read(data, binary.LittleEndian, &m.CHAN7_SCALED)
-	binary.Read(data, binary.LittleEndian, &m.CHAN8_SCALED)
-	binary.Read(data, binary.LittleEndian, &m.PORT)
-	binary.Read(data, binary.LittleEndian, &m.RSSI)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN1_SCALED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN2_SCALED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN3_SCALED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN4_SCALED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN5_SCALED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN6_SCALED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN7_SCALED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN8_SCALED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PORT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.RSSI); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE RC_CHANNELS_RAW
@@ -2241,34 +2796,78 @@ func (*RcChannelsRaw) Crc() uint8 {
 // Pack returns a packed byte array which represents a RcChannelsRaw payload
 func (m *RcChannelsRaw) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.CHAN1_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN2_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN3_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN4_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN5_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN6_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN7_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN8_RAW)
-	binary.Write(data, binary.LittleEndian, m.PORT)
-	binary.Write(data, binary.LittleEndian, m.RSSI)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN1_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN2_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN3_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN4_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN5_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN6_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN7_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN8_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PORT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.RSSI); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the RcChannelsRaw
 func (m *RcChannelsRaw) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.CHAN1_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN2_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN3_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN4_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN5_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN6_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN7_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN8_RAW)
-	binary.Read(data, binary.LittleEndian, &m.PORT)
-	binary.Read(data, binary.LittleEndian, &m.RSSI)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN1_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN2_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN3_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN4_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN5_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN6_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN7_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN8_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PORT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.RSSI); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE SERVO_OUTPUT_RAW
@@ -2325,32 +2924,72 @@ func (*ServoOutputRaw) Crc() uint8 {
 // Pack returns a packed byte array which represents a ServoOutputRaw payload
 func (m *ServoOutputRaw) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_USEC)
-	binary.Write(data, binary.LittleEndian, m.SERVO1_RAW)
-	binary.Write(data, binary.LittleEndian, m.SERVO2_RAW)
-	binary.Write(data, binary.LittleEndian, m.SERVO3_RAW)
-	binary.Write(data, binary.LittleEndian, m.SERVO4_RAW)
-	binary.Write(data, binary.LittleEndian, m.SERVO5_RAW)
-	binary.Write(data, binary.LittleEndian, m.SERVO6_RAW)
-	binary.Write(data, binary.LittleEndian, m.SERVO7_RAW)
-	binary.Write(data, binary.LittleEndian, m.SERVO8_RAW)
-	binary.Write(data, binary.LittleEndian, m.PORT)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SERVO1_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SERVO2_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SERVO3_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SERVO4_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SERVO5_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SERVO6_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SERVO7_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SERVO8_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PORT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the ServoOutputRaw
 func (m *ServoOutputRaw) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_USEC)
-	binary.Read(data, binary.LittleEndian, &m.SERVO1_RAW)
-	binary.Read(data, binary.LittleEndian, &m.SERVO2_RAW)
-	binary.Read(data, binary.LittleEndian, &m.SERVO3_RAW)
-	binary.Read(data, binary.LittleEndian, &m.SERVO4_RAW)
-	binary.Read(data, binary.LittleEndian, &m.SERVO5_RAW)
-	binary.Read(data, binary.LittleEndian, &m.SERVO6_RAW)
-	binary.Read(data, binary.LittleEndian, &m.SERVO7_RAW)
-	binary.Read(data, binary.LittleEndian, &m.SERVO8_RAW)
-	binary.Read(data, binary.LittleEndian, &m.PORT)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SERVO1_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SERVO2_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SERVO3_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SERVO4_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SERVO5_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SERVO6_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SERVO7_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SERVO8_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PORT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE MISSION_REQUEST_PARTIAL_LIST
@@ -2395,20 +3034,36 @@ func (*MissionRequestPartialList) Crc() uint8 {
 // Pack returns a packed byte array which represents a MissionRequestPartialList payload
 func (m *MissionRequestPartialList) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.START_INDEX)
-	binary.Write(data, binary.LittleEndian, m.END_INDEX)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
+	if err := binary.Write(data, binary.LittleEndian, m.START_INDEX); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.END_INDEX); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the MissionRequestPartialList
 func (m *MissionRequestPartialList) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.START_INDEX)
-	binary.Read(data, binary.LittleEndian, &m.END_INDEX)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
+	if err := binary.Read(data, binary.LittleEndian, &m.START_INDEX); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.END_INDEX); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE MISSION_WRITE_PARTIAL_LIST
@@ -2453,20 +3108,36 @@ func (*MissionWritePartialList) Crc() uint8 {
 // Pack returns a packed byte array which represents a MissionWritePartialList payload
 func (m *MissionWritePartialList) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.START_INDEX)
-	binary.Write(data, binary.LittleEndian, m.END_INDEX)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
+	if err := binary.Write(data, binary.LittleEndian, m.START_INDEX); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.END_INDEX); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the MissionWritePartialList
 func (m *MissionWritePartialList) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.START_INDEX)
-	binary.Read(data, binary.LittleEndian, &m.END_INDEX)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
+	if err := binary.Read(data, binary.LittleEndian, &m.START_INDEX); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.END_INDEX); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE MISSION_ITEM
@@ -2531,40 +3202,96 @@ func (*MissionItem) Crc() uint8 {
 // Pack returns a packed byte array which represents a MissionItem payload
 func (m *MissionItem) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.PARAM1)
-	binary.Write(data, binary.LittleEndian, m.PARAM2)
-	binary.Write(data, binary.LittleEndian, m.PARAM3)
-	binary.Write(data, binary.LittleEndian, m.PARAM4)
-	binary.Write(data, binary.LittleEndian, m.X)
-	binary.Write(data, binary.LittleEndian, m.Y)
-	binary.Write(data, binary.LittleEndian, m.Z)
-	binary.Write(data, binary.LittleEndian, m.SEQ)
-	binary.Write(data, binary.LittleEndian, m.COMMAND)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
-	binary.Write(data, binary.LittleEndian, m.FRAME)
-	binary.Write(data, binary.LittleEndian, m.CURRENT)
-	binary.Write(data, binary.LittleEndian, m.AUTOCONTINUE)
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM1); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM2); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM3); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM4); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SEQ); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.COMMAND); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FRAME); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CURRENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.AUTOCONTINUE); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the MissionItem
 func (m *MissionItem) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.PARAM1)
-	binary.Read(data, binary.LittleEndian, &m.PARAM2)
-	binary.Read(data, binary.LittleEndian, &m.PARAM3)
-	binary.Read(data, binary.LittleEndian, &m.PARAM4)
-	binary.Read(data, binary.LittleEndian, &m.X)
-	binary.Read(data, binary.LittleEndian, &m.Y)
-	binary.Read(data, binary.LittleEndian, &m.Z)
-	binary.Read(data, binary.LittleEndian, &m.SEQ)
-	binary.Read(data, binary.LittleEndian, &m.COMMAND)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
-	binary.Read(data, binary.LittleEndian, &m.FRAME)
-	binary.Read(data, binary.LittleEndian, &m.CURRENT)
-	binary.Read(data, binary.LittleEndian, &m.AUTOCONTINUE)
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM1); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM2); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM3); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM4); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SEQ); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.COMMAND); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FRAME); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CURRENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.AUTOCONTINUE); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE MISSION_REQUEST
@@ -2607,18 +3334,30 @@ func (*MissionRequest) Crc() uint8 {
 // Pack returns a packed byte array which represents a MissionRequest payload
 func (m *MissionRequest) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.SEQ)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
+	if err := binary.Write(data, binary.LittleEndian, m.SEQ); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the MissionRequest
 func (m *MissionRequest) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.SEQ)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
+	if err := binary.Read(data, binary.LittleEndian, &m.SEQ); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE MISSION_SET_CURRENT
@@ -2661,18 +3400,30 @@ func (*MissionSetCurrent) Crc() uint8 {
 // Pack returns a packed byte array which represents a MissionSetCurrent payload
 func (m *MissionSetCurrent) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.SEQ)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
+	if err := binary.Write(data, binary.LittleEndian, m.SEQ); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the MissionSetCurrent
 func (m *MissionSetCurrent) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.SEQ)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
+	if err := binary.Read(data, binary.LittleEndian, &m.SEQ); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE MISSION_CURRENT
@@ -2711,14 +3462,18 @@ func (*MissionCurrent) Crc() uint8 {
 // Pack returns a packed byte array which represents a MissionCurrent payload
 func (m *MissionCurrent) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.SEQ)
+	if err := binary.Write(data, binary.LittleEndian, m.SEQ); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the MissionCurrent
 func (m *MissionCurrent) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.SEQ)
+	if err := binary.Read(data, binary.LittleEndian, &m.SEQ); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE MISSION_REQUEST_LIST
@@ -2759,16 +3514,24 @@ func (*MissionRequestList) Crc() uint8 {
 // Pack returns a packed byte array which represents a MissionRequestList payload
 func (m *MissionRequestList) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the MissionRequestList
 func (m *MissionRequestList) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE MISSION_COUNT
@@ -2811,18 +3574,30 @@ func (*MissionCount) Crc() uint8 {
 // Pack returns a packed byte array which represents a MissionCount payload
 func (m *MissionCount) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.COUNT)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
+	if err := binary.Write(data, binary.LittleEndian, m.COUNT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the MissionCount
 func (m *MissionCount) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.COUNT)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
+	if err := binary.Read(data, binary.LittleEndian, &m.COUNT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE MISSION_CLEAR_ALL
@@ -2863,16 +3638,24 @@ func (*MissionClearAll) Crc() uint8 {
 // Pack returns a packed byte array which represents a MissionClearAll payload
 func (m *MissionClearAll) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the MissionClearAll
 func (m *MissionClearAll) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE MISSION_ITEM_REACHED
@@ -2911,14 +3694,18 @@ func (*MissionItemReached) Crc() uint8 {
 // Pack returns a packed byte array which represents a MissionItemReached payload
 func (m *MissionItemReached) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.SEQ)
+	if err := binary.Write(data, binary.LittleEndian, m.SEQ); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the MissionItemReached
 func (m *MissionItemReached) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.SEQ)
+	if err := binary.Read(data, binary.LittleEndian, &m.SEQ); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE MISSION_ACK
@@ -2961,18 +3748,30 @@ func (*MissionAck) Crc() uint8 {
 // Pack returns a packed byte array which represents a MissionAck payload
 func (m *MissionAck) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
-	binary.Write(data, binary.LittleEndian, m.TYPE)
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TYPE); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the MissionAck
 func (m *MissionAck) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
-	binary.Read(data, binary.LittleEndian, &m.TYPE)
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TYPE); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE SET_GPS_GLOBAL_ORIGIN
@@ -3017,20 +3816,36 @@ func (*SetGpsGlobalOrigin) Crc() uint8 {
 // Pack returns a packed byte array which represents a SetGpsGlobalOrigin payload
 func (m *SetGpsGlobalOrigin) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.LATITUDE)
-	binary.Write(data, binary.LittleEndian, m.LONGITUDE)
-	binary.Write(data, binary.LittleEndian, m.ALTITUDE)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
+	if err := binary.Write(data, binary.LittleEndian, m.LATITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LONGITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ALTITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the SetGpsGlobalOrigin
 func (m *SetGpsGlobalOrigin) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.LATITUDE)
-	binary.Read(data, binary.LittleEndian, &m.LONGITUDE)
-	binary.Read(data, binary.LittleEndian, &m.ALTITUDE)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
+	if err := binary.Read(data, binary.LittleEndian, &m.LATITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LONGITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ALTITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE GPS_GLOBAL_ORIGIN
@@ -3073,18 +3888,30 @@ func (*GpsGlobalOrigin) Crc() uint8 {
 // Pack returns a packed byte array which represents a GpsGlobalOrigin payload
 func (m *GpsGlobalOrigin) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.LATITUDE)
-	binary.Write(data, binary.LittleEndian, m.LONGITUDE)
-	binary.Write(data, binary.LittleEndian, m.ALTITUDE)
+	if err := binary.Write(data, binary.LittleEndian, m.LATITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LONGITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ALTITUDE); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the GpsGlobalOrigin
 func (m *GpsGlobalOrigin) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.LATITUDE)
-	binary.Read(data, binary.LittleEndian, &m.LONGITUDE)
-	binary.Read(data, binary.LittleEndian, &m.ALTITUDE)
+	if err := binary.Read(data, binary.LittleEndian, &m.LATITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LONGITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ALTITUDE); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE SET_LOCAL_POSITION_SETPOINT
@@ -3135,26 +3962,54 @@ func (*SetLocalPositionSetpoint) Crc() uint8 {
 // Pack returns a packed byte array which represents a SetLocalPositionSetpoint payload
 func (m *SetLocalPositionSetpoint) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.X)
-	binary.Write(data, binary.LittleEndian, m.Y)
-	binary.Write(data, binary.LittleEndian, m.Z)
-	binary.Write(data, binary.LittleEndian, m.YAW)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
-	binary.Write(data, binary.LittleEndian, m.COORDINATE_FRAME)
+	if err := binary.Write(data, binary.LittleEndian, m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.COORDINATE_FRAME); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the SetLocalPositionSetpoint
 func (m *SetLocalPositionSetpoint) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.X)
-	binary.Read(data, binary.LittleEndian, &m.Y)
-	binary.Read(data, binary.LittleEndian, &m.Z)
-	binary.Read(data, binary.LittleEndian, &m.YAW)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
-	binary.Read(data, binary.LittleEndian, &m.COORDINATE_FRAME)
+	if err := binary.Read(data, binary.LittleEndian, &m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.COORDINATE_FRAME); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE LOCAL_POSITION_SETPOINT
@@ -3201,22 +4056,42 @@ func (*LocalPositionSetpoint) Crc() uint8 {
 // Pack returns a packed byte array which represents a LocalPositionSetpoint payload
 func (m *LocalPositionSetpoint) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.X)
-	binary.Write(data, binary.LittleEndian, m.Y)
-	binary.Write(data, binary.LittleEndian, m.Z)
-	binary.Write(data, binary.LittleEndian, m.YAW)
-	binary.Write(data, binary.LittleEndian, m.COORDINATE_FRAME)
+	if err := binary.Write(data, binary.LittleEndian, m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.COORDINATE_FRAME); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the LocalPositionSetpoint
 func (m *LocalPositionSetpoint) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.X)
-	binary.Read(data, binary.LittleEndian, &m.Y)
-	binary.Read(data, binary.LittleEndian, &m.Z)
-	binary.Read(data, binary.LittleEndian, &m.YAW)
-	binary.Read(data, binary.LittleEndian, &m.COORDINATE_FRAME)
+	if err := binary.Read(data, binary.LittleEndian, &m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.COORDINATE_FRAME); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE GLOBAL_POSITION_SETPOINT_INT
@@ -3263,22 +4138,42 @@ func (*GlobalPositionSetpointInt) Crc() uint8 {
 // Pack returns a packed byte array which represents a GlobalPositionSetpointInt payload
 func (m *GlobalPositionSetpointInt) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.LATITUDE)
-	binary.Write(data, binary.LittleEndian, m.LONGITUDE)
-	binary.Write(data, binary.LittleEndian, m.ALTITUDE)
-	binary.Write(data, binary.LittleEndian, m.YAW)
-	binary.Write(data, binary.LittleEndian, m.COORDINATE_FRAME)
+	if err := binary.Write(data, binary.LittleEndian, m.LATITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LONGITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ALTITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.COORDINATE_FRAME); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the GlobalPositionSetpointInt
 func (m *GlobalPositionSetpointInt) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.LATITUDE)
-	binary.Read(data, binary.LittleEndian, &m.LONGITUDE)
-	binary.Read(data, binary.LittleEndian, &m.ALTITUDE)
-	binary.Read(data, binary.LittleEndian, &m.YAW)
-	binary.Read(data, binary.LittleEndian, &m.COORDINATE_FRAME)
+	if err := binary.Read(data, binary.LittleEndian, &m.LATITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LONGITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ALTITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.COORDINATE_FRAME); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE SET_GLOBAL_POSITION_SETPOINT_INT
@@ -3325,22 +4220,42 @@ func (*SetGlobalPositionSetpointInt) Crc() uint8 {
 // Pack returns a packed byte array which represents a SetGlobalPositionSetpointInt payload
 func (m *SetGlobalPositionSetpointInt) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.LATITUDE)
-	binary.Write(data, binary.LittleEndian, m.LONGITUDE)
-	binary.Write(data, binary.LittleEndian, m.ALTITUDE)
-	binary.Write(data, binary.LittleEndian, m.YAW)
-	binary.Write(data, binary.LittleEndian, m.COORDINATE_FRAME)
+	if err := binary.Write(data, binary.LittleEndian, m.LATITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LONGITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ALTITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.COORDINATE_FRAME); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the SetGlobalPositionSetpointInt
 func (m *SetGlobalPositionSetpointInt) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.LATITUDE)
-	binary.Read(data, binary.LittleEndian, &m.LONGITUDE)
-	binary.Read(data, binary.LittleEndian, &m.ALTITUDE)
-	binary.Read(data, binary.LittleEndian, &m.YAW)
-	binary.Read(data, binary.LittleEndian, &m.COORDINATE_FRAME)
+	if err := binary.Read(data, binary.LittleEndian, &m.LATITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LONGITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ALTITUDE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.COORDINATE_FRAME); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE SAFETY_SET_ALLOWED_AREA
@@ -3395,30 +4310,66 @@ func (*SafetySetAllowedArea) Crc() uint8 {
 // Pack returns a packed byte array which represents a SafetySetAllowedArea payload
 func (m *SafetySetAllowedArea) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.P1X)
-	binary.Write(data, binary.LittleEndian, m.P1Y)
-	binary.Write(data, binary.LittleEndian, m.P1Z)
-	binary.Write(data, binary.LittleEndian, m.P2X)
-	binary.Write(data, binary.LittleEndian, m.P2Y)
-	binary.Write(data, binary.LittleEndian, m.P2Z)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
-	binary.Write(data, binary.LittleEndian, m.FRAME)
+	if err := binary.Write(data, binary.LittleEndian, m.P1X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.P1Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.P1Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.P2X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.P2Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.P2Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FRAME); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the SafetySetAllowedArea
 func (m *SafetySetAllowedArea) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.P1X)
-	binary.Read(data, binary.LittleEndian, &m.P1Y)
-	binary.Read(data, binary.LittleEndian, &m.P1Z)
-	binary.Read(data, binary.LittleEndian, &m.P2X)
-	binary.Read(data, binary.LittleEndian, &m.P2Y)
-	binary.Read(data, binary.LittleEndian, &m.P2Z)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
-	binary.Read(data, binary.LittleEndian, &m.FRAME)
+	if err := binary.Read(data, binary.LittleEndian, &m.P1X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.P1Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.P1Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.P2X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.P2Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.P2Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FRAME); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE SAFETY_ALLOWED_AREA
@@ -3469,26 +4420,54 @@ func (*SafetyAllowedArea) Crc() uint8 {
 // Pack returns a packed byte array which represents a SafetyAllowedArea payload
 func (m *SafetyAllowedArea) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.P1X)
-	binary.Write(data, binary.LittleEndian, m.P1Y)
-	binary.Write(data, binary.LittleEndian, m.P1Z)
-	binary.Write(data, binary.LittleEndian, m.P2X)
-	binary.Write(data, binary.LittleEndian, m.P2Y)
-	binary.Write(data, binary.LittleEndian, m.P2Z)
-	binary.Write(data, binary.LittleEndian, m.FRAME)
+	if err := binary.Write(data, binary.LittleEndian, m.P1X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.P1Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.P1Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.P2X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.P2Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.P2Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FRAME); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the SafetyAllowedArea
 func (m *SafetyAllowedArea) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.P1X)
-	binary.Read(data, binary.LittleEndian, &m.P1Y)
-	binary.Read(data, binary.LittleEndian, &m.P1Z)
-	binary.Read(data, binary.LittleEndian, &m.P2X)
-	binary.Read(data, binary.LittleEndian, &m.P2Y)
-	binary.Read(data, binary.LittleEndian, &m.P2Z)
-	binary.Read(data, binary.LittleEndian, &m.FRAME)
+	if err := binary.Read(data, binary.LittleEndian, &m.P1X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.P1Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.P1Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.P2X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.P2Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.P2Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FRAME); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE SET_ROLL_PITCH_YAW_THRUST
@@ -3537,24 +4516,48 @@ func (*SetRollPitchYawThrust) Crc() uint8 {
 // Pack returns a packed byte array which represents a SetRollPitchYawThrust payload
 func (m *SetRollPitchYawThrust) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.ROLL)
-	binary.Write(data, binary.LittleEndian, m.PITCH)
-	binary.Write(data, binary.LittleEndian, m.YAW)
-	binary.Write(data, binary.LittleEndian, m.THRUST)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
+	if err := binary.Write(data, binary.LittleEndian, m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.THRUST); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the SetRollPitchYawThrust
 func (m *SetRollPitchYawThrust) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.ROLL)
-	binary.Read(data, binary.LittleEndian, &m.PITCH)
-	binary.Read(data, binary.LittleEndian, &m.YAW)
-	binary.Read(data, binary.LittleEndian, &m.THRUST)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.THRUST); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE SET_ROLL_PITCH_YAW_SPEED_THRUST
@@ -3603,24 +4606,48 @@ func (*SetRollPitchYawSpeedThrust) Crc() uint8 {
 // Pack returns a packed byte array which represents a SetRollPitchYawSpeedThrust payload
 func (m *SetRollPitchYawSpeedThrust) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.ROLL_SPEED)
-	binary.Write(data, binary.LittleEndian, m.PITCH_SPEED)
-	binary.Write(data, binary.LittleEndian, m.YAW_SPEED)
-	binary.Write(data, binary.LittleEndian, m.THRUST)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
+	if err := binary.Write(data, binary.LittleEndian, m.ROLL_SPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCH_SPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW_SPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.THRUST); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the SetRollPitchYawSpeedThrust
 func (m *SetRollPitchYawSpeedThrust) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.ROLL_SPEED)
-	binary.Read(data, binary.LittleEndian, &m.PITCH_SPEED)
-	binary.Read(data, binary.LittleEndian, &m.YAW_SPEED)
-	binary.Read(data, binary.LittleEndian, &m.THRUST)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLL_SPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCH_SPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW_SPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.THRUST); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE ROLL_PITCH_YAW_THRUST_SETPOINT
@@ -3667,22 +4694,42 @@ func (*RollPitchYawThrustSetpoint) Crc() uint8 {
 // Pack returns a packed byte array which represents a RollPitchYawThrustSetpoint payload
 func (m *RollPitchYawThrustSetpoint) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.ROLL)
-	binary.Write(data, binary.LittleEndian, m.PITCH)
-	binary.Write(data, binary.LittleEndian, m.YAW)
-	binary.Write(data, binary.LittleEndian, m.THRUST)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.THRUST); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the RollPitchYawThrustSetpoint
 func (m *RollPitchYawThrustSetpoint) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.ROLL)
-	binary.Read(data, binary.LittleEndian, &m.PITCH)
-	binary.Read(data, binary.LittleEndian, &m.YAW)
-	binary.Read(data, binary.LittleEndian, &m.THRUST)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.THRUST); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE ROLL_PITCH_YAW_SPEED_THRUST_SETPOINT
@@ -3729,22 +4776,42 @@ func (*RollPitchYawSpeedThrustSetpoint) Crc() uint8 {
 // Pack returns a packed byte array which represents a RollPitchYawSpeedThrustSetpoint payload
 func (m *RollPitchYawSpeedThrustSetpoint) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.ROLL_SPEED)
-	binary.Write(data, binary.LittleEndian, m.PITCH_SPEED)
-	binary.Write(data, binary.LittleEndian, m.YAW_SPEED)
-	binary.Write(data, binary.LittleEndian, m.THRUST)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROLL_SPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCH_SPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW_SPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.THRUST); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the RollPitchYawSpeedThrustSetpoint
 func (m *RollPitchYawSpeedThrustSetpoint) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.ROLL_SPEED)
-	binary.Read(data, binary.LittleEndian, &m.PITCH_SPEED)
-	binary.Read(data, binary.LittleEndian, &m.YAW_SPEED)
-	binary.Read(data, binary.LittleEndian, &m.THRUST)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLL_SPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCH_SPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW_SPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.THRUST); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE SET_QUAD_MOTORS_SETPOINT
@@ -3791,22 +4858,42 @@ func (*SetQuadMotorsSetpoint) Crc() uint8 {
 // Pack returns a packed byte array which represents a SetQuadMotorsSetpoint payload
 func (m *SetQuadMotorsSetpoint) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.MOTOR_FRONT_NW)
-	binary.Write(data, binary.LittleEndian, m.MOTOR_RIGHT_NE)
-	binary.Write(data, binary.LittleEndian, m.MOTOR_BACK_SE)
-	binary.Write(data, binary.LittleEndian, m.MOTOR_LEFT_SW)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
+	if err := binary.Write(data, binary.LittleEndian, m.MOTOR_FRONT_NW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.MOTOR_RIGHT_NE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.MOTOR_BACK_SE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.MOTOR_LEFT_SW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the SetQuadMotorsSetpoint
 func (m *SetQuadMotorsSetpoint) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.MOTOR_FRONT_NW)
-	binary.Read(data, binary.LittleEndian, &m.MOTOR_RIGHT_NE)
-	binary.Read(data, binary.LittleEndian, &m.MOTOR_BACK_SE)
-	binary.Read(data, binary.LittleEndian, &m.MOTOR_LEFT_SW)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
+	if err := binary.Read(data, binary.LittleEndian, &m.MOTOR_FRONT_NW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.MOTOR_RIGHT_NE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.MOTOR_BACK_SE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.MOTOR_LEFT_SW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE SET_QUAD_SWARM_ROLL_PITCH_YAW_THRUST
@@ -3855,24 +4942,48 @@ func (*SetQuadSwarmRollPitchYawThrust) Crc() uint8 {
 // Pack returns a packed byte array which represents a SetQuadSwarmRollPitchYawThrust payload
 func (m *SetQuadSwarmRollPitchYawThrust) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.ROLL)
-	binary.Write(data, binary.LittleEndian, m.PITCH)
-	binary.Write(data, binary.LittleEndian, m.YAW)
-	binary.Write(data, binary.LittleEndian, m.THRUST)
-	binary.Write(data, binary.LittleEndian, m.GROUP)
-	binary.Write(data, binary.LittleEndian, m.MODE)
+	if err := binary.Write(data, binary.LittleEndian, m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.THRUST); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.GROUP); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.MODE); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the SetQuadSwarmRollPitchYawThrust
 func (m *SetQuadSwarmRollPitchYawThrust) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.ROLL)
-	binary.Read(data, binary.LittleEndian, &m.PITCH)
-	binary.Read(data, binary.LittleEndian, &m.YAW)
-	binary.Read(data, binary.LittleEndian, &m.THRUST)
-	binary.Read(data, binary.LittleEndian, &m.GROUP)
-	binary.Read(data, binary.LittleEndian, &m.MODE)
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.THRUST); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.GROUP); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.MODE); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -3932,28 +5043,60 @@ func (*NavControllerOutput) Crc() uint8 {
 // Pack returns a packed byte array which represents a NavControllerOutput payload
 func (m *NavControllerOutput) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.NAV_ROLL)
-	binary.Write(data, binary.LittleEndian, m.NAV_PITCH)
-	binary.Write(data, binary.LittleEndian, m.ALT_ERROR)
-	binary.Write(data, binary.LittleEndian, m.ASPD_ERROR)
-	binary.Write(data, binary.LittleEndian, m.XTRACK_ERROR)
-	binary.Write(data, binary.LittleEndian, m.NAV_BEARING)
-	binary.Write(data, binary.LittleEndian, m.TARGET_BEARING)
-	binary.Write(data, binary.LittleEndian, m.WP_DIST)
+	if err := binary.Write(data, binary.LittleEndian, m.NAV_ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.NAV_PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ALT_ERROR); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ASPD_ERROR); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XTRACK_ERROR); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.NAV_BEARING); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_BEARING); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.WP_DIST); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the NavControllerOutput
 func (m *NavControllerOutput) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.NAV_ROLL)
-	binary.Read(data, binary.LittleEndian, &m.NAV_PITCH)
-	binary.Read(data, binary.LittleEndian, &m.ALT_ERROR)
-	binary.Read(data, binary.LittleEndian, &m.ASPD_ERROR)
-	binary.Read(data, binary.LittleEndian, &m.XTRACK_ERROR)
-	binary.Read(data, binary.LittleEndian, &m.NAV_BEARING)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_BEARING)
-	binary.Read(data, binary.LittleEndian, &m.WP_DIST)
+	if err := binary.Read(data, binary.LittleEndian, &m.NAV_ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.NAV_PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ALT_ERROR); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ASPD_ERROR); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XTRACK_ERROR); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.NAV_BEARING); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_BEARING); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.WP_DIST); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE SET_QUAD_SWARM_LED_ROLL_PITCH_YAW_THRUST
@@ -4008,30 +5151,66 @@ func (*SetQuadSwarmLedRollPitchYawThrust) Crc() uint8 {
 // Pack returns a packed byte array which represents a SetQuadSwarmLedRollPitchYawThrust payload
 func (m *SetQuadSwarmLedRollPitchYawThrust) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.ROLL)
-	binary.Write(data, binary.LittleEndian, m.PITCH)
-	binary.Write(data, binary.LittleEndian, m.YAW)
-	binary.Write(data, binary.LittleEndian, m.THRUST)
-	binary.Write(data, binary.LittleEndian, m.GROUP)
-	binary.Write(data, binary.LittleEndian, m.MODE)
-	binary.Write(data, binary.LittleEndian, m.LED_RED)
-	binary.Write(data, binary.LittleEndian, m.LED_BLUE)
-	binary.Write(data, binary.LittleEndian, m.LED_GREEN)
+	if err := binary.Write(data, binary.LittleEndian, m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.THRUST); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.GROUP); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.MODE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LED_RED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LED_BLUE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LED_GREEN); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the SetQuadSwarmLedRollPitchYawThrust
 func (m *SetQuadSwarmLedRollPitchYawThrust) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.ROLL)
-	binary.Read(data, binary.LittleEndian, &m.PITCH)
-	binary.Read(data, binary.LittleEndian, &m.YAW)
-	binary.Read(data, binary.LittleEndian, &m.THRUST)
-	binary.Read(data, binary.LittleEndian, &m.GROUP)
-	binary.Read(data, binary.LittleEndian, &m.MODE)
-	binary.Read(data, binary.LittleEndian, &m.LED_RED)
-	binary.Read(data, binary.LittleEndian, &m.LED_BLUE)
-	binary.Read(data, binary.LittleEndian, &m.LED_GREEN)
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.THRUST); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.GROUP); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.MODE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LED_RED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LED_BLUE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LED_GREEN); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -4096,30 +5275,66 @@ func (*StateCorrection) Crc() uint8 {
 // Pack returns a packed byte array which represents a StateCorrection payload
 func (m *StateCorrection) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.XERR)
-	binary.Write(data, binary.LittleEndian, m.YERR)
-	binary.Write(data, binary.LittleEndian, m.ZERR)
-	binary.Write(data, binary.LittleEndian, m.ROLLERR)
-	binary.Write(data, binary.LittleEndian, m.PITCHERR)
-	binary.Write(data, binary.LittleEndian, m.YAWERR)
-	binary.Write(data, binary.LittleEndian, m.VXERR)
-	binary.Write(data, binary.LittleEndian, m.VYERR)
-	binary.Write(data, binary.LittleEndian, m.VZERR)
+	if err := binary.Write(data, binary.LittleEndian, m.XERR); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YERR); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZERR); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROLLERR); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCHERR); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAWERR); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VXERR); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VYERR); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VZERR); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the StateCorrection
 func (m *StateCorrection) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.XERR)
-	binary.Read(data, binary.LittleEndian, &m.YERR)
-	binary.Read(data, binary.LittleEndian, &m.ZERR)
-	binary.Read(data, binary.LittleEndian, &m.ROLLERR)
-	binary.Read(data, binary.LittleEndian, &m.PITCHERR)
-	binary.Read(data, binary.LittleEndian, &m.YAWERR)
-	binary.Read(data, binary.LittleEndian, &m.VXERR)
-	binary.Read(data, binary.LittleEndian, &m.VYERR)
-	binary.Read(data, binary.LittleEndian, &m.VZERR)
+	if err := binary.Read(data, binary.LittleEndian, &m.XERR); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YERR); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZERR); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLLERR); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCHERR); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAWERR); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VXERR); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VYERR); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VZERR); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE RC_CHANNELS
@@ -4198,54 +5413,138 @@ func (*RcChannels) Crc() uint8 {
 // Pack returns a packed byte array which represents a RcChannels payload
 func (m *RcChannels) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.CHAN1_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN2_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN3_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN4_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN5_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN6_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN7_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN8_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN9_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN10_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN11_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN12_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN13_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN14_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN15_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN16_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN17_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN18_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHANCOUNT)
-	binary.Write(data, binary.LittleEndian, m.RSSI)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN1_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN2_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN3_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN4_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN5_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN6_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN7_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN8_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN9_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN10_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN11_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN12_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN13_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN14_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN15_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN16_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN17_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN18_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHANCOUNT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.RSSI); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the RcChannels
 func (m *RcChannels) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.CHAN1_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN2_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN3_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN4_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN5_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN6_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN7_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN8_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN9_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN10_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN11_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN12_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN13_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN14_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN15_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN16_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN17_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN18_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHANCOUNT)
-	binary.Read(data, binary.LittleEndian, &m.RSSI)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN1_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN2_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN3_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN4_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN5_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN6_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN7_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN8_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN9_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN10_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN11_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN12_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN13_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN14_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN15_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN16_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN17_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN18_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHANCOUNT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.RSSI); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE REQUEST_DATA_STREAM
@@ -4292,22 +5591,42 @@ func (*RequestDataStream) Crc() uint8 {
 // Pack returns a packed byte array which represents a RequestDataStream payload
 func (m *RequestDataStream) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.REQ_MESSAGE_RATE)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
-	binary.Write(data, binary.LittleEndian, m.REQ_STREAM_ID)
-	binary.Write(data, binary.LittleEndian, m.START_STOP)
+	if err := binary.Write(data, binary.LittleEndian, m.REQ_MESSAGE_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.REQ_STREAM_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.START_STOP); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the RequestDataStream
 func (m *RequestDataStream) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.REQ_MESSAGE_RATE)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
-	binary.Read(data, binary.LittleEndian, &m.REQ_STREAM_ID)
-	binary.Read(data, binary.LittleEndian, &m.START_STOP)
+	if err := binary.Read(data, binary.LittleEndian, &m.REQ_MESSAGE_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.REQ_STREAM_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.START_STOP); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE DATA_STREAM
@@ -4350,18 +5669,30 @@ func (*DataStream) Crc() uint8 {
 // Pack returns a packed byte array which represents a DataStream payload
 func (m *DataStream) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.MESSAGE_RATE)
-	binary.Write(data, binary.LittleEndian, m.STREAM_ID)
-	binary.Write(data, binary.LittleEndian, m.ON_OFF)
+	if err := binary.Write(data, binary.LittleEndian, m.MESSAGE_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.STREAM_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ON_OFF); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the DataStream
 func (m *DataStream) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.MESSAGE_RATE)
-	binary.Read(data, binary.LittleEndian, &m.STREAM_ID)
-	binary.Read(data, binary.LittleEndian, &m.ON_OFF)
+	if err := binary.Read(data, binary.LittleEndian, &m.MESSAGE_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.STREAM_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ON_OFF); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE MANUAL_CONTROL
@@ -4410,24 +5741,48 @@ func (*ManualControl) Crc() uint8 {
 // Pack returns a packed byte array which represents a ManualControl payload
 func (m *ManualControl) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.X)
-	binary.Write(data, binary.LittleEndian, m.Y)
-	binary.Write(data, binary.LittleEndian, m.Z)
-	binary.Write(data, binary.LittleEndian, m.R)
-	binary.Write(data, binary.LittleEndian, m.BUTTONS)
-	binary.Write(data, binary.LittleEndian, m.TARGET)
+	if err := binary.Write(data, binary.LittleEndian, m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.R); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.BUTTONS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the ManualControl
 func (m *ManualControl) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.X)
-	binary.Read(data, binary.LittleEndian, &m.Y)
-	binary.Read(data, binary.LittleEndian, &m.Z)
-	binary.Read(data, binary.LittleEndian, &m.R)
-	binary.Read(data, binary.LittleEndian, &m.BUTTONS)
-	binary.Read(data, binary.LittleEndian, &m.TARGET)
+	if err := binary.Read(data, binary.LittleEndian, &m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.R); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.BUTTONS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE RC_CHANNELS_OVERRIDE
@@ -4484,32 +5839,72 @@ func (*RcChannelsOverride) Crc() uint8 {
 // Pack returns a packed byte array which represents a RcChannelsOverride payload
 func (m *RcChannelsOverride) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.CHAN1_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN2_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN3_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN4_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN5_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN6_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN7_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN8_RAW)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN1_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN2_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN3_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN4_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN5_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN6_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN7_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN8_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the RcChannelsOverride
 func (m *RcChannelsOverride) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.CHAN1_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN2_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN3_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN4_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN5_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN6_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN7_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN8_RAW)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN1_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN2_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN3_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN4_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN5_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN6_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN7_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN8_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE VFR_HUD
@@ -4558,24 +5953,48 @@ func (*VfrHud) Crc() uint8 {
 // Pack returns a packed byte array which represents a VfrHud payload
 func (m *VfrHud) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.AIRSPEED)
-	binary.Write(data, binary.LittleEndian, m.GROUNDSPEED)
-	binary.Write(data, binary.LittleEndian, m.ALT)
-	binary.Write(data, binary.LittleEndian, m.CLIMB)
-	binary.Write(data, binary.LittleEndian, m.HEADING)
-	binary.Write(data, binary.LittleEndian, m.THROTTLE)
+	if err := binary.Write(data, binary.LittleEndian, m.AIRSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.GROUNDSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CLIMB); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.HEADING); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.THROTTLE); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the VfrHud
 func (m *VfrHud) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.AIRSPEED)
-	binary.Read(data, binary.LittleEndian, &m.GROUNDSPEED)
-	binary.Read(data, binary.LittleEndian, &m.ALT)
-	binary.Read(data, binary.LittleEndian, &m.CLIMB)
-	binary.Read(data, binary.LittleEndian, &m.HEADING)
-	binary.Read(data, binary.LittleEndian, &m.THROTTLE)
+	if err := binary.Read(data, binary.LittleEndian, &m.AIRSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.GROUNDSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CLIMB); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.HEADING); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.THROTTLE); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE COMMAND_LONG
@@ -4634,34 +6053,78 @@ func (*CommandLong) Crc() uint8 {
 // Pack returns a packed byte array which represents a CommandLong payload
 func (m *CommandLong) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.PARAM1)
-	binary.Write(data, binary.LittleEndian, m.PARAM2)
-	binary.Write(data, binary.LittleEndian, m.PARAM3)
-	binary.Write(data, binary.LittleEndian, m.PARAM4)
-	binary.Write(data, binary.LittleEndian, m.PARAM5)
-	binary.Write(data, binary.LittleEndian, m.PARAM6)
-	binary.Write(data, binary.LittleEndian, m.PARAM7)
-	binary.Write(data, binary.LittleEndian, m.COMMAND)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
-	binary.Write(data, binary.LittleEndian, m.CONFIRMATION)
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM1); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM2); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM3); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM4); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM5); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM6); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PARAM7); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.COMMAND); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CONFIRMATION); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the CommandLong
 func (m *CommandLong) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.PARAM1)
-	binary.Read(data, binary.LittleEndian, &m.PARAM2)
-	binary.Read(data, binary.LittleEndian, &m.PARAM3)
-	binary.Read(data, binary.LittleEndian, &m.PARAM4)
-	binary.Read(data, binary.LittleEndian, &m.PARAM5)
-	binary.Read(data, binary.LittleEndian, &m.PARAM6)
-	binary.Read(data, binary.LittleEndian, &m.PARAM7)
-	binary.Read(data, binary.LittleEndian, &m.COMMAND)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
-	binary.Read(data, binary.LittleEndian, &m.CONFIRMATION)
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM1); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM2); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM3); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM4); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM5); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM6); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PARAM7); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.COMMAND); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CONFIRMATION); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE COMMAND_ACK
@@ -4702,16 +6165,24 @@ func (*CommandAck) Crc() uint8 {
 // Pack returns a packed byte array which represents a CommandAck payload
 func (m *CommandAck) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.COMMAND)
-	binary.Write(data, binary.LittleEndian, m.RESULT)
+	if err := binary.Write(data, binary.LittleEndian, m.COMMAND); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.RESULT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the CommandAck
 func (m *CommandAck) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.COMMAND)
-	binary.Read(data, binary.LittleEndian, &m.RESULT)
+	if err := binary.Read(data, binary.LittleEndian, &m.COMMAND); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.RESULT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE ROLL_PITCH_YAW_RATES_THRUST_SETPOINT
@@ -4758,22 +6229,42 @@ func (*RollPitchYawRatesThrustSetpoint) Crc() uint8 {
 // Pack returns a packed byte array which represents a RollPitchYawRatesThrustSetpoint payload
 func (m *RollPitchYawRatesThrustSetpoint) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.ROLL_RATE)
-	binary.Write(data, binary.LittleEndian, m.PITCH_RATE)
-	binary.Write(data, binary.LittleEndian, m.YAW_RATE)
-	binary.Write(data, binary.LittleEndian, m.THRUST)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROLL_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCH_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.THRUST); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the RollPitchYawRatesThrustSetpoint
 func (m *RollPitchYawRatesThrustSetpoint) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.ROLL_RATE)
-	binary.Read(data, binary.LittleEndian, &m.PITCH_RATE)
-	binary.Read(data, binary.LittleEndian, &m.YAW_RATE)
-	binary.Read(data, binary.LittleEndian, &m.THRUST)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLL_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCH_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.THRUST); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE MANUAL_SETPOINT
@@ -4824,26 +6315,54 @@ func (*ManualSetpoint) Crc() uint8 {
 // Pack returns a packed byte array which represents a ManualSetpoint payload
 func (m *ManualSetpoint) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.ROLL)
-	binary.Write(data, binary.LittleEndian, m.PITCH)
-	binary.Write(data, binary.LittleEndian, m.YAW)
-	binary.Write(data, binary.LittleEndian, m.THRUST)
-	binary.Write(data, binary.LittleEndian, m.MODE_SWITCH)
-	binary.Write(data, binary.LittleEndian, m.MANUAL_OVERRIDE_SWITCH)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.THRUST); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.MODE_SWITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.MANUAL_OVERRIDE_SWITCH); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the ManualSetpoint
 func (m *ManualSetpoint) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.ROLL)
-	binary.Read(data, binary.LittleEndian, &m.PITCH)
-	binary.Read(data, binary.LittleEndian, &m.YAW)
-	binary.Read(data, binary.LittleEndian, &m.THRUST)
-	binary.Read(data, binary.LittleEndian, &m.MODE_SWITCH)
-	binary.Read(data, binary.LittleEndian, &m.MANUAL_OVERRIDE_SWITCH)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.THRUST); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.MODE_SWITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.MANUAL_OVERRIDE_SWITCH); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE ATTITUDE_SETPOINT_EXTERNAL
@@ -4898,30 +6417,66 @@ func (*AttitudeSetpointExternal) Crc() uint8 {
 // Pack returns a packed byte array which represents a AttitudeSetpointExternal payload
 func (m *AttitudeSetpointExternal) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.Q)
-	binary.Write(data, binary.LittleEndian, m.BODY_ROLL_RATE)
-	binary.Write(data, binary.LittleEndian, m.BODY_PITCH_RATE)
-	binary.Write(data, binary.LittleEndian, m.BODY_YAW_RATE)
-	binary.Write(data, binary.LittleEndian, m.THRUST)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
-	binary.Write(data, binary.LittleEndian, m.TYPE_MASK)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Q); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.BODY_ROLL_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.BODY_PITCH_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.BODY_YAW_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.THRUST); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TYPE_MASK); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the AttitudeSetpointExternal
 func (m *AttitudeSetpointExternal) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.Q)
-	binary.Read(data, binary.LittleEndian, &m.BODY_ROLL_RATE)
-	binary.Read(data, binary.LittleEndian, &m.BODY_PITCH_RATE)
-	binary.Read(data, binary.LittleEndian, &m.BODY_YAW_RATE)
-	binary.Read(data, binary.LittleEndian, &m.THRUST)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
-	binary.Read(data, binary.LittleEndian, &m.TYPE_MASK)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Q); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.BODY_ROLL_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.BODY_PITCH_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.BODY_YAW_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.THRUST); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TYPE_MASK); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -4990,40 +6545,96 @@ func (*LocalNedPositionSetpointExternal) Crc() uint8 {
 // Pack returns a packed byte array which represents a LocalNedPositionSetpointExternal payload
 func (m *LocalNedPositionSetpointExternal) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.X)
-	binary.Write(data, binary.LittleEndian, m.Y)
-	binary.Write(data, binary.LittleEndian, m.Z)
-	binary.Write(data, binary.LittleEndian, m.VX)
-	binary.Write(data, binary.LittleEndian, m.VY)
-	binary.Write(data, binary.LittleEndian, m.VZ)
-	binary.Write(data, binary.LittleEndian, m.AFX)
-	binary.Write(data, binary.LittleEndian, m.AFY)
-	binary.Write(data, binary.LittleEndian, m.AFZ)
-	binary.Write(data, binary.LittleEndian, m.TYPE_MASK)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
-	binary.Write(data, binary.LittleEndian, m.COORDINATE_FRAME)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VX); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VY); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VZ); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.AFX); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.AFY); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.AFZ); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TYPE_MASK); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.COORDINATE_FRAME); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the LocalNedPositionSetpointExternal
 func (m *LocalNedPositionSetpointExternal) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.X)
-	binary.Read(data, binary.LittleEndian, &m.Y)
-	binary.Read(data, binary.LittleEndian, &m.Z)
-	binary.Read(data, binary.LittleEndian, &m.VX)
-	binary.Read(data, binary.LittleEndian, &m.VY)
-	binary.Read(data, binary.LittleEndian, &m.VZ)
-	binary.Read(data, binary.LittleEndian, &m.AFX)
-	binary.Read(data, binary.LittleEndian, &m.AFY)
-	binary.Read(data, binary.LittleEndian, &m.AFZ)
-	binary.Read(data, binary.LittleEndian, &m.TYPE_MASK)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
-	binary.Read(data, binary.LittleEndian, &m.COORDINATE_FRAME)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VX); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VY); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VZ); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.AFX); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.AFY); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.AFZ); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TYPE_MASK); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.COORDINATE_FRAME); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE GLOBAL_POSITION_SETPOINT_EXTERNAL_INT
@@ -5086,38 +6697,90 @@ func (*GlobalPositionSetpointExternalInt) Crc() uint8 {
 // Pack returns a packed byte array which represents a GlobalPositionSetpointExternalInt payload
 func (m *GlobalPositionSetpointExternalInt) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.LAT_INT)
-	binary.Write(data, binary.LittleEndian, m.LON_INT)
-	binary.Write(data, binary.LittleEndian, m.ALT)
-	binary.Write(data, binary.LittleEndian, m.VX)
-	binary.Write(data, binary.LittleEndian, m.VY)
-	binary.Write(data, binary.LittleEndian, m.VZ)
-	binary.Write(data, binary.LittleEndian, m.AFX)
-	binary.Write(data, binary.LittleEndian, m.AFY)
-	binary.Write(data, binary.LittleEndian, m.AFZ)
-	binary.Write(data, binary.LittleEndian, m.TYPE_MASK)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LAT_INT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LON_INT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VX); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VY); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VZ); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.AFX); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.AFY); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.AFZ); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TYPE_MASK); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the GlobalPositionSetpointExternalInt
 func (m *GlobalPositionSetpointExternalInt) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.LAT_INT)
-	binary.Read(data, binary.LittleEndian, &m.LON_INT)
-	binary.Read(data, binary.LittleEndian, &m.ALT)
-	binary.Read(data, binary.LittleEndian, &m.VX)
-	binary.Read(data, binary.LittleEndian, &m.VY)
-	binary.Read(data, binary.LittleEndian, &m.VZ)
-	binary.Read(data, binary.LittleEndian, &m.AFX)
-	binary.Read(data, binary.LittleEndian, &m.AFY)
-	binary.Read(data, binary.LittleEndian, &m.AFZ)
-	binary.Read(data, binary.LittleEndian, &m.TYPE_MASK)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LAT_INT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LON_INT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VX); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VY); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VZ); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.AFX); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.AFY); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.AFZ); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TYPE_MASK); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE LOCAL_POSITION_NED_SYSTEM_GLOBAL_OFFSET
@@ -5168,26 +6831,54 @@ func (*LocalPositionNedSystemGlobalOffset) Crc() uint8 {
 // Pack returns a packed byte array which represents a LocalPositionNedSystemGlobalOffset payload
 func (m *LocalPositionNedSystemGlobalOffset) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.X)
-	binary.Write(data, binary.LittleEndian, m.Y)
-	binary.Write(data, binary.LittleEndian, m.Z)
-	binary.Write(data, binary.LittleEndian, m.ROLL)
-	binary.Write(data, binary.LittleEndian, m.PITCH)
-	binary.Write(data, binary.LittleEndian, m.YAW)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the LocalPositionNedSystemGlobalOffset
 func (m *LocalPositionNedSystemGlobalOffset) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.X)
-	binary.Read(data, binary.LittleEndian, &m.Y)
-	binary.Read(data, binary.LittleEndian, &m.Z)
-	binary.Read(data, binary.LittleEndian, &m.ROLL)
-	binary.Read(data, binary.LittleEndian, &m.PITCH)
-	binary.Read(data, binary.LittleEndian, &m.YAW)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE HIL_STATE
@@ -5256,44 +6947,108 @@ func (*HilState) Crc() uint8 {
 // Pack returns a packed byte array which represents a HilState payload
 func (m *HilState) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_USEC)
-	binary.Write(data, binary.LittleEndian, m.ROLL)
-	binary.Write(data, binary.LittleEndian, m.PITCH)
-	binary.Write(data, binary.LittleEndian, m.YAW)
-	binary.Write(data, binary.LittleEndian, m.ROLLSPEED)
-	binary.Write(data, binary.LittleEndian, m.PITCHSPEED)
-	binary.Write(data, binary.LittleEndian, m.YAWSPEED)
-	binary.Write(data, binary.LittleEndian, m.LAT)
-	binary.Write(data, binary.LittleEndian, m.LON)
-	binary.Write(data, binary.LittleEndian, m.ALT)
-	binary.Write(data, binary.LittleEndian, m.VX)
-	binary.Write(data, binary.LittleEndian, m.VY)
-	binary.Write(data, binary.LittleEndian, m.VZ)
-	binary.Write(data, binary.LittleEndian, m.XACC)
-	binary.Write(data, binary.LittleEndian, m.YACC)
-	binary.Write(data, binary.LittleEndian, m.ZACC)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROLLSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCHSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAWSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VX); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VY); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VZ); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZACC); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the HilState
 func (m *HilState) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_USEC)
-	binary.Read(data, binary.LittleEndian, &m.ROLL)
-	binary.Read(data, binary.LittleEndian, &m.PITCH)
-	binary.Read(data, binary.LittleEndian, &m.YAW)
-	binary.Read(data, binary.LittleEndian, &m.ROLLSPEED)
-	binary.Read(data, binary.LittleEndian, &m.PITCHSPEED)
-	binary.Read(data, binary.LittleEndian, &m.YAWSPEED)
-	binary.Read(data, binary.LittleEndian, &m.LAT)
-	binary.Read(data, binary.LittleEndian, &m.LON)
-	binary.Read(data, binary.LittleEndian, &m.ALT)
-	binary.Read(data, binary.LittleEndian, &m.VX)
-	binary.Read(data, binary.LittleEndian, &m.VY)
-	binary.Read(data, binary.LittleEndian, &m.VZ)
-	binary.Read(data, binary.LittleEndian, &m.XACC)
-	binary.Read(data, binary.LittleEndian, &m.YACC)
-	binary.Read(data, binary.LittleEndian, &m.ZACC)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLLSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCHSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAWSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VX); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VY); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VZ); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZACC); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE HIL_CONTROLS
@@ -5352,34 +7107,78 @@ func (*HilControls) Crc() uint8 {
 // Pack returns a packed byte array which represents a HilControls payload
 func (m *HilControls) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_USEC)
-	binary.Write(data, binary.LittleEndian, m.ROLL_AILERONS)
-	binary.Write(data, binary.LittleEndian, m.PITCH_ELEVATOR)
-	binary.Write(data, binary.LittleEndian, m.YAW_RUDDER)
-	binary.Write(data, binary.LittleEndian, m.THROTTLE)
-	binary.Write(data, binary.LittleEndian, m.AUX1)
-	binary.Write(data, binary.LittleEndian, m.AUX2)
-	binary.Write(data, binary.LittleEndian, m.AUX3)
-	binary.Write(data, binary.LittleEndian, m.AUX4)
-	binary.Write(data, binary.LittleEndian, m.MODE)
-	binary.Write(data, binary.LittleEndian, m.NAV_MODE)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROLL_AILERONS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCH_ELEVATOR); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW_RUDDER); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.THROTTLE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.AUX1); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.AUX2); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.AUX3); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.AUX4); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.MODE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.NAV_MODE); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the HilControls
 func (m *HilControls) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_USEC)
-	binary.Read(data, binary.LittleEndian, &m.ROLL_AILERONS)
-	binary.Read(data, binary.LittleEndian, &m.PITCH_ELEVATOR)
-	binary.Read(data, binary.LittleEndian, &m.YAW_RUDDER)
-	binary.Read(data, binary.LittleEndian, &m.THROTTLE)
-	binary.Read(data, binary.LittleEndian, &m.AUX1)
-	binary.Read(data, binary.LittleEndian, &m.AUX2)
-	binary.Read(data, binary.LittleEndian, &m.AUX3)
-	binary.Read(data, binary.LittleEndian, &m.AUX4)
-	binary.Read(data, binary.LittleEndian, &m.MODE)
-	binary.Read(data, binary.LittleEndian, &m.NAV_MODE)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLL_AILERONS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCH_ELEVATOR); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW_RUDDER); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.THROTTLE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.AUX1); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.AUX2); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.AUX3); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.AUX4); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.MODE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.NAV_MODE); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE HIL_RC_INPUTS_RAW
@@ -5444,40 +7243,96 @@ func (*HilRcInputsRaw) Crc() uint8 {
 // Pack returns a packed byte array which represents a HilRcInputsRaw payload
 func (m *HilRcInputsRaw) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_USEC)
-	binary.Write(data, binary.LittleEndian, m.CHAN1_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN2_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN3_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN4_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN5_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN6_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN7_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN8_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN9_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN10_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN11_RAW)
-	binary.Write(data, binary.LittleEndian, m.CHAN12_RAW)
-	binary.Write(data, binary.LittleEndian, m.RSSI)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN1_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN2_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN3_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN4_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN5_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN6_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN7_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN8_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN9_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN10_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN11_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CHAN12_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.RSSI); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the HilRcInputsRaw
 func (m *HilRcInputsRaw) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_USEC)
-	binary.Read(data, binary.LittleEndian, &m.CHAN1_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN2_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN3_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN4_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN5_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN6_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN7_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN8_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN9_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN10_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN11_RAW)
-	binary.Read(data, binary.LittleEndian, &m.CHAN12_RAW)
-	binary.Read(data, binary.LittleEndian, &m.RSSI)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN1_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN2_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN3_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN4_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN5_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN6_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN7_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN8_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN9_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN10_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN11_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CHAN12_RAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.RSSI); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE OPTICAL_FLOW
@@ -5530,28 +7385,60 @@ func (*OpticalFlow) Crc() uint8 {
 // Pack returns a packed byte array which represents a OpticalFlow payload
 func (m *OpticalFlow) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_USEC)
-	binary.Write(data, binary.LittleEndian, m.FLOW_COMP_M_X)
-	binary.Write(data, binary.LittleEndian, m.FLOW_COMP_M_Y)
-	binary.Write(data, binary.LittleEndian, m.GROUND_DISTANCE)
-	binary.Write(data, binary.LittleEndian, m.FLOW_X)
-	binary.Write(data, binary.LittleEndian, m.FLOW_Y)
-	binary.Write(data, binary.LittleEndian, m.SENSOR_ID)
-	binary.Write(data, binary.LittleEndian, m.QUALITY)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FLOW_COMP_M_X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FLOW_COMP_M_Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.GROUND_DISTANCE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FLOW_X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FLOW_Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SENSOR_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.QUALITY); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the OpticalFlow
 func (m *OpticalFlow) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_USEC)
-	binary.Read(data, binary.LittleEndian, &m.FLOW_COMP_M_X)
-	binary.Read(data, binary.LittleEndian, &m.FLOW_COMP_M_Y)
-	binary.Read(data, binary.LittleEndian, &m.GROUND_DISTANCE)
-	binary.Read(data, binary.LittleEndian, &m.FLOW_X)
-	binary.Read(data, binary.LittleEndian, &m.FLOW_Y)
-	binary.Read(data, binary.LittleEndian, &m.SENSOR_ID)
-	binary.Read(data, binary.LittleEndian, &m.QUALITY)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FLOW_COMP_M_X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FLOW_COMP_M_Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.GROUND_DISTANCE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FLOW_X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FLOW_Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SENSOR_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.QUALITY); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE GLOBAL_VISION_POSITION_ESTIMATE
@@ -5602,26 +7489,54 @@ func (*GlobalVisionPositionEstimate) Crc() uint8 {
 // Pack returns a packed byte array which represents a GlobalVisionPositionEstimate payload
 func (m *GlobalVisionPositionEstimate) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.USEC)
-	binary.Write(data, binary.LittleEndian, m.X)
-	binary.Write(data, binary.LittleEndian, m.Y)
-	binary.Write(data, binary.LittleEndian, m.Z)
-	binary.Write(data, binary.LittleEndian, m.ROLL)
-	binary.Write(data, binary.LittleEndian, m.PITCH)
-	binary.Write(data, binary.LittleEndian, m.YAW)
+	if err := binary.Write(data, binary.LittleEndian, m.USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the GlobalVisionPositionEstimate
 func (m *GlobalVisionPositionEstimate) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.USEC)
-	binary.Read(data, binary.LittleEndian, &m.X)
-	binary.Read(data, binary.LittleEndian, &m.Y)
-	binary.Read(data, binary.LittleEndian, &m.Z)
-	binary.Read(data, binary.LittleEndian, &m.ROLL)
-	binary.Read(data, binary.LittleEndian, &m.PITCH)
-	binary.Read(data, binary.LittleEndian, &m.YAW)
+	if err := binary.Read(data, binary.LittleEndian, &m.USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE VISION_POSITION_ESTIMATE
@@ -5672,26 +7587,54 @@ func (*VisionPositionEstimate) Crc() uint8 {
 // Pack returns a packed byte array which represents a VisionPositionEstimate payload
 func (m *VisionPositionEstimate) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.USEC)
-	binary.Write(data, binary.LittleEndian, m.X)
-	binary.Write(data, binary.LittleEndian, m.Y)
-	binary.Write(data, binary.LittleEndian, m.Z)
-	binary.Write(data, binary.LittleEndian, m.ROLL)
-	binary.Write(data, binary.LittleEndian, m.PITCH)
-	binary.Write(data, binary.LittleEndian, m.YAW)
+	if err := binary.Write(data, binary.LittleEndian, m.USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the VisionPositionEstimate
 func (m *VisionPositionEstimate) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.USEC)
-	binary.Read(data, binary.LittleEndian, &m.X)
-	binary.Read(data, binary.LittleEndian, &m.Y)
-	binary.Read(data, binary.LittleEndian, &m.Z)
-	binary.Read(data, binary.LittleEndian, &m.ROLL)
-	binary.Read(data, binary.LittleEndian, &m.PITCH)
-	binary.Read(data, binary.LittleEndian, &m.YAW)
+	if err := binary.Read(data, binary.LittleEndian, &m.USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE VISION_SPEED_ESTIMATE
@@ -5736,20 +7679,36 @@ func (*VisionSpeedEstimate) Crc() uint8 {
 // Pack returns a packed byte array which represents a VisionSpeedEstimate payload
 func (m *VisionSpeedEstimate) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.USEC)
-	binary.Write(data, binary.LittleEndian, m.X)
-	binary.Write(data, binary.LittleEndian, m.Y)
-	binary.Write(data, binary.LittleEndian, m.Z)
+	if err := binary.Write(data, binary.LittleEndian, m.USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Z); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the VisionSpeedEstimate
 func (m *VisionSpeedEstimate) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.USEC)
-	binary.Read(data, binary.LittleEndian, &m.X)
-	binary.Read(data, binary.LittleEndian, &m.Y)
-	binary.Read(data, binary.LittleEndian, &m.Z)
+	if err := binary.Read(data, binary.LittleEndian, &m.USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Z); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE VICON_POSITION_ESTIMATE
@@ -5800,26 +7759,54 @@ func (*ViconPositionEstimate) Crc() uint8 {
 // Pack returns a packed byte array which represents a ViconPositionEstimate payload
 func (m *ViconPositionEstimate) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.USEC)
-	binary.Write(data, binary.LittleEndian, m.X)
-	binary.Write(data, binary.LittleEndian, m.Y)
-	binary.Write(data, binary.LittleEndian, m.Z)
-	binary.Write(data, binary.LittleEndian, m.ROLL)
-	binary.Write(data, binary.LittleEndian, m.PITCH)
-	binary.Write(data, binary.LittleEndian, m.YAW)
+	if err := binary.Write(data, binary.LittleEndian, m.USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the ViconPositionEstimate
 func (m *ViconPositionEstimate) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.USEC)
-	binary.Read(data, binary.LittleEndian, &m.X)
-	binary.Read(data, binary.LittleEndian, &m.Y)
-	binary.Read(data, binary.LittleEndian, &m.Z)
-	binary.Read(data, binary.LittleEndian, &m.ROLL)
-	binary.Read(data, binary.LittleEndian, &m.PITCH)
-	binary.Read(data, binary.LittleEndian, &m.YAW)
+	if err := binary.Read(data, binary.LittleEndian, &m.USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE HIGHRES_IMU
@@ -5886,42 +7873,102 @@ func (*HighresImu) Crc() uint8 {
 // Pack returns a packed byte array which represents a HighresImu payload
 func (m *HighresImu) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_USEC)
-	binary.Write(data, binary.LittleEndian, m.XACC)
-	binary.Write(data, binary.LittleEndian, m.YACC)
-	binary.Write(data, binary.LittleEndian, m.ZACC)
-	binary.Write(data, binary.LittleEndian, m.XGYRO)
-	binary.Write(data, binary.LittleEndian, m.YGYRO)
-	binary.Write(data, binary.LittleEndian, m.ZGYRO)
-	binary.Write(data, binary.LittleEndian, m.XMAG)
-	binary.Write(data, binary.LittleEndian, m.YMAG)
-	binary.Write(data, binary.LittleEndian, m.ZMAG)
-	binary.Write(data, binary.LittleEndian, m.ABS_PRESSURE)
-	binary.Write(data, binary.LittleEndian, m.DIFF_PRESSURE)
-	binary.Write(data, binary.LittleEndian, m.PRESSURE_ALT)
-	binary.Write(data, binary.LittleEndian, m.TEMPERATURE)
-	binary.Write(data, binary.LittleEndian, m.FIELDS_UPDATED)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ABS_PRESSURE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.DIFF_PRESSURE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PRESSURE_ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TEMPERATURE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FIELDS_UPDATED); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the HighresImu
 func (m *HighresImu) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_USEC)
-	binary.Read(data, binary.LittleEndian, &m.XACC)
-	binary.Read(data, binary.LittleEndian, &m.YACC)
-	binary.Read(data, binary.LittleEndian, &m.ZACC)
-	binary.Read(data, binary.LittleEndian, &m.XGYRO)
-	binary.Read(data, binary.LittleEndian, &m.YGYRO)
-	binary.Read(data, binary.LittleEndian, &m.ZGYRO)
-	binary.Read(data, binary.LittleEndian, &m.XMAG)
-	binary.Read(data, binary.LittleEndian, &m.YMAG)
-	binary.Read(data, binary.LittleEndian, &m.ZMAG)
-	binary.Read(data, binary.LittleEndian, &m.ABS_PRESSURE)
-	binary.Read(data, binary.LittleEndian, &m.DIFF_PRESSURE)
-	binary.Read(data, binary.LittleEndian, &m.PRESSURE_ALT)
-	binary.Read(data, binary.LittleEndian, &m.TEMPERATURE)
-	binary.Read(data, binary.LittleEndian, &m.FIELDS_UPDATED)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ABS_PRESSURE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.DIFF_PRESSURE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PRESSURE_ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TEMPERATURE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FIELDS_UPDATED); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE OMNIDIRECTIONAL_FLOW
@@ -5970,24 +8017,48 @@ func (*OmnidirectionalFlow) Crc() uint8 {
 // Pack returns a packed byte array which represents a OmnidirectionalFlow payload
 func (m *OmnidirectionalFlow) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_USEC)
-	binary.Write(data, binary.LittleEndian, m.FRONT_DISTANCE_M)
-	binary.Write(data, binary.LittleEndian, m.LEFT)
-	binary.Write(data, binary.LittleEndian, m.RIGHT)
-	binary.Write(data, binary.LittleEndian, m.SENSOR_ID)
-	binary.Write(data, binary.LittleEndian, m.QUALITY)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FRONT_DISTANCE_M); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LEFT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.RIGHT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SENSOR_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.QUALITY); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the OmnidirectionalFlow
 func (m *OmnidirectionalFlow) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_USEC)
-	binary.Read(data, binary.LittleEndian, &m.FRONT_DISTANCE_M)
-	binary.Read(data, binary.LittleEndian, &m.LEFT)
-	binary.Read(data, binary.LittleEndian, &m.RIGHT)
-	binary.Read(data, binary.LittleEndian, &m.SENSOR_ID)
-	binary.Read(data, binary.LittleEndian, &m.QUALITY)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FRONT_DISTANCE_M); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LEFT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.RIGHT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SENSOR_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.QUALITY); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -6059,42 +8130,102 @@ func (*HilSensor) Crc() uint8 {
 // Pack returns a packed byte array which represents a HilSensor payload
 func (m *HilSensor) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_USEC)
-	binary.Write(data, binary.LittleEndian, m.XACC)
-	binary.Write(data, binary.LittleEndian, m.YACC)
-	binary.Write(data, binary.LittleEndian, m.ZACC)
-	binary.Write(data, binary.LittleEndian, m.XGYRO)
-	binary.Write(data, binary.LittleEndian, m.YGYRO)
-	binary.Write(data, binary.LittleEndian, m.ZGYRO)
-	binary.Write(data, binary.LittleEndian, m.XMAG)
-	binary.Write(data, binary.LittleEndian, m.YMAG)
-	binary.Write(data, binary.LittleEndian, m.ZMAG)
-	binary.Write(data, binary.LittleEndian, m.ABS_PRESSURE)
-	binary.Write(data, binary.LittleEndian, m.DIFF_PRESSURE)
-	binary.Write(data, binary.LittleEndian, m.PRESSURE_ALT)
-	binary.Write(data, binary.LittleEndian, m.TEMPERATURE)
-	binary.Write(data, binary.LittleEndian, m.FIELDS_UPDATED)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ABS_PRESSURE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.DIFF_PRESSURE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PRESSURE_ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TEMPERATURE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FIELDS_UPDATED); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the HilSensor
 func (m *HilSensor) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_USEC)
-	binary.Read(data, binary.LittleEndian, &m.XACC)
-	binary.Read(data, binary.LittleEndian, &m.YACC)
-	binary.Read(data, binary.LittleEndian, &m.ZACC)
-	binary.Read(data, binary.LittleEndian, &m.XGYRO)
-	binary.Read(data, binary.LittleEndian, &m.YGYRO)
-	binary.Read(data, binary.LittleEndian, &m.ZGYRO)
-	binary.Read(data, binary.LittleEndian, &m.XMAG)
-	binary.Read(data, binary.LittleEndian, &m.YMAG)
-	binary.Read(data, binary.LittleEndian, &m.ZMAG)
-	binary.Read(data, binary.LittleEndian, &m.ABS_PRESSURE)
-	binary.Read(data, binary.LittleEndian, &m.DIFF_PRESSURE)
-	binary.Read(data, binary.LittleEndian, &m.PRESSURE_ALT)
-	binary.Read(data, binary.LittleEndian, &m.TEMPERATURE)
-	binary.Read(data, binary.LittleEndian, &m.FIELDS_UPDATED)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ABS_PRESSURE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.DIFF_PRESSURE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PRESSURE_ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TEMPERATURE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FIELDS_UPDATED); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE SIM_STATE
@@ -6173,54 +8304,138 @@ func (*SimState) Crc() uint8 {
 // Pack returns a packed byte array which represents a SimState payload
 func (m *SimState) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.Q1)
-	binary.Write(data, binary.LittleEndian, m.Q2)
-	binary.Write(data, binary.LittleEndian, m.Q3)
-	binary.Write(data, binary.LittleEndian, m.Q4)
-	binary.Write(data, binary.LittleEndian, m.ROLL)
-	binary.Write(data, binary.LittleEndian, m.PITCH)
-	binary.Write(data, binary.LittleEndian, m.YAW)
-	binary.Write(data, binary.LittleEndian, m.XACC)
-	binary.Write(data, binary.LittleEndian, m.YACC)
-	binary.Write(data, binary.LittleEndian, m.ZACC)
-	binary.Write(data, binary.LittleEndian, m.XGYRO)
-	binary.Write(data, binary.LittleEndian, m.YGYRO)
-	binary.Write(data, binary.LittleEndian, m.ZGYRO)
-	binary.Write(data, binary.LittleEndian, m.LAT)
-	binary.Write(data, binary.LittleEndian, m.LON)
-	binary.Write(data, binary.LittleEndian, m.ALT)
-	binary.Write(data, binary.LittleEndian, m.STD_DEV_HORZ)
-	binary.Write(data, binary.LittleEndian, m.STD_DEV_VERT)
-	binary.Write(data, binary.LittleEndian, m.VN)
-	binary.Write(data, binary.LittleEndian, m.VE)
-	binary.Write(data, binary.LittleEndian, m.VD)
+	if err := binary.Write(data, binary.LittleEndian, m.Q1); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Q2); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Q3); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Q4); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.STD_DEV_HORZ); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.STD_DEV_VERT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VN); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VD); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the SimState
 func (m *SimState) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.Q1)
-	binary.Read(data, binary.LittleEndian, &m.Q2)
-	binary.Read(data, binary.LittleEndian, &m.Q3)
-	binary.Read(data, binary.LittleEndian, &m.Q4)
-	binary.Read(data, binary.LittleEndian, &m.ROLL)
-	binary.Read(data, binary.LittleEndian, &m.PITCH)
-	binary.Read(data, binary.LittleEndian, &m.YAW)
-	binary.Read(data, binary.LittleEndian, &m.XACC)
-	binary.Read(data, binary.LittleEndian, &m.YACC)
-	binary.Read(data, binary.LittleEndian, &m.ZACC)
-	binary.Read(data, binary.LittleEndian, &m.XGYRO)
-	binary.Read(data, binary.LittleEndian, &m.YGYRO)
-	binary.Read(data, binary.LittleEndian, &m.ZGYRO)
-	binary.Read(data, binary.LittleEndian, &m.LAT)
-	binary.Read(data, binary.LittleEndian, &m.LON)
-	binary.Read(data, binary.LittleEndian, &m.ALT)
-	binary.Read(data, binary.LittleEndian, &m.STD_DEV_HORZ)
-	binary.Read(data, binary.LittleEndian, &m.STD_DEV_VERT)
-	binary.Read(data, binary.LittleEndian, &m.VN)
-	binary.Read(data, binary.LittleEndian, &m.VE)
-	binary.Read(data, binary.LittleEndian, &m.VD)
+	if err := binary.Read(data, binary.LittleEndian, &m.Q1); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Q2); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Q3); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Q4); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLL); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.STD_DEV_HORZ); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.STD_DEV_VERT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VN); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VD); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE RADIO_STATUS
@@ -6271,26 +8486,54 @@ func (*RadioStatus) Crc() uint8 {
 // Pack returns a packed byte array which represents a RadioStatus payload
 func (m *RadioStatus) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.RXERRORS)
-	binary.Write(data, binary.LittleEndian, m.FIXED)
-	binary.Write(data, binary.LittleEndian, m.RSSI)
-	binary.Write(data, binary.LittleEndian, m.REMRSSI)
-	binary.Write(data, binary.LittleEndian, m.TXBUF)
-	binary.Write(data, binary.LittleEndian, m.NOISE)
-	binary.Write(data, binary.LittleEndian, m.REMNOISE)
+	if err := binary.Write(data, binary.LittleEndian, m.RXERRORS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FIXED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.RSSI); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.REMRSSI); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TXBUF); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.NOISE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.REMNOISE); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the RadioStatus
 func (m *RadioStatus) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.RXERRORS)
-	binary.Read(data, binary.LittleEndian, &m.FIXED)
-	binary.Read(data, binary.LittleEndian, &m.RSSI)
-	binary.Read(data, binary.LittleEndian, &m.REMRSSI)
-	binary.Read(data, binary.LittleEndian, &m.TXBUF)
-	binary.Read(data, binary.LittleEndian, &m.NOISE)
-	binary.Read(data, binary.LittleEndian, &m.REMNOISE)
+	if err := binary.Read(data, binary.LittleEndian, &m.RXERRORS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FIXED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.RSSI); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.REMRSSI); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TXBUF); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.NOISE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.REMNOISE); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE FILE_TRANSFER_START
@@ -6337,22 +8580,42 @@ func (*FileTransferStart) Crc() uint8 {
 // Pack returns a packed byte array which represents a FileTransferStart payload
 func (m *FileTransferStart) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TRANSFER_UID)
-	binary.Write(data, binary.LittleEndian, m.FILE_SIZE)
-	binary.Write(data, binary.LittleEndian, m.DEST_PATH)
-	binary.Write(data, binary.LittleEndian, m.DIRECTION)
-	binary.Write(data, binary.LittleEndian, m.FLAGS)
+	if err := binary.Write(data, binary.LittleEndian, m.TRANSFER_UID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FILE_SIZE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.DEST_PATH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.DIRECTION); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FLAGS); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the FileTransferStart
 func (m *FileTransferStart) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TRANSFER_UID)
-	binary.Read(data, binary.LittleEndian, &m.FILE_SIZE)
-	binary.Read(data, binary.LittleEndian, &m.DEST_PATH)
-	binary.Read(data, binary.LittleEndian, &m.DIRECTION)
-	binary.Read(data, binary.LittleEndian, &m.FLAGS)
+	if err := binary.Read(data, binary.LittleEndian, &m.TRANSFER_UID); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FILE_SIZE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.DEST_PATH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.DIRECTION); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FLAGS); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -6399,18 +8662,30 @@ func (*FileTransferDirList) Crc() uint8 {
 // Pack returns a packed byte array which represents a FileTransferDirList payload
 func (m *FileTransferDirList) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TRANSFER_UID)
-	binary.Write(data, binary.LittleEndian, m.DIR_PATH)
-	binary.Write(data, binary.LittleEndian, m.FLAGS)
+	if err := binary.Write(data, binary.LittleEndian, m.TRANSFER_UID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.DIR_PATH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FLAGS); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the FileTransferDirList
 func (m *FileTransferDirList) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TRANSFER_UID)
-	binary.Read(data, binary.LittleEndian, &m.DIR_PATH)
-	binary.Read(data, binary.LittleEndian, &m.FLAGS)
+	if err := binary.Read(data, binary.LittleEndian, &m.TRANSFER_UID); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.DIR_PATH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FLAGS); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -6455,16 +8730,24 @@ func (*FileTransferRes) Crc() uint8 {
 // Pack returns a packed byte array which represents a FileTransferRes payload
 func (m *FileTransferRes) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TRANSFER_UID)
-	binary.Write(data, binary.LittleEndian, m.RESULT)
+	if err := binary.Write(data, binary.LittleEndian, m.TRANSFER_UID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.RESULT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the FileTransferRes
 func (m *FileTransferRes) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TRANSFER_UID)
-	binary.Read(data, binary.LittleEndian, &m.RESULT)
+	if err := binary.Read(data, binary.LittleEndian, &m.TRANSFER_UID); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.RESULT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE HIL_GPS
@@ -6527,38 +8810,90 @@ func (*HilGps) Crc() uint8 {
 // Pack returns a packed byte array which represents a HilGps payload
 func (m *HilGps) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_USEC)
-	binary.Write(data, binary.LittleEndian, m.LAT)
-	binary.Write(data, binary.LittleEndian, m.LON)
-	binary.Write(data, binary.LittleEndian, m.ALT)
-	binary.Write(data, binary.LittleEndian, m.EPH)
-	binary.Write(data, binary.LittleEndian, m.EPV)
-	binary.Write(data, binary.LittleEndian, m.VEL)
-	binary.Write(data, binary.LittleEndian, m.VN)
-	binary.Write(data, binary.LittleEndian, m.VE)
-	binary.Write(data, binary.LittleEndian, m.VD)
-	binary.Write(data, binary.LittleEndian, m.COG)
-	binary.Write(data, binary.LittleEndian, m.FIX_TYPE)
-	binary.Write(data, binary.LittleEndian, m.SATELLITES_VISIBLE)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.EPH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.EPV); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VEL); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VN); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VD); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.COG); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FIX_TYPE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SATELLITES_VISIBLE); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the HilGps
 func (m *HilGps) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_USEC)
-	binary.Read(data, binary.LittleEndian, &m.LAT)
-	binary.Read(data, binary.LittleEndian, &m.LON)
-	binary.Read(data, binary.LittleEndian, &m.ALT)
-	binary.Read(data, binary.LittleEndian, &m.EPH)
-	binary.Read(data, binary.LittleEndian, &m.EPV)
-	binary.Read(data, binary.LittleEndian, &m.VEL)
-	binary.Read(data, binary.LittleEndian, &m.VN)
-	binary.Read(data, binary.LittleEndian, &m.VE)
-	binary.Read(data, binary.LittleEndian, &m.VD)
-	binary.Read(data, binary.LittleEndian, &m.COG)
-	binary.Read(data, binary.LittleEndian, &m.FIX_TYPE)
-	binary.Read(data, binary.LittleEndian, &m.SATELLITES_VISIBLE)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.EPH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.EPV); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VEL); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VN); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VD); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.COG); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FIX_TYPE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SATELLITES_VISIBLE); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE HIL_OPTICAL_FLOW
@@ -6611,28 +8946,60 @@ func (*HilOpticalFlow) Crc() uint8 {
 // Pack returns a packed byte array which represents a HilOpticalFlow payload
 func (m *HilOpticalFlow) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_USEC)
-	binary.Write(data, binary.LittleEndian, m.FLOW_COMP_M_X)
-	binary.Write(data, binary.LittleEndian, m.FLOW_COMP_M_Y)
-	binary.Write(data, binary.LittleEndian, m.GROUND_DISTANCE)
-	binary.Write(data, binary.LittleEndian, m.FLOW_X)
-	binary.Write(data, binary.LittleEndian, m.FLOW_Y)
-	binary.Write(data, binary.LittleEndian, m.SENSOR_ID)
-	binary.Write(data, binary.LittleEndian, m.QUALITY)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FLOW_COMP_M_X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FLOW_COMP_M_Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.GROUND_DISTANCE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FLOW_X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FLOW_Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SENSOR_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.QUALITY); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the HilOpticalFlow
 func (m *HilOpticalFlow) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_USEC)
-	binary.Read(data, binary.LittleEndian, &m.FLOW_COMP_M_X)
-	binary.Read(data, binary.LittleEndian, &m.FLOW_COMP_M_Y)
-	binary.Read(data, binary.LittleEndian, &m.GROUND_DISTANCE)
-	binary.Read(data, binary.LittleEndian, &m.FLOW_X)
-	binary.Read(data, binary.LittleEndian, &m.FLOW_Y)
-	binary.Read(data, binary.LittleEndian, &m.SENSOR_ID)
-	binary.Read(data, binary.LittleEndian, &m.QUALITY)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FLOW_COMP_M_X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FLOW_COMP_M_Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.GROUND_DISTANCE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FLOW_X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FLOW_Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SENSOR_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.QUALITY); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE HIL_STATE_QUATERNION
@@ -6701,44 +9068,108 @@ func (*HilStateQuaternion) Crc() uint8 {
 // Pack returns a packed byte array which represents a HilStateQuaternion payload
 func (m *HilStateQuaternion) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_USEC)
-	binary.Write(data, binary.LittleEndian, m.ATTITUDE_QUATERNION)
-	binary.Write(data, binary.LittleEndian, m.ROLLSPEED)
-	binary.Write(data, binary.LittleEndian, m.PITCHSPEED)
-	binary.Write(data, binary.LittleEndian, m.YAWSPEED)
-	binary.Write(data, binary.LittleEndian, m.LAT)
-	binary.Write(data, binary.LittleEndian, m.LON)
-	binary.Write(data, binary.LittleEndian, m.ALT)
-	binary.Write(data, binary.LittleEndian, m.VX)
-	binary.Write(data, binary.LittleEndian, m.VY)
-	binary.Write(data, binary.LittleEndian, m.VZ)
-	binary.Write(data, binary.LittleEndian, m.IND_AIRSPEED)
-	binary.Write(data, binary.LittleEndian, m.TRUE_AIRSPEED)
-	binary.Write(data, binary.LittleEndian, m.XACC)
-	binary.Write(data, binary.LittleEndian, m.YACC)
-	binary.Write(data, binary.LittleEndian, m.ZACC)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ATTITUDE_QUATERNION); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROLLSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PITCHSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YAWSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VX); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VY); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VZ); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.IND_AIRSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TRUE_AIRSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZACC); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the HilStateQuaternion
 func (m *HilStateQuaternion) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_USEC)
-	binary.Read(data, binary.LittleEndian, &m.ATTITUDE_QUATERNION)
-	binary.Read(data, binary.LittleEndian, &m.ROLLSPEED)
-	binary.Read(data, binary.LittleEndian, &m.PITCHSPEED)
-	binary.Read(data, binary.LittleEndian, &m.YAWSPEED)
-	binary.Read(data, binary.LittleEndian, &m.LAT)
-	binary.Read(data, binary.LittleEndian, &m.LON)
-	binary.Read(data, binary.LittleEndian, &m.ALT)
-	binary.Read(data, binary.LittleEndian, &m.VX)
-	binary.Read(data, binary.LittleEndian, &m.VY)
-	binary.Read(data, binary.LittleEndian, &m.VZ)
-	binary.Read(data, binary.LittleEndian, &m.IND_AIRSPEED)
-	binary.Read(data, binary.LittleEndian, &m.TRUE_AIRSPEED)
-	binary.Read(data, binary.LittleEndian, &m.XACC)
-	binary.Read(data, binary.LittleEndian, &m.YACC)
-	binary.Read(data, binary.LittleEndian, &m.ZACC)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ATTITUDE_QUATERNION); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROLLSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PITCHSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YAWSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VX); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VY); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VZ); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.IND_AIRSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TRUE_AIRSPEED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZACC); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -6799,32 +9230,72 @@ func (*ScaledImu2) Crc() uint8 {
 // Pack returns a packed byte array which represents a ScaledImu2 payload
 func (m *ScaledImu2) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.XACC)
-	binary.Write(data, binary.LittleEndian, m.YACC)
-	binary.Write(data, binary.LittleEndian, m.ZACC)
-	binary.Write(data, binary.LittleEndian, m.XGYRO)
-	binary.Write(data, binary.LittleEndian, m.YGYRO)
-	binary.Write(data, binary.LittleEndian, m.ZGYRO)
-	binary.Write(data, binary.LittleEndian, m.XMAG)
-	binary.Write(data, binary.LittleEndian, m.YMAG)
-	binary.Write(data, binary.LittleEndian, m.ZMAG)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.XMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.YMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ZMAG); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the ScaledImu2
 func (m *ScaledImu2) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.XACC)
-	binary.Read(data, binary.LittleEndian, &m.YACC)
-	binary.Read(data, binary.LittleEndian, &m.ZACC)
-	binary.Read(data, binary.LittleEndian, &m.XGYRO)
-	binary.Read(data, binary.LittleEndian, &m.YGYRO)
-	binary.Read(data, binary.LittleEndian, &m.ZGYRO)
-	binary.Read(data, binary.LittleEndian, &m.XMAG)
-	binary.Read(data, binary.LittleEndian, &m.YMAG)
-	binary.Read(data, binary.LittleEndian, &m.ZMAG)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZACC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZGYRO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.XMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.YMAG); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ZMAG); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE LOG_REQUEST_LIST
@@ -6869,20 +9340,36 @@ func (*LogRequestList) Crc() uint8 {
 // Pack returns a packed byte array which represents a LogRequestList payload
 func (m *LogRequestList) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.START)
-	binary.Write(data, binary.LittleEndian, m.END)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
+	if err := binary.Write(data, binary.LittleEndian, m.START); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.END); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the LogRequestList
 func (m *LogRequestList) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.START)
-	binary.Read(data, binary.LittleEndian, &m.END)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
+	if err := binary.Read(data, binary.LittleEndian, &m.START); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.END); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE LOG_ENTRY
@@ -6929,22 +9416,42 @@ func (*LogEntry) Crc() uint8 {
 // Pack returns a packed byte array which represents a LogEntry payload
 func (m *LogEntry) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_UTC)
-	binary.Write(data, binary.LittleEndian, m.SIZE)
-	binary.Write(data, binary.LittleEndian, m.ID)
-	binary.Write(data, binary.LittleEndian, m.NUM_LOGS)
-	binary.Write(data, binary.LittleEndian, m.LAST_LOG_NUM)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_UTC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SIZE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.NUM_LOGS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LAST_LOG_NUM); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the LogEntry
 func (m *LogEntry) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_UTC)
-	binary.Read(data, binary.LittleEndian, &m.SIZE)
-	binary.Read(data, binary.LittleEndian, &m.ID)
-	binary.Read(data, binary.LittleEndian, &m.NUM_LOGS)
-	binary.Read(data, binary.LittleEndian, &m.LAST_LOG_NUM)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_UTC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SIZE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.NUM_LOGS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LAST_LOG_NUM); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE LOG_REQUEST_DATA
@@ -6991,22 +9498,42 @@ func (*LogRequestData) Crc() uint8 {
 // Pack returns a packed byte array which represents a LogRequestData payload
 func (m *LogRequestData) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.OFS)
-	binary.Write(data, binary.LittleEndian, m.COUNT)
-	binary.Write(data, binary.LittleEndian, m.ID)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
+	if err := binary.Write(data, binary.LittleEndian, m.OFS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.COUNT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the LogRequestData
 func (m *LogRequestData) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.OFS)
-	binary.Read(data, binary.LittleEndian, &m.COUNT)
-	binary.Read(data, binary.LittleEndian, &m.ID)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
+	if err := binary.Read(data, binary.LittleEndian, &m.OFS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.COUNT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE LOG_DATA
@@ -7051,20 +9578,36 @@ func (*LogData) Crc() uint8 {
 // Pack returns a packed byte array which represents a LogData payload
 func (m *LogData) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.OFS)
-	binary.Write(data, binary.LittleEndian, m.ID)
-	binary.Write(data, binary.LittleEndian, m.COUNT)
-	binary.Write(data, binary.LittleEndian, m.DATA)
+	if err := binary.Write(data, binary.LittleEndian, m.OFS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.COUNT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.DATA); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the LogData
 func (m *LogData) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.OFS)
-	binary.Read(data, binary.LittleEndian, &m.ID)
-	binary.Read(data, binary.LittleEndian, &m.COUNT)
-	binary.Read(data, binary.LittleEndian, &m.DATA)
+	if err := binary.Read(data, binary.LittleEndian, &m.OFS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.COUNT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.DATA); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -7109,16 +9652,24 @@ func (*LogErase) Crc() uint8 {
 // Pack returns a packed byte array which represents a LogErase payload
 func (m *LogErase) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the LogErase
 func (m *LogErase) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE LOG_REQUEST_END
@@ -7159,16 +9710,24 @@ func (*LogRequestEnd) Crc() uint8 {
 // Pack returns a packed byte array which represents a LogRequestEnd payload
 func (m *LogRequestEnd) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the LogRequestEnd
 func (m *LogRequestEnd) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE GPS_INJECT_DATA
@@ -7213,20 +9772,36 @@ func (*GpsInjectData) Crc() uint8 {
 // Pack returns a packed byte array which represents a GpsInjectData payload
 func (m *GpsInjectData) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
-	binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT)
-	binary.Write(data, binary.LittleEndian, m.LEN)
-	binary.Write(data, binary.LittleEndian, m.DATA)
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LEN); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.DATA); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the GpsInjectData
 func (m *GpsInjectData) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT)
-	binary.Read(data, binary.LittleEndian, &m.LEN)
-	binary.Read(data, binary.LittleEndian, &m.DATA)
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_COMPONENT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LEN); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.DATA); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -7291,36 +9866,84 @@ func (*Gps2Raw) Crc() uint8 {
 // Pack returns a packed byte array which represents a Gps2Raw payload
 func (m *Gps2Raw) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_USEC)
-	binary.Write(data, binary.LittleEndian, m.LAT)
-	binary.Write(data, binary.LittleEndian, m.LON)
-	binary.Write(data, binary.LittleEndian, m.ALT)
-	binary.Write(data, binary.LittleEndian, m.DGPS_AGE)
-	binary.Write(data, binary.LittleEndian, m.EPH)
-	binary.Write(data, binary.LittleEndian, m.EPV)
-	binary.Write(data, binary.LittleEndian, m.VEL)
-	binary.Write(data, binary.LittleEndian, m.COG)
-	binary.Write(data, binary.LittleEndian, m.FIX_TYPE)
-	binary.Write(data, binary.LittleEndian, m.SATELLITES_VISIBLE)
-	binary.Write(data, binary.LittleEndian, m.DGPS_NUMCH)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.DGPS_AGE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.EPH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.EPV); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VEL); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.COG); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FIX_TYPE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SATELLITES_VISIBLE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.DGPS_NUMCH); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the Gps2Raw
 func (m *Gps2Raw) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_USEC)
-	binary.Read(data, binary.LittleEndian, &m.LAT)
-	binary.Read(data, binary.LittleEndian, &m.LON)
-	binary.Read(data, binary.LittleEndian, &m.ALT)
-	binary.Read(data, binary.LittleEndian, &m.DGPS_AGE)
-	binary.Read(data, binary.LittleEndian, &m.EPH)
-	binary.Read(data, binary.LittleEndian, &m.EPV)
-	binary.Read(data, binary.LittleEndian, &m.VEL)
-	binary.Read(data, binary.LittleEndian, &m.COG)
-	binary.Read(data, binary.LittleEndian, &m.FIX_TYPE)
-	binary.Read(data, binary.LittleEndian, &m.SATELLITES_VISIBLE)
-	binary.Read(data, binary.LittleEndian, &m.DGPS_NUMCH)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ALT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.DGPS_AGE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.EPH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.EPV); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VEL); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.COG); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FIX_TYPE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SATELLITES_VISIBLE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.DGPS_NUMCH); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE POWER_STATUS
@@ -7363,18 +9986,30 @@ func (*PowerStatus) Crc() uint8 {
 // Pack returns a packed byte array which represents a PowerStatus payload
 func (m *PowerStatus) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.VCC)
-	binary.Write(data, binary.LittleEndian, m.VSERVO)
-	binary.Write(data, binary.LittleEndian, m.FLAGS)
+	if err := binary.Write(data, binary.LittleEndian, m.VCC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VSERVO); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FLAGS); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the PowerStatus
 func (m *PowerStatus) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.VCC)
-	binary.Read(data, binary.LittleEndian, &m.VSERVO)
-	binary.Read(data, binary.LittleEndian, &m.FLAGS)
+	if err := binary.Read(data, binary.LittleEndian, &m.VCC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VSERVO); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FLAGS); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE SERIAL_CONTROL
@@ -7423,24 +10058,48 @@ func (*SerialControl) Crc() uint8 {
 // Pack returns a packed byte array which represents a SerialControl payload
 func (m *SerialControl) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.BAUDRATE)
-	binary.Write(data, binary.LittleEndian, m.TIMEOUT)
-	binary.Write(data, binary.LittleEndian, m.DEVICE)
-	binary.Write(data, binary.LittleEndian, m.FLAGS)
-	binary.Write(data, binary.LittleEndian, m.COUNT)
-	binary.Write(data, binary.LittleEndian, m.DATA)
+	if err := binary.Write(data, binary.LittleEndian, m.BAUDRATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TIMEOUT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.DEVICE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.FLAGS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.COUNT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.DATA); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the SerialControl
 func (m *SerialControl) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.BAUDRATE)
-	binary.Read(data, binary.LittleEndian, &m.TIMEOUT)
-	binary.Read(data, binary.LittleEndian, &m.DEVICE)
-	binary.Read(data, binary.LittleEndian, &m.FLAGS)
-	binary.Read(data, binary.LittleEndian, &m.COUNT)
-	binary.Read(data, binary.LittleEndian, &m.DATA)
+	if err := binary.Read(data, binary.LittleEndian, &m.BAUDRATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TIMEOUT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.DEVICE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.FLAGS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.COUNT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.DATA); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -7507,38 +10166,90 @@ func (*GpsRtk) Crc() uint8 {
 // Pack returns a packed byte array which represents a GpsRtk payload
 func (m *GpsRtk) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_LAST_BASELINE_MS)
-	binary.Write(data, binary.LittleEndian, m.TOW)
-	binary.Write(data, binary.LittleEndian, m.BASELINE_A_MM)
-	binary.Write(data, binary.LittleEndian, m.BASELINE_B_MM)
-	binary.Write(data, binary.LittleEndian, m.BASELINE_C_MM)
-	binary.Write(data, binary.LittleEndian, m.ACCURACY)
-	binary.Write(data, binary.LittleEndian, m.IAR_NUM_HYPOTHESES)
-	binary.Write(data, binary.LittleEndian, m.WN)
-	binary.Write(data, binary.LittleEndian, m.RTK_RECEIVER_ID)
-	binary.Write(data, binary.LittleEndian, m.RTK_HEALTH)
-	binary.Write(data, binary.LittleEndian, m.RTK_RATE)
-	binary.Write(data, binary.LittleEndian, m.NSATS)
-	binary.Write(data, binary.LittleEndian, m.BASELINE_COORDS_TYPE)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_LAST_BASELINE_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TOW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.BASELINE_A_MM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.BASELINE_B_MM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.BASELINE_C_MM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ACCURACY); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.IAR_NUM_HYPOTHESES); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.WN); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.RTK_RECEIVER_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.RTK_HEALTH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.RTK_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.NSATS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.BASELINE_COORDS_TYPE); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the GpsRtk
 func (m *GpsRtk) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_LAST_BASELINE_MS)
-	binary.Read(data, binary.LittleEndian, &m.TOW)
-	binary.Read(data, binary.LittleEndian, &m.BASELINE_A_MM)
-	binary.Read(data, binary.LittleEndian, &m.BASELINE_B_MM)
-	binary.Read(data, binary.LittleEndian, &m.BASELINE_C_MM)
-	binary.Read(data, binary.LittleEndian, &m.ACCURACY)
-	binary.Read(data, binary.LittleEndian, &m.IAR_NUM_HYPOTHESES)
-	binary.Read(data, binary.LittleEndian, &m.WN)
-	binary.Read(data, binary.LittleEndian, &m.RTK_RECEIVER_ID)
-	binary.Read(data, binary.LittleEndian, &m.RTK_HEALTH)
-	binary.Read(data, binary.LittleEndian, &m.RTK_RATE)
-	binary.Read(data, binary.LittleEndian, &m.NSATS)
-	binary.Read(data, binary.LittleEndian, &m.BASELINE_COORDS_TYPE)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_LAST_BASELINE_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TOW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.BASELINE_A_MM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.BASELINE_B_MM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.BASELINE_C_MM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ACCURACY); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.IAR_NUM_HYPOTHESES); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.WN); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.RTK_RECEIVER_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.RTK_HEALTH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.RTK_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.NSATS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.BASELINE_COORDS_TYPE); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE GPS2_RTK
@@ -7601,38 +10312,90 @@ func (*Gps2Rtk) Crc() uint8 {
 // Pack returns a packed byte array which represents a Gps2Rtk payload
 func (m *Gps2Rtk) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_LAST_BASELINE_MS)
-	binary.Write(data, binary.LittleEndian, m.TOW)
-	binary.Write(data, binary.LittleEndian, m.BASELINE_A_MM)
-	binary.Write(data, binary.LittleEndian, m.BASELINE_B_MM)
-	binary.Write(data, binary.LittleEndian, m.BASELINE_C_MM)
-	binary.Write(data, binary.LittleEndian, m.ACCURACY)
-	binary.Write(data, binary.LittleEndian, m.IAR_NUM_HYPOTHESES)
-	binary.Write(data, binary.LittleEndian, m.WN)
-	binary.Write(data, binary.LittleEndian, m.RTK_RECEIVER_ID)
-	binary.Write(data, binary.LittleEndian, m.RTK_HEALTH)
-	binary.Write(data, binary.LittleEndian, m.RTK_RATE)
-	binary.Write(data, binary.LittleEndian, m.NSATS)
-	binary.Write(data, binary.LittleEndian, m.BASELINE_COORDS_TYPE)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_LAST_BASELINE_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TOW); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.BASELINE_A_MM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.BASELINE_B_MM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.BASELINE_C_MM); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ACCURACY); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.IAR_NUM_HYPOTHESES); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.WN); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.RTK_RECEIVER_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.RTK_HEALTH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.RTK_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.NSATS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.BASELINE_COORDS_TYPE); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the Gps2Rtk
 func (m *Gps2Rtk) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_LAST_BASELINE_MS)
-	binary.Read(data, binary.LittleEndian, &m.TOW)
-	binary.Read(data, binary.LittleEndian, &m.BASELINE_A_MM)
-	binary.Read(data, binary.LittleEndian, &m.BASELINE_B_MM)
-	binary.Read(data, binary.LittleEndian, &m.BASELINE_C_MM)
-	binary.Read(data, binary.LittleEndian, &m.ACCURACY)
-	binary.Read(data, binary.LittleEndian, &m.IAR_NUM_HYPOTHESES)
-	binary.Read(data, binary.LittleEndian, &m.WN)
-	binary.Read(data, binary.LittleEndian, &m.RTK_RECEIVER_ID)
-	binary.Read(data, binary.LittleEndian, &m.RTK_HEALTH)
-	binary.Read(data, binary.LittleEndian, &m.RTK_RATE)
-	binary.Read(data, binary.LittleEndian, &m.NSATS)
-	binary.Read(data, binary.LittleEndian, &m.BASELINE_COORDS_TYPE)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_LAST_BASELINE_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TOW); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.BASELINE_A_MM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.BASELINE_B_MM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.BASELINE_C_MM); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ACCURACY); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.IAR_NUM_HYPOTHESES); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.WN); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.RTK_RECEIVER_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.RTK_HEALTH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.RTK_RATE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.NSATS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.BASELINE_COORDS_TYPE); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE DATA_TRANSMISSION_HANDSHAKE
@@ -7683,26 +10446,54 @@ func (*DataTransmissionHandshake) Crc() uint8 {
 // Pack returns a packed byte array which represents a DataTransmissionHandshake payload
 func (m *DataTransmissionHandshake) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.SIZE)
-	binary.Write(data, binary.LittleEndian, m.WIDTH)
-	binary.Write(data, binary.LittleEndian, m.HEIGHT)
-	binary.Write(data, binary.LittleEndian, m.PACKETS)
-	binary.Write(data, binary.LittleEndian, m.TYPE)
-	binary.Write(data, binary.LittleEndian, m.PAYLOAD)
-	binary.Write(data, binary.LittleEndian, m.JPG_QUALITY)
+	if err := binary.Write(data, binary.LittleEndian, m.SIZE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.WIDTH); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.HEIGHT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PACKETS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TYPE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PAYLOAD); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.JPG_QUALITY); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the DataTransmissionHandshake
 func (m *DataTransmissionHandshake) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.SIZE)
-	binary.Read(data, binary.LittleEndian, &m.WIDTH)
-	binary.Read(data, binary.LittleEndian, &m.HEIGHT)
-	binary.Read(data, binary.LittleEndian, &m.PACKETS)
-	binary.Read(data, binary.LittleEndian, &m.TYPE)
-	binary.Read(data, binary.LittleEndian, &m.PAYLOAD)
-	binary.Read(data, binary.LittleEndian, &m.JPG_QUALITY)
+	if err := binary.Read(data, binary.LittleEndian, &m.SIZE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.WIDTH); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.HEIGHT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PACKETS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TYPE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PAYLOAD); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.JPG_QUALITY); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE ENCAPSULATED_DATA
@@ -7743,16 +10534,24 @@ func (*EncapsulatedData) Crc() uint8 {
 // Pack returns a packed byte array which represents a EncapsulatedData payload
 func (m *EncapsulatedData) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.SEQNR)
-	binary.Write(data, binary.LittleEndian, m.DATA)
+	if err := binary.Write(data, binary.LittleEndian, m.SEQNR); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.DATA); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the EncapsulatedData
 func (m *EncapsulatedData) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.SEQNR)
-	binary.Read(data, binary.LittleEndian, &m.DATA)
+	if err := binary.Read(data, binary.LittleEndian, &m.SEQNR); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.DATA); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -7809,28 +10608,60 @@ func (*DistanceSensor) Crc() uint8 {
 // Pack returns a packed byte array which represents a DistanceSensor payload
 func (m *DistanceSensor) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.MIN_DISTANCE)
-	binary.Write(data, binary.LittleEndian, m.MAX_DISTANCE)
-	binary.Write(data, binary.LittleEndian, m.CURRENT_DISTANCE)
-	binary.Write(data, binary.LittleEndian, m.TYPE)
-	binary.Write(data, binary.LittleEndian, m.ID)
-	binary.Write(data, binary.LittleEndian, m.ORIENTATION)
-	binary.Write(data, binary.LittleEndian, m.COVARIANCE)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.MIN_DISTANCE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.MAX_DISTANCE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CURRENT_DISTANCE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TYPE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ORIENTATION); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.COVARIANCE); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the DistanceSensor
 func (m *DistanceSensor) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.MIN_DISTANCE)
-	binary.Read(data, binary.LittleEndian, &m.MAX_DISTANCE)
-	binary.Read(data, binary.LittleEndian, &m.CURRENT_DISTANCE)
-	binary.Read(data, binary.LittleEndian, &m.TYPE)
-	binary.Read(data, binary.LittleEndian, &m.ID)
-	binary.Read(data, binary.LittleEndian, &m.ORIENTATION)
-	binary.Read(data, binary.LittleEndian, &m.COVARIANCE)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.MIN_DISTANCE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.MAX_DISTANCE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CURRENT_DISTANCE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TYPE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ORIENTATION); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.COVARIANCE); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE TERRAIN_REQUEST
@@ -7875,20 +10706,36 @@ func (*TerrainRequest) Crc() uint8 {
 // Pack returns a packed byte array which represents a TerrainRequest payload
 func (m *TerrainRequest) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.MASK)
-	binary.Write(data, binary.LittleEndian, m.LAT)
-	binary.Write(data, binary.LittleEndian, m.LON)
-	binary.Write(data, binary.LittleEndian, m.GRID_SPACING)
+	if err := binary.Write(data, binary.LittleEndian, m.MASK); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.GRID_SPACING); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the TerrainRequest
 func (m *TerrainRequest) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.MASK)
-	binary.Read(data, binary.LittleEndian, &m.LAT)
-	binary.Read(data, binary.LittleEndian, &m.LON)
-	binary.Read(data, binary.LittleEndian, &m.GRID_SPACING)
+	if err := binary.Read(data, binary.LittleEndian, &m.MASK); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.GRID_SPACING); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE TERRAIN_DATA
@@ -7935,22 +10782,42 @@ func (*TerrainData) Crc() uint8 {
 // Pack returns a packed byte array which represents a TerrainData payload
 func (m *TerrainData) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.LAT)
-	binary.Write(data, binary.LittleEndian, m.LON)
-	binary.Write(data, binary.LittleEndian, m.GRID_SPACING)
-	binary.Write(data, binary.LittleEndian, m.DATA)
-	binary.Write(data, binary.LittleEndian, m.GRIDBIT)
+	if err := binary.Write(data, binary.LittleEndian, m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.GRID_SPACING); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.DATA); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.GRIDBIT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the TerrainData
 func (m *TerrainData) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.LAT)
-	binary.Read(data, binary.LittleEndian, &m.LON)
-	binary.Read(data, binary.LittleEndian, &m.GRID_SPACING)
-	binary.Read(data, binary.LittleEndian, &m.DATA)
-	binary.Read(data, binary.LittleEndian, &m.GRIDBIT)
+	if err := binary.Read(data, binary.LittleEndian, &m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.GRID_SPACING); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.DATA); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.GRIDBIT); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -7995,16 +10862,24 @@ func (*TerrainCheck) Crc() uint8 {
 // Pack returns a packed byte array which represents a TerrainCheck payload
 func (m *TerrainCheck) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.LAT)
-	binary.Write(data, binary.LittleEndian, m.LON)
+	if err := binary.Write(data, binary.LittleEndian, m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LON); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the TerrainCheck
 func (m *TerrainCheck) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.LAT)
-	binary.Read(data, binary.LittleEndian, &m.LON)
+	if err := binary.Read(data, binary.LittleEndian, &m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LON); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE TERRAIN_REPORT
@@ -8055,26 +10930,54 @@ func (*TerrainReport) Crc() uint8 {
 // Pack returns a packed byte array which represents a TerrainReport payload
 func (m *TerrainReport) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.LAT)
-	binary.Write(data, binary.LittleEndian, m.LON)
-	binary.Write(data, binary.LittleEndian, m.TERRAIN_HEIGHT)
-	binary.Write(data, binary.LittleEndian, m.CURRENT_HEIGHT)
-	binary.Write(data, binary.LittleEndian, m.SPACING)
-	binary.Write(data, binary.LittleEndian, m.PENDING)
-	binary.Write(data, binary.LittleEndian, m.LOADED)
+	if err := binary.Write(data, binary.LittleEndian, m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TERRAIN_HEIGHT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CURRENT_HEIGHT); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SPACING); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.PENDING); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.LOADED); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the TerrainReport
 func (m *TerrainReport) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.LAT)
-	binary.Read(data, binary.LittleEndian, &m.LON)
-	binary.Read(data, binary.LittleEndian, &m.TERRAIN_HEIGHT)
-	binary.Read(data, binary.LittleEndian, &m.CURRENT_HEIGHT)
-	binary.Read(data, binary.LittleEndian, &m.SPACING)
-	binary.Read(data, binary.LittleEndian, &m.PENDING)
-	binary.Read(data, binary.LittleEndian, &m.LOADED)
+	if err := binary.Read(data, binary.LittleEndian, &m.LAT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LON); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TERRAIN_HEIGHT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CURRENT_HEIGHT); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.SPACING); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.PENDING); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.LOADED); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE BATTERY_STATUS
@@ -8133,34 +11036,78 @@ func (*BatteryStatus) Crc() uint8 {
 // Pack returns a packed byte array which represents a BatteryStatus payload
 func (m *BatteryStatus) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.CURRENT_CONSUMED)
-	binary.Write(data, binary.LittleEndian, m.ENERGY_CONSUMED)
-	binary.Write(data, binary.LittleEndian, m.VOLTAGE_CELL_1)
-	binary.Write(data, binary.LittleEndian, m.VOLTAGE_CELL_2)
-	binary.Write(data, binary.LittleEndian, m.VOLTAGE_CELL_3)
-	binary.Write(data, binary.LittleEndian, m.VOLTAGE_CELL_4)
-	binary.Write(data, binary.LittleEndian, m.VOLTAGE_CELL_5)
-	binary.Write(data, binary.LittleEndian, m.VOLTAGE_CELL_6)
-	binary.Write(data, binary.LittleEndian, m.CURRENT_BATTERY)
-	binary.Write(data, binary.LittleEndian, m.ACCU_ID)
-	binary.Write(data, binary.LittleEndian, m.BATTERY_REMAINING)
+	if err := binary.Write(data, binary.LittleEndian, m.CURRENT_CONSUMED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ENERGY_CONSUMED); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VOLTAGE_CELL_1); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VOLTAGE_CELL_2); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VOLTAGE_CELL_3); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VOLTAGE_CELL_4); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VOLTAGE_CELL_5); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VOLTAGE_CELL_6); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.CURRENT_BATTERY); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ACCU_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.BATTERY_REMAINING); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the BatteryStatus
 func (m *BatteryStatus) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.CURRENT_CONSUMED)
-	binary.Read(data, binary.LittleEndian, &m.ENERGY_CONSUMED)
-	binary.Read(data, binary.LittleEndian, &m.VOLTAGE_CELL_1)
-	binary.Read(data, binary.LittleEndian, &m.VOLTAGE_CELL_2)
-	binary.Read(data, binary.LittleEndian, &m.VOLTAGE_CELL_3)
-	binary.Read(data, binary.LittleEndian, &m.VOLTAGE_CELL_4)
-	binary.Read(data, binary.LittleEndian, &m.VOLTAGE_CELL_5)
-	binary.Read(data, binary.LittleEndian, &m.VOLTAGE_CELL_6)
-	binary.Read(data, binary.LittleEndian, &m.CURRENT_BATTERY)
-	binary.Read(data, binary.LittleEndian, &m.ACCU_ID)
-	binary.Read(data, binary.LittleEndian, &m.BATTERY_REMAINING)
+	if err := binary.Read(data, binary.LittleEndian, &m.CURRENT_CONSUMED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ENERGY_CONSUMED); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VOLTAGE_CELL_1); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VOLTAGE_CELL_2); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VOLTAGE_CELL_3); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VOLTAGE_CELL_4); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VOLTAGE_CELL_5); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VOLTAGE_CELL_6); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.CURRENT_BATTERY); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ACCU_ID); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.BATTERY_REMAINING); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE SETPOINT_8DOF
@@ -8215,30 +11162,66 @@ func (*Setpoint8Dof) Crc() uint8 {
 // Pack returns a packed byte array which represents a Setpoint8Dof payload
 func (m *Setpoint8Dof) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.VAL1)
-	binary.Write(data, binary.LittleEndian, m.VAL2)
-	binary.Write(data, binary.LittleEndian, m.VAL3)
-	binary.Write(data, binary.LittleEndian, m.VAL4)
-	binary.Write(data, binary.LittleEndian, m.VAL5)
-	binary.Write(data, binary.LittleEndian, m.VAL6)
-	binary.Write(data, binary.LittleEndian, m.VAL7)
-	binary.Write(data, binary.LittleEndian, m.VAL8)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
+	if err := binary.Write(data, binary.LittleEndian, m.VAL1); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VAL2); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VAL3); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VAL4); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VAL5); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VAL6); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VAL7); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VAL8); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the Setpoint8Dof
 func (m *Setpoint8Dof) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.VAL1)
-	binary.Read(data, binary.LittleEndian, &m.VAL2)
-	binary.Read(data, binary.LittleEndian, &m.VAL3)
-	binary.Read(data, binary.LittleEndian, &m.VAL4)
-	binary.Read(data, binary.LittleEndian, &m.VAL5)
-	binary.Read(data, binary.LittleEndian, &m.VAL6)
-	binary.Read(data, binary.LittleEndian, &m.VAL7)
-	binary.Read(data, binary.LittleEndian, &m.VAL8)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
+	if err := binary.Read(data, binary.LittleEndian, &m.VAL1); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VAL2); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VAL3); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VAL4); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VAL5); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VAL6); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VAL7); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VAL8); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE SETPOINT_6DOF
@@ -8289,26 +11272,54 @@ func (*Setpoint6Dof) Crc() uint8 {
 // Pack returns a packed byte array which represents a Setpoint6Dof payload
 func (m *Setpoint6Dof) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TRANS_X)
-	binary.Write(data, binary.LittleEndian, m.TRANS_Y)
-	binary.Write(data, binary.LittleEndian, m.TRANS_Z)
-	binary.Write(data, binary.LittleEndian, m.ROT_X)
-	binary.Write(data, binary.LittleEndian, m.ROT_Y)
-	binary.Write(data, binary.LittleEndian, m.ROT_Z)
-	binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM)
+	if err := binary.Write(data, binary.LittleEndian, m.TRANS_X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TRANS_Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TRANS_Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROT_X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROT_Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ROT_Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the Setpoint6Dof
 func (m *Setpoint6Dof) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TRANS_X)
-	binary.Read(data, binary.LittleEndian, &m.TRANS_Y)
-	binary.Read(data, binary.LittleEndian, &m.TRANS_Z)
-	binary.Read(data, binary.LittleEndian, &m.ROT_X)
-	binary.Read(data, binary.LittleEndian, &m.ROT_Y)
-	binary.Read(data, binary.LittleEndian, &m.ROT_Z)
-	binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM)
+	if err := binary.Read(data, binary.LittleEndian, &m.TRANS_X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TRANS_Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TRANS_Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROT_X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROT_Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.ROT_Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TARGET_SYSTEM); err != nil {
+		panic(err)
+	}
 }
 
 // MESSAGE MEMORY_VECT
@@ -8353,20 +11364,36 @@ func (*MemoryVect) Crc() uint8 {
 // Pack returns a packed byte array which represents a MemoryVect payload
 func (m *MemoryVect) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.ADDRESS)
-	binary.Write(data, binary.LittleEndian, m.VER)
-	binary.Write(data, binary.LittleEndian, m.TYPE)
-	binary.Write(data, binary.LittleEndian, m.VALUE)
+	if err := binary.Write(data, binary.LittleEndian, m.ADDRESS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VER); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TYPE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VALUE); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the MemoryVect
 func (m *MemoryVect) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.ADDRESS)
-	binary.Read(data, binary.LittleEndian, &m.VER)
-	binary.Read(data, binary.LittleEndian, &m.TYPE)
-	binary.Read(data, binary.LittleEndian, &m.VALUE)
+	if err := binary.Read(data, binary.LittleEndian, &m.ADDRESS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VER); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TYPE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VALUE); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -8417,22 +11444,42 @@ func (*DebugVect) Crc() uint8 {
 // Pack returns a packed byte array which represents a DebugVect payload
 func (m *DebugVect) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_USEC)
-	binary.Write(data, binary.LittleEndian, m.X)
-	binary.Write(data, binary.LittleEndian, m.Y)
-	binary.Write(data, binary.LittleEndian, m.Z)
-	binary.Write(data, binary.LittleEndian, m.NAME)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.NAME); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the DebugVect
 func (m *DebugVect) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_USEC)
-	binary.Read(data, binary.LittleEndian, &m.X)
-	binary.Read(data, binary.LittleEndian, &m.Y)
-	binary.Read(data, binary.LittleEndian, &m.Z)
-	binary.Read(data, binary.LittleEndian, &m.NAME)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_USEC); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.X); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Y); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.Z); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.NAME); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -8479,18 +11526,30 @@ func (*NamedValueFloat) Crc() uint8 {
 // Pack returns a packed byte array which represents a NamedValueFloat payload
 func (m *NamedValueFloat) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.VALUE)
-	binary.Write(data, binary.LittleEndian, m.NAME)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VALUE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.NAME); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the NamedValueFloat
 func (m *NamedValueFloat) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.VALUE)
-	binary.Read(data, binary.LittleEndian, &m.NAME)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VALUE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.NAME); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -8537,18 +11596,30 @@ func (*NamedValueInt) Crc() uint8 {
 // Pack returns a packed byte array which represents a NamedValueInt payload
 func (m *NamedValueInt) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.VALUE)
-	binary.Write(data, binary.LittleEndian, m.NAME)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VALUE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.NAME); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the NamedValueInt
 func (m *NamedValueInt) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.VALUE)
-	binary.Read(data, binary.LittleEndian, &m.NAME)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VALUE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.NAME); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -8593,16 +11664,24 @@ func (*Statustext) Crc() uint8 {
 // Pack returns a packed byte array which represents a Statustext payload
 func (m *Statustext) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.SEVERITY)
-	binary.Write(data, binary.LittleEndian, m.TEXT)
+	if err := binary.Write(data, binary.LittleEndian, m.SEVERITY); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.TEXT); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the Statustext
 func (m *Statustext) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.SEVERITY)
-	binary.Read(data, binary.LittleEndian, &m.TEXT)
+	if err := binary.Read(data, binary.LittleEndian, &m.SEVERITY); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.TEXT); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -8649,16 +11728,28 @@ func (*Debug) Crc() uint8 {
 // Pack returns a packed byte array which represents a Debug payload
 func (m *Debug) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS)
-	binary.Write(data, binary.LittleEndian, m.VALUE)
-	binary.Write(data, binary.LittleEndian, m.IND)
+	if err := binary.Write(data, binary.LittleEndian, m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.VALUE); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.IND); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
 // Decode accepts a packed byte array and populates the fields of the Debug
 func (m *Debug) Decode(buf []byte) {
 	data := bytes.NewBuffer(buf)
-	binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS)
-	binary.Read(data, binary.LittleEndian, &m.VALUE)
-	binary.Read(data, binary.LittleEndian, &m.IND)
+	if err := binary.Read(data, binary.LittleEndian, &m.TIME_BOOT_MS); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.VALUE); err != nil {
+		panic(err)
+	}
+	if err := binary.Read(data, binary.LittleEndian, &m.IND); err != nil {
+		panic(err)
+	}
 }

--- a/platforms/mavlink/common/mavlink.go
+++ b/platforms/mavlink/common/mavlink.go
@@ -1,4 +1,3 @@
-//nolint:errcheck // to much code to fix it immediately
 package mavlink
 
 //
@@ -117,14 +116,28 @@ func (m *MAVLinkPacket) MAVLinkMessage() (MAVLinkMessage, error) {
 // Pack returns a packed byte array which represents the MAVLinkPacket
 func (m *MAVLinkPacket) Pack() []byte {
 	data := new(bytes.Buffer)
-	binary.Write(data, binary.LittleEndian, m.Protocol)
-	binary.Write(data, binary.LittleEndian, m.Length)
-	binary.Write(data, binary.LittleEndian, m.Sequence)
-	binary.Write(data, binary.LittleEndian, m.SystemID)
-	binary.Write(data, binary.LittleEndian, m.ComponentID)
-	binary.Write(data, binary.LittleEndian, m.MessageID)
+	if err := binary.Write(data, binary.LittleEndian, m.Protocol); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Length); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.Sequence); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.SystemID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.ComponentID); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(data, binary.LittleEndian, m.MessageID); err != nil {
+		panic(err)
+	}
 	data.Write(m.Data)
-	binary.Write(data, binary.LittleEndian, m.Checksum)
+	if err := binary.Write(data, binary.LittleEndian, m.Checksum); err != nil {
+		panic(err)
+	}
 	return data.Bytes()
 }
 
@@ -148,15 +161,16 @@ func read(r io.Reader, length int) ([]byte, error) {
 		i, err := r.Read(tmp[:])
 		if err != nil {
 			return nil, err
-		} else {
-			length -= i
-			buf = append(buf, tmp...)
-			if length != i {
-				time.Sleep(1 * time.Millisecond)
-			} else {
-				break
-			}
 		}
+
+		length -= i
+		buf = append(buf, tmp...)
+		if length != i {
+			time.Sleep(1 * time.Millisecond)
+		} else {
+			break
+		}
+
 	}
 	return buf, nil
 }


### PR DESCRIPTION
## Solved issues and/or description of the change

see #949 , in addition adjust some links in README

## Manual test

no

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code