### PR TITLE
jetson(PWM): fix set period

### DIFF
--- a/platforms/jetson/pwm_pin.go
+++ b/platforms/jetson/pwm_pin.go
@@ -89,7 +89,7 @@ func (p *PWMPin) SetPeriod(period uint32) error {
 	if period < minimumPeriod {
 		return errors.New("Cannot set the period more then minimum")
 	}
-	if err := p.writeFile(fmt.Sprintf("pwm%s/period", p.fn), fmt.Sprintf("%v", p.period)); err != nil {
+	if err := p.writeFile(fmt.Sprintf("pwm%s/period", p.fn), fmt.Sprintf("%v", period)); err != nil {
 		return err
 	}
 	p.period = period


### PR DESCRIPTION


## Solved issues and/or description of the change
changed so the SetPeriod uses the value from the parameter
...

## Manual test

- OS and Version (Win/Mac/Linux):
- Adaptor(s) and/or driver(s):
...

## Checklist

- [ ] The PR's target branch is 'hybridgroup:dev'
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (e.g. by run `make test`)
- [ ] No linter errors exist locally (e.g. by run `make fmt_check`)
- [ ] I have performed a self-review of my own code

If this is a new driver or adaptor:

- [ ] I have added the name to the corresponding README.md
- [ ] I have added an example to see how to setup and use it
- [ ] I have checked or build at least my new example (e.g. by run `make examples_check`)

If this is a PR for release:

- [ ] The PR's target branch is 'hybridgroup:release'
- [ ] I have adjusted the CHANGELOG.md (or already prepared and will be merged as soon as possible)
