### PR TITLE
build(go, deps): switch to Go 1.19 and update modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ version: 2
 jobs:
   "test_core_and_drivers_with_coverage":
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.19
     steps:
       - checkout
       - run:
@@ -31,7 +31,7 @@ jobs:
 
   "test_platforms":
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.19
     steps:
       - checkout
       - run:
@@ -45,7 +45,7 @@ jobs:
   
   "check_examples":
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.19
     steps:
       - checkout
       - run:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -31,7 +31,8 @@ jobs:
 
           # Optional: golangci-lint command line arguments.
           # mostly there is no problem locally, but on server: "could not import C (cgo preprocessing failed) (typecheck)"
-          args: --skip-files platforms/digispark/littleWire.go
+          # and the digispark adaptor can not be build since switch to linter version 1.54.2
+          args: --skip-files="platforms/digispark/littleWire.go,platforms/digispark/digispark_adaptor.go"
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,16 +15,16 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.18'
+          go-version: '1.19'
           cache: false
-      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.53.3
+          version: v1.54.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gobot.io/x/gobot/v2
 
-go 1.18
+go 1.19
 
 require (
 	github.com/0xcafed00d/joystick v1.0.1


### PR DESCRIPTION
## Solved issues and/or description of the change

#993 

## Manual test

none

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code
