### PR TITLE
adaptors(PWM): fix wrong duty cycle after kill program

### DIFF
--- a/platforms/adaptors/pwmpinsadaptor.go
+++ b/platforms/adaptors/pwmpinsadaptor.go
@@ -191,7 +191,7 @@ func (a *PWMPinsAdaptor) getDefaultInitializer() func(gobot.PWMPinner) error {
 				return err
 			}
 		}
-		if err := setPeriod(pin, a.periodDefault, false); err != nil {
+		if err := setPeriod(pin, a.periodDefault, a.adjustDutyOnSetPeriod); err != nil {
 			return err
 		}
 		// period needs to be set >1 before all next statements

--- a/platforms/beaglebone/beaglebone_adaptor_test.go
+++ b/platforms/beaglebone/beaglebone_adaptor_test.go
@@ -54,6 +54,8 @@ func TestPWM(t *testing.T) {
 	}
 
 	a, fs := initTestAdaptorWithMockedFilesystem(mockPaths)
+	fs.Files["/sys/devices/platform/ocp/48300000.epwmss/48300200.pwm/pwm/pwmchip0/pwm1/duty_cycle"].Contents = "0"
+	fs.Files["/sys/devices/platform/ocp/48300000.epwmss/48300200.pwm/pwm/pwmchip0/pwm1/period"].Contents = "0"
 
 	gobottest.Assert(t, a.PwmWrite("P9_99", 175), errors.New("'P9_99' is not a valid id for a PWM pin"))
 	_ = a.PwmWrite("P9_21", 175)

--- a/platforms/chip/chip_adaptor_test.go
+++ b/platforms/chip/chip_adaptor_test.go
@@ -81,6 +81,9 @@ func TestFinalizeErrorAfterGPIO(t *testing.T) {
 
 func TestFinalizeErrorAfterPWM(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem()
+	fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents = "0"
+	fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents = "0"
+
 	gobottest.Assert(t, a.Connect(), nil)
 	gobottest.Assert(t, a.PwmWrite("PWM0", 100), nil)
 
@@ -122,6 +125,9 @@ func TestProDigitalIO(t *testing.T) {
 
 func TestPWM(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem()
+	fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents = "0"
+	fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents = "0"
+
 	_ = a.Connect()
 
 	err := a.PwmWrite("PWM0", 100)
@@ -130,17 +136,21 @@ func TestPWM(t *testing.T) {
 	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/export"].Contents, "0")
 	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm0/enable"].Contents, "1")
 	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents, "3921568")
+	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents, "10000000") // pwmPeriodDefault
 	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm0/polarity"].Contents, "normal")
 
 	err = a.ServoWrite("PWM0", 0)
 	gobottest.Assert(t, err, nil)
 
 	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents, "500000")
+	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents, "10000000")
 
 	err = a.ServoWrite("PWM0", 180)
 	gobottest.Assert(t, err, nil)
 
 	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents, "2000000")
+	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents, "10000000") // pwmPeriodDefault
+
 	gobottest.Assert(t, a.Finalize(), nil)
 }
 

--- a/platforms/upboard/up2/adaptor_test.go
+++ b/platforms/upboard/up2/adaptor_test.go
@@ -82,6 +82,8 @@ func TestDigitalIO(t *testing.T) {
 
 func TestPWM(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem(pwmMockPaths)
+	fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents = "0"
+	fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents = "0"
 
 	err := a.PwmWrite("32", 100)
 	gobottest.Assert(t, err, nil)
@@ -89,17 +91,21 @@ func TestPWM(t *testing.T) {
 	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/export"].Contents, "0")
 	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm0/enable"].Contents, "1")
 	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents, "3921568")
+	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents, "10000000") // pwmPeriodDefault
 	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm0/polarity"].Contents, "normal")
 
 	err = a.ServoWrite("32", 0)
 	gobottest.Assert(t, err, nil)
 
 	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents, "500000")
+	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents, "10000000")
 
 	err = a.ServoWrite("32", 180)
 	gobottest.Assert(t, err, nil)
 
 	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents, "2000000")
+	gobottest.Assert(t, fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents, "10000000")
+
 	gobottest.Assert(t, a.Finalize(), nil)
 }
 
@@ -116,6 +122,8 @@ func TestFinalizeErrorAfterGPIO(t *testing.T) {
 
 func TestFinalizeErrorAfterPWM(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem(pwmMockPaths)
+	fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents = "0"
+	fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents = "0"
 
 	gobottest.Assert(t, a.PwmWrite("32", 1), nil)
 


### PR DESCRIPTION
## Solved issues and/or description of the change

After a program with PWM usage is stopped by e.g. STRG-C, a restart is sometimes not possible due to bad state of duty cycle value. This can be solved by automatically adjusting the duty cycle on program start. This feature still exist, but was not enabled before.

## Manual test

- OS and Version (Win/Mac/Linux): Linux
- Adaptor(s) and/or driver(s): tinkerboard

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code