### PR TITLE
sphero: Add support for Sphero calibration.

### DIFF
--- a/examples/sphero_calibration.go
+++ b/examples/sphero_calibration.go
@@ -1,0 +1,67 @@
+//go:build example
+// +build example
+
+//
+// Do not build by default.
+
+package main
+
+import (
+	"gobot.io/x/gobot/v2"
+	"gobot.io/x/gobot/v2/api"
+	"gobot.io/x/gobot/v2/platforms/keyboard"
+	"gobot.io/x/gobot/v2/platforms/sphero"
+)
+
+func main() {
+	master := gobot.NewMaster()
+	a := api.NewAPI(master)
+	a.Start()
+
+	ballConn := sphero.NewAdaptor("/dev/rfcomm0")
+	ball := sphero.NewSpheroDriver(ballConn)
+
+	keys := keyboard.NewDriver()
+
+	calibrating := false
+
+	work := func() {
+		keys.On(keyboard.Key, func(data interface{}) {
+			key := data.(keyboard.KeyEvent)
+
+			switch key.Key {
+			case keyboard.ArrowUp:
+				if calibrating {
+					break
+				}
+				ball.Roll(100, 0)
+			case keyboard.ArrowDown:
+				if calibrating {
+					break
+				}
+				ball.Roll(100, 100)
+			case keyboard.ArrowLeft:
+				ball.Roll(100, 270)
+			case keyboard.ArrowRight:
+				ball.Roll(100, 90)
+			case keyboard.Spacebar:
+				if calibrating {
+					ball.FinishCalibration()
+				} else {
+					ball.StartCalibration()
+				}
+				calibrating = !calibrating
+			}
+		})
+	}
+
+	robot := gobot.NewRobot("sphero-calibration",
+		[]gobot.Connection{ballConn},
+		[]gobot.Device{ball, keys},
+		work,
+	)
+
+	master.AddRobot(robot)
+
+	master.Start()
+}


### PR DESCRIPTION
## Solved issues and/or description of the change

Add support for Sphero calibration. Based on on existing Javascrip code.

## Manual test

- OS and Version (Win/Mac/Linux): Mac
- Adaptor(s) and/or driver(s): Sphero

## Checklist

- [ X] The PR's target branch is 'hybridgroup:dev'
- [ X] I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes (e.g. by run `make test`)
- [ X] No linter errors exist locally (e.g. by run `make fmt_check`)
- [ X] I have performed a self-review of my own code

If this is a new driver or adaptor:

- [ ] I have added the name to the corresponding README.md
- [ ] I have added an example to see how to setup and use it
- [ ] I have checked or build at least my new example (e.g. by run `make examples_check`)

If this is a PR for release:

- [ ] The PR's target branch is 'hybridgroup:release'
- [ ] I have adjusted the CHANGELOG.md (or already prepared and will be merged as soon as possible)
