### PR TITLE
test(all): substitude assert.Error by assert.ErrorContains

### DIFF
--- a/drivers/gpio/buzzer_driver_test.go
+++ b/drivers/gpio/buzzer_driver_test.go
@@ -57,7 +57,7 @@ func TestBuzzerDriverOnError(t *testing.T) {
 		return errors.New("write error")
 	})
 
-	assert.Error(t, d.On(), "write error")
+	assert.ErrorContains(t, d.On(), "write error")
 }
 
 func TestBuzzerDriverOffError(t *testing.T) {
@@ -67,7 +67,7 @@ func TestBuzzerDriverOffError(t *testing.T) {
 		return errors.New("write error")
 	})
 
-	assert.Error(t, d.Off(), "write error")
+	assert.ErrorContains(t, d.Off(), "write error")
 }
 
 func TestBuzzerDriverToneError(t *testing.T) {
@@ -77,5 +77,5 @@ func TestBuzzerDriverToneError(t *testing.T) {
 		return errors.New("write error")
 	})
 
-	assert.Error(t, d.Tone(100, 0.01), "write error")
+	assert.ErrorContains(t, d.Tone(100, 0.01), "write error")
 }

--- a/drivers/gpio/direct_pin_driver_test.go
+++ b/drivers/gpio/direct_pin_driver_test.go
@@ -43,13 +43,13 @@ func TestDirectPinDriver(t *testing.T) {
 	assert.Nil(t, ret["err"])
 
 	err = d.Command("DigitalWrite")(map[string]interface{}{"level": "1"})
-	assert.Error(t, err.(error), "write error")
+	assert.ErrorContains(t, err.(error), "write error")
 
 	err = d.Command("PwmWrite")(map[string]interface{}{"level": "1"})
-	assert.Error(t, err.(error), "write error")
+	assert.ErrorContains(t, err.(error), "write error")
 
 	err = d.Command("ServoWrite")(map[string]interface{}{"level": "1"})
-	assert.Error(t, err.(error), "write error")
+	assert.ErrorContains(t, err.(error), "write error")
 }
 
 func TestDirectPinDriverStart(t *testing.T) {
@@ -74,7 +74,7 @@ func TestDirectPinDriverOff(t *testing.T) {
 func TestDirectPinDriverOffNotSupported(t *testing.T) {
 	a := &gpioTestBareAdaptor{}
 	d := NewDirectPinDriver(a, "1")
-	assert.Error(t, d.Off(), "DigitalWrite is not supported by this platform")
+	assert.ErrorContains(t, d.Off(), "DigitalWrite is not supported by this platform")
 }
 
 func TestDirectPinDriverOn(t *testing.T) {
@@ -91,7 +91,7 @@ func TestDirectPinDriverOnError(t *testing.T) {
 func TestDirectPinDriverOnNotSupported(t *testing.T) {
 	a := &gpioTestBareAdaptor{}
 	d := NewDirectPinDriver(a, "1")
-	assert.Error(t, d.On(), "DigitalWrite is not supported by this platform")
+	assert.ErrorContains(t, d.On(), "DigitalWrite is not supported by this platform")
 }
 
 func TestDirectPinDriverDigitalWrite(t *testing.T) {
@@ -103,7 +103,7 @@ func TestDirectPinDriverDigitalWrite(t *testing.T) {
 func TestDirectPinDriverDigitalWriteNotSupported(t *testing.T) {
 	a := &gpioTestBareAdaptor{}
 	d := NewDirectPinDriver(a, "1")
-	assert.Error(t, d.DigitalWrite(1), "DigitalWrite is not supported by this platform")
+	assert.ErrorContains(t, d.DigitalWrite(1), "DigitalWrite is not supported by this platform")
 }
 
 func TestDirectPinDriverDigitalWriteError(t *testing.T) {
@@ -122,7 +122,7 @@ func TestDirectPinDriverDigitalReadNotSupported(t *testing.T) {
 	a := &gpioTestBareAdaptor{}
 	d := NewDirectPinDriver(a, "1")
 	_, e := d.DigitalRead()
-	assert.Error(t, e, "DigitalRead is not supported by this platform")
+	assert.ErrorContains(t, e, "DigitalRead is not supported by this platform")
 }
 
 func TestDirectPinDriverPwmWrite(t *testing.T) {
@@ -134,7 +134,7 @@ func TestDirectPinDriverPwmWrite(t *testing.T) {
 func TestDirectPinDriverPwmWriteNotSupported(t *testing.T) {
 	a := &gpioTestBareAdaptor{}
 	d := NewDirectPinDriver(a, "1")
-	assert.Error(t, d.PwmWrite(1), "PwmWrite is not supported by this platform")
+	assert.ErrorContains(t, d.PwmWrite(1), "PwmWrite is not supported by this platform")
 }
 
 func TestDirectPinDriverPwmWriteError(t *testing.T) {
@@ -151,7 +151,7 @@ func TestDirectPinDriverServoWrite(t *testing.T) {
 func TestDirectPinDriverServoWriteNotSupported(t *testing.T) {
 	a := &gpioTestBareAdaptor{}
 	d := NewDirectPinDriver(a, "1")
-	assert.Error(t, d.ServoWrite(1), "ServoWrite is not supported by this platform")
+	assert.ErrorContains(t, d.ServoWrite(1), "ServoWrite is not supported by this platform")
 }
 
 func TestDirectPinDriverServoWriteError(t *testing.T) {

--- a/drivers/gpio/hd44780_driver_test.go
+++ b/drivers/gpio/hd44780_driver_test.go
@@ -93,7 +93,7 @@ func TestHD44780DriverStartError(t *testing.T) {
 		D7: "",
 	}
 	d = NewHD44780Driver(a, 2, 16, HD44780_4BITMODE, "13", "15", pins)
-	assert.Error(t, d.Start(), "Initialization error")
+	assert.ErrorContains(t, d.Start(), "Initialization error")
 
 	pins = HD44780DataPin{
 		D0: "31",
@@ -106,7 +106,7 @@ func TestHD44780DriverStartError(t *testing.T) {
 		D7: "",
 	}
 	d = NewHD44780Driver(a, 2, 16, HD44780_8BITMODE, "13", "15", pins)
-	assert.Error(t, d.Start(), "Initialization error")
+	assert.ErrorContains(t, d.Start(), "Initialization error")
 }
 
 func TestHD44780DriverWrite(t *testing.T) {
@@ -130,14 +130,14 @@ func TestHD44780DriverWriteError(t *testing.T) {
 		return errors.New("write error")
 	}
 	_ = d.Start()
-	assert.Error(t, d.Write("hello gobot"), "write error")
+	assert.ErrorContains(t, d.Write("hello gobot"), "write error")
 
 	d, a = initTestHD44780Driver8BitModeWithStubbedAdaptor()
 	a.testAdaptorDigitalWrite = func(string, byte) (err error) {
 		return errors.New("write error")
 	}
 	_ = d.Start()
-	assert.Error(t, d.Write("hello gobot"), "write error")
+	assert.ErrorContains(t, d.Write("hello gobot"), "write error")
 }
 
 func TestHD44780DriverClear(t *testing.T) {
@@ -158,10 +158,10 @@ func TestHD44780DriverSetCursor(t *testing.T) {
 func TestHD44780DriverSetCursorInvalid(t *testing.T) {
 	d := initTestHD44780Driver()
 
-	assert.Error(t, d.SetCursor(-1, 3), "Invalid position value (-1, 3), range (1, 15)")
-	assert.Error(t, d.SetCursor(2, 3), "Invalid position value (2, 3), range (1, 15)")
-	assert.Error(t, d.SetCursor(0, -1), "Invalid position value (0, -1), range (1, 15)")
-	assert.Error(t, d.SetCursor(0, 16), "Invalid position value (0, 16), range (1, 15)")
+	assert.ErrorContains(t, d.SetCursor(-1, 3), "Invalid position value (-1, 3), range (1, 15)")
+	assert.ErrorContains(t, d.SetCursor(2, 3), "Invalid position value (2, 3), range (1, 15)")
+	assert.ErrorContains(t, d.SetCursor(0, -1), "Invalid position value (0, -1), range (1, 15)")
+	assert.ErrorContains(t, d.SetCursor(0, 16), "Invalid position value (0, 16), range (1, 15)")
 }
 
 func TestHD44780DriverDisplayOn(t *testing.T) {
@@ -233,5 +233,5 @@ func TestHD44780DriverCreateChar(t *testing.T) {
 func TestHD44780DriverCreateCharError(t *testing.T) {
 	d := initTestHD44780Driver()
 	charMap := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
-	assert.Error(t, d.CreateChar(8, charMap), "can't set a custom character at a position greater than 7")
+	assert.ErrorContains(t, d.CreateChar(8, charMap), "can't set a custom character at a position greater than 7")
 }

--- a/drivers/gpio/led_driver_test.go
+++ b/drivers/gpio/led_driver_test.go
@@ -38,16 +38,16 @@ func TestLedDriver(t *testing.T) {
 	}
 
 	err = d.Command("Toggle")(nil)
-	assert.Error(t, err.(error), "write error")
+	assert.ErrorContains(t, err.(error), "write error")
 
 	err = d.Command("On")(nil)
-	assert.Error(t, err.(error), "write error")
+	assert.ErrorContains(t, err.(error), "write error")
 
 	err = d.Command("Off")(nil)
-	assert.Error(t, err.(error), "write error")
+	assert.ErrorContains(t, err.(error), "write error")
 
 	err = d.Command("Brightness")(map[string]interface{}{"level": 100.0})
-	assert.Error(t, err.(error), "pwm error")
+	assert.ErrorContains(t, err.(error), "pwm error")
 }
 
 func TestLedDriverStart(t *testing.T) {
@@ -76,7 +76,7 @@ func TestLedDriverBrightness(t *testing.T) {
 		err = errors.New("pwm error")
 		return
 	}
-	assert.Error(t, d.Brightness(150), "pwm error")
+	assert.ErrorContains(t, d.Brightness(150), "pwm error")
 }
 
 func TestLEDDriverDefaultName(t *testing.T) {

--- a/drivers/gpio/rgb_led_driver_test.go
+++ b/drivers/gpio/rgb_led_driver_test.go
@@ -42,16 +42,16 @@ func TestRgbLedDriver(t *testing.T) {
 	}
 
 	err = d.Command("Toggle")(nil)
-	assert.Error(t, err.(error), "pwm error")
+	assert.ErrorContains(t, err.(error), "pwm error")
 
 	err = d.Command("On")(nil)
-	assert.Error(t, err.(error), "pwm error")
+	assert.ErrorContains(t, err.(error), "pwm error")
 
 	err = d.Command("Off")(nil)
-	assert.Error(t, err.(error), "pwm error")
+	assert.ErrorContains(t, err.(error), "pwm error")
 
 	err = d.Command("SetRGB")(map[string]interface{}{"r": 0xff, "g": 0xff, "b": 0xff})
-	assert.Error(t, err.(error), "pwm error")
+	assert.ErrorContains(t, err.(error), "pwm error")
 }
 
 func TestRgbLedDriverStart(t *testing.T) {
@@ -83,7 +83,7 @@ func TestRgbLedDriverSetLevel(t *testing.T) {
 		err = errors.New("pwm error")
 		return
 	}
-	assert.Error(t, d.SetLevel("1", 150), "pwm error")
+	assert.ErrorContains(t, d.SetLevel("1", 150), "pwm error")
 }
 
 func TestRgbLedDriverDefaultName(t *testing.T) {

--- a/drivers/gpio/servo_driver_test.go
+++ b/drivers/gpio/servo_driver_test.go
@@ -29,16 +29,16 @@ func TestServoDriver(t *testing.T) {
 	}
 
 	err = d.Command("Min")(nil)
-	assert.Error(t, err.(error), "pwm error")
+	assert.ErrorContains(t, err.(error), "pwm error")
 
 	err = d.Command("Center")(nil)
-	assert.Error(t, err.(error), "pwm error")
+	assert.ErrorContains(t, err.(error), "pwm error")
 
 	err = d.Command("Max")(nil)
-	assert.Error(t, err.(error), "pwm error")
+	assert.ErrorContains(t, err.(error), "pwm error")
 
 	err = d.Command("Move")(map[string]interface{}{"angle": 100.0})
-	assert.Error(t, err.(error), "pwm error")
+	assert.ErrorContains(t, err.(error), "pwm error")
 }
 
 func TestServoDriverStart(t *testing.T) {

--- a/drivers/gpio/stepper_driver_test.go
+++ b/drivers/gpio/stepper_driver_test.go
@@ -57,7 +57,7 @@ func TestStepperDriverDefaultDirection(t *testing.T) {
 func TestStepperDriverInvalidDirection(t *testing.T) {
 	d := initStepperMotorDriver()
 	err := d.SetDirection("reverse")
-	assert.Error(t, err, "Invalid direction. Value should be forward or backward")
+	assert.ErrorContains(t, err, "Invalid direction. Value should be forward or backward")
 }
 
 func TestStepperDriverMoveForward(t *testing.T) {

--- a/drivers/i2c/adafruit1109_driver_test.go
+++ b/drivers/i2c/adafruit1109_driver_test.go
@@ -73,7 +73,7 @@ func TestAdafruit1109StartWriteErr(t *testing.T) {
 	adaptor.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
-	assert.Error(t, d.Start(), "write error")
+	assert.ErrorContains(t, d.Start(), "write error")
 }
 
 func TestAdafruit1109StartReadErr(t *testing.T) {
@@ -81,7 +81,7 @@ func TestAdafruit1109StartReadErr(t *testing.T) {
 	adaptor.i2cReadImpl = func([]byte) (int, error) {
 		return 0, errors.New("read error")
 	}
-	assert.Error(t, d.Start(), "MCP write-read: MCP write-ReadByteData(reg=0): read error")
+	assert.ErrorContains(t, d.Start(), "MCP write-read: MCP write-ReadByteData(reg=0): read error")
 }
 
 func TestAdafruit1109Halt(t *testing.T) {

--- a/drivers/i2c/adafruit_driver_test.go
+++ b/drivers/i2c/adafruit_driver_test.go
@@ -45,7 +45,7 @@ func TestAdafruitMotorHatDriverStartWriteError(t *testing.T) {
 	adaptor.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
-	assert.Error(t, d.Start(), "write error")
+	assert.ErrorContains(t, d.Start(), "write error")
 }
 
 func TestAdafruitMotorHatDriverStartReadError(t *testing.T) {
@@ -53,13 +53,13 @@ func TestAdafruitMotorHatDriverStartReadError(t *testing.T) {
 	adaptor.i2cReadImpl = func([]byte) (int, error) {
 		return 0, errors.New("read error")
 	}
-	assert.Error(t, d.Start(), "read error")
+	assert.ErrorContains(t, d.Start(), "read error")
 }
 
 func TestAdafruitMotorHatDriverStartConnectError(t *testing.T) {
 	d, adaptor := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
 	adaptor.Testi2cConnectErr(true)
-	assert.Error(t, d.Start(), "Invalid i2c connection")
+	assert.ErrorContains(t, d.Start(), "Invalid i2c connection")
 }
 
 func TestAdafruitMotorHatDriverHalt(t *testing.T) {
@@ -96,7 +96,7 @@ func TestAdafruitMotorHatDriverSetServoMotorFreqError(t *testing.T) {
 	}
 
 	freq := 60.0
-	assert.Error(t, ada.SetServoMotorFreq(freq), "write error")
+	assert.ErrorContains(t, ada.SetServoMotorFreq(freq), "write error")
 }
 
 func TestAdafruitMotorHatDriverSetServoMotorPulse(t *testing.T) {
@@ -122,7 +122,7 @@ func TestAdafruitMotorHatDriverSetServoMotorPulseError(t *testing.T) {
 	var channel byte = 7
 	var on int32 = 1234
 	var off int32 = 4321
-	assert.Error(t, ada.SetServoMotorPulse(channel, on, off), "write error")
+	assert.ErrorContains(t, ada.SetServoMotorPulse(channel, on, off), "write error")
 }
 
 func TestAdafruitMotorHatDriverSetDCMotorSpeed(t *testing.T) {
@@ -144,7 +144,7 @@ func TestAdafruitMotorHatDriverSetDCMotorSpeedError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 
-	assert.Error(t, ada.SetDCMotorSpeed(1, 255), "write error")
+	assert.ErrorContains(t, ada.SetDCMotorSpeed(1, 255), "write error")
 }
 
 func TestAdafruitMotorHatDriverRunDCMotor(t *testing.T) {
@@ -166,9 +166,9 @@ func TestAdafruitMotorHatDriverRunDCMotorError(t *testing.T) {
 	}
 
 	dcMotor := 1
-	assert.Error(t, ada.RunDCMotor(dcMotor, AdafruitForward), "write error")
-	assert.Error(t, ada.RunDCMotor(dcMotor, AdafruitBackward), "write error")
-	assert.Error(t, ada.RunDCMotor(dcMotor, AdafruitRelease), "write error")
+	assert.ErrorContains(t, ada.RunDCMotor(dcMotor, AdafruitForward), "write error")
+	assert.ErrorContains(t, ada.RunDCMotor(dcMotor, AdafruitBackward), "write error")
+	assert.ErrorContains(t, ada.RunDCMotor(dcMotor, AdafruitRelease), "write error")
 }
 
 func TestAdafruitMotorHatDriverSetStepperMotorSpeed(t *testing.T) {

--- a/drivers/i2c/ads1x15_driver_1015_test.go
+++ b/drivers/i2c/ads1x15_driver_1015_test.go
@@ -115,14 +115,14 @@ func TestADS1x15AnalogReadError(t *testing.T) {
 	}
 
 	_, err := d.AnalogRead("0")
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 }
 
 func TestADS1x15AnalogReadInvalidPin(t *testing.T) {
 	d, _ := initTestADS1015DriverWithStubbedAdaptor()
 
 	_, err := d.AnalogRead("99")
-	assert.Error(t, err, "Invalid channel (99), must be between 0 and 3")
+	assert.ErrorContains(t, err, "Invalid channel (99), must be between 0 and 3")
 }
 
 func TestADS1x15AnalogReadWriteError(t *testing.T) {
@@ -133,41 +133,41 @@ func TestADS1x15AnalogReadWriteError(t *testing.T) {
 	}
 
 	_, err := d.AnalogRead("0")
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 
 	_, err = d.AnalogRead("0-1")
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 
 	_, err = d.AnalogRead("2-3")
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }
 
 func TestADS1x15ReadInvalidChannel(t *testing.T) {
 	d, _ := initTestADS1015DriverWithStubbedAdaptor()
 
 	_, err := d.Read(9, 1, 1600)
-	assert.Error(t, err, "Invalid channel (9), must be between 0 and 3")
+	assert.ErrorContains(t, err, "Invalid channel (9), must be between 0 and 3")
 }
 
 func TestADS1x15ReadInvalidGain(t *testing.T) {
 	d, _ := initTestADS1015DriverWithStubbedAdaptor()
 
 	_, err := d.Read(0, 8, 1600)
-	assert.Error(t, err, "Gain (8) must be one of: [0 1 2 3 4 5 6 7]")
+	assert.ErrorContains(t, err, "Gain (8) must be one of: [0 1 2 3 4 5 6 7]")
 }
 
 func TestADS1x15ReadInvalidDataRate(t *testing.T) {
 	d, _ := initTestADS1015DriverWithStubbedAdaptor()
 
 	_, err := d.Read(0, 1, 321)
-	assert.Error(t, err, "Invalid data rate (321). Accepted values: [128 250 490 920 1600 2400 3300]")
+	assert.ErrorContains(t, err, "Invalid data rate (321). Accepted values: [128 250 490 920 1600 2400 3300]")
 }
 
 func TestADS1x15ReadDifferenceInvalidChannel(t *testing.T) {
 	d, _ := initTestADS1015DriverWithStubbedAdaptor()
 
 	_, err := d.ReadDifference(9, 1, 1600)
-	assert.Error(t, err, "Invalid channel (9), must be between 0 and 3")
+	assert.ErrorContains(t, err, "Invalid channel (9), must be between 0 and 3")
 }
 
 func TestADS1015_rawRead(t *testing.T) {

--- a/drivers/i2c/ads1x15_driver_1115_test.go
+++ b/drivers/i2c/ads1x15_driver_1115_test.go
@@ -115,14 +115,14 @@ func TestADS1115AnalogReadError(t *testing.T) {
 	}
 
 	_, err := d.AnalogRead("0")
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 }
 
 func TestADS1115AnalogReadInvalidPin(t *testing.T) {
 	d, _ := initTestADS1115DriverWithStubbedAdaptor()
 
 	_, err := d.AnalogRead("98")
-	assert.Error(t, err, "Invalid channel (98), must be between 0 and 3")
+	assert.ErrorContains(t, err, "Invalid channel (98), must be between 0 and 3")
 }
 
 func TestADS1115AnalogReadWriteError(t *testing.T) {
@@ -133,41 +133,41 @@ func TestADS1115AnalogReadWriteError(t *testing.T) {
 	}
 
 	_, err := d.AnalogRead("0")
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 
 	_, err = d.AnalogRead("0-1")
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 
 	_, err = d.AnalogRead("2-3")
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }
 
 func TestADS1115ReadInvalidChannel(t *testing.T) {
 	d, _ := initTestADS1115DriverWithStubbedAdaptor()
 
 	_, err := d.Read(7, 1, 1600)
-	assert.Error(t, err, "Invalid channel (7), must be between 0 and 3")
+	assert.ErrorContains(t, err, "Invalid channel (7), must be between 0 and 3")
 }
 
 func TestADS1115ReadInvalidGain(t *testing.T) {
 	d, _ := initTestADS1115DriverWithStubbedAdaptor()
 
 	_, err := d.Read(0, 21, 1600)
-	assert.Error(t, err, "Gain (21) must be one of: [0 1 2 3 4 5 6 7]")
+	assert.ErrorContains(t, err, "Gain (21) must be one of: [0 1 2 3 4 5 6 7]")
 }
 
 func TestADS1115ReadInvalidDataRate(t *testing.T) {
 	d, _ := initTestADS1115DriverWithStubbedAdaptor()
 
 	_, err := d.Read(0, 1, 678)
-	assert.Error(t, err, "Invalid data rate (678). Accepted values: [8 16 32 64 128 250 475 860]")
+	assert.ErrorContains(t, err, "Invalid data rate (678). Accepted values: [8 16 32 64 128 250 475 860]")
 }
 
 func TestADS1115ReadDifferenceInvalidChannel(t *testing.T) {
 	d, _ := initTestADS1115DriverWithStubbedAdaptor()
 
 	_, err := d.ReadDifference(5, 1, 1600)
-	assert.Error(t, err, "Invalid channel (5), must be between 0 and 3")
+	assert.ErrorContains(t, err, "Invalid channel (5), must be between 0 and 3")
 }
 
 func TestADS1115_rawRead(t *testing.T) {

--- a/drivers/i2c/ads1x15_driver_test.go
+++ b/drivers/i2c/ads1x15_driver_test.go
@@ -99,5 +99,5 @@ func TestADS1x15_ads1x15BestGainForVoltage(t *testing.T) {
 	assert.Equal(t, 2, g)
 
 	_, err := ads1x15BestGainForVoltage(20.0)
-	assert.Error(t, err, "The maximum voltage which can be read is 6.144000")
+	assert.ErrorContains(t, err, "The maximum voltage which can be read is 6.144000")
 }

--- a/drivers/i2c/adxl345_driver_test.go
+++ b/drivers/i2c/adxl345_driver_test.go
@@ -205,7 +205,7 @@ func TestADXL345RawXYZError(t *testing.T) {
 	// act
 	_, _, _, err := d.RawXYZ()
 	// assert
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 }
 
 func TestADXL345XYZ(t *testing.T) {
@@ -269,7 +269,7 @@ func TestADXL345XYZError(t *testing.T) {
 	// act
 	_, _, _, err := d.XYZ()
 	// assert
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 }
 
 func TestADXL345_initialize(t *testing.T) {

--- a/drivers/i2c/bh1750_driver_test.go
+++ b/drivers/i2c/bh1750_driver_test.go
@@ -96,7 +96,7 @@ func TestBH1750LuxError(t *testing.T) {
 	}
 
 	_, err := d.Lux()
-	assert.Error(t, err, "wrong number of bytes read")
+	assert.ErrorContains(t, err, "wrong number of bytes read")
 }
 
 func TestBH1750RawSensorDataError(t *testing.T) {
@@ -106,5 +106,5 @@ func TestBH1750RawSensorDataError(t *testing.T) {
 	}
 
 	_, err := d.RawSensorData()
-	assert.Error(t, err, "wrong number of bytes read")
+	assert.ErrorContains(t, err, "wrong number of bytes read")
 }

--- a/drivers/i2c/blinkm_driver_test.go
+++ b/drivers/i2c/blinkm_driver_test.go
@@ -125,7 +125,7 @@ func TestBlinkMFirmwareVersion(t *testing.T) {
 	}
 
 	_, err := d.FirmwareVersion()
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }
 
 func TestBlinkMColor(t *testing.T) {
@@ -153,7 +153,7 @@ func TestBlinkMColor(t *testing.T) {
 	}
 
 	_, err := d.Color()
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }
 
 func TestBlinkMFade(t *testing.T) {
@@ -163,7 +163,7 @@ func TestBlinkMFade(t *testing.T) {
 	}
 
 	err := d.Fade(100, 100, 100)
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }
 
 func TestBlinkMRGB(t *testing.T) {
@@ -173,5 +173,5 @@ func TestBlinkMRGB(t *testing.T) {
 	}
 
 	err := d.Rgb(100, 100, 100)
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }

--- a/drivers/i2c/bme280_driver_test.go
+++ b/drivers/i2c/bme280_driver_test.go
@@ -92,7 +92,7 @@ func TestBME280InitH1Error(t *testing.T) {
 		return buf.Len(), nil
 	}
 
-	assert.Error(t, bme280.Start(), "h1 read error")
+	assert.ErrorContains(t, bme280.Start(), "h1 read error")
 }
 
 func TestBME280InitH2Error(t *testing.T) {
@@ -111,7 +111,7 @@ func TestBME280InitH2Error(t *testing.T) {
 		return buf.Len(), nil
 	}
 
-	assert.Error(t, bme280.Start(), "h2 read error")
+	assert.ErrorContains(t, bme280.Start(), "h2 read error")
 }
 
 func TestBME280HumidityWriteError(t *testing.T) {
@@ -122,7 +122,7 @@ func TestBME280HumidityWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	hum, err := bme280.Humidity()
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 	assert.Equal(t, float32(0.0), hum)
 }
 
@@ -134,7 +134,7 @@ func TestBME280HumidityReadError(t *testing.T) {
 		return 0, errors.New("read error")
 	}
 	hum, err := bme280.Humidity()
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 	assert.Equal(t, float32(0.0), hum)
 }
 
@@ -159,7 +159,7 @@ func TestBME280HumidityNotEnabled(t *testing.T) {
 	}
 	_ = bme280.Start()
 	hum, err := bme280.Humidity()
-	assert.Error(t, err, "Humidity disabled")
+	assert.ErrorContains(t, err, "Humidity disabled")
 	assert.Equal(t, float32(0.0), hum)
 }
 

--- a/drivers/i2c/bmp180_driver_test.go
+++ b/drivers/i2c/bmp180_driver_test.go
@@ -108,7 +108,7 @@ func TestBMP180TemperatureError(t *testing.T) {
 	}
 	_ = bmp180.Start()
 	_, err := bmp180.Temperature()
-	assert.Error(t, err, "temp error")
+	assert.ErrorContains(t, err, "temp error")
 }
 
 func TestBMP180PressureError(t *testing.T) {
@@ -138,7 +138,7 @@ func TestBMP180PressureError(t *testing.T) {
 	}
 	_ = bmp180.Start()
 	_, err := bmp180.Pressure()
-	assert.Error(t, err, "press error")
+	assert.ErrorContains(t, err, "press error")
 }
 
 func TestBMP180PressureWriteError(t *testing.T) {
@@ -150,7 +150,7 @@ func TestBMP180PressureWriteError(t *testing.T) {
 	}
 
 	_, err := bmp180.Pressure()
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }
 
 func TestBMP180_initialization(t *testing.T) {

--- a/drivers/i2c/bmp280_driver_test.go
+++ b/drivers/i2c/bmp280_driver_test.go
@@ -106,7 +106,7 @@ func TestBMP280TemperatureWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	temp, err := d.Temperature()
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 	assert.Equal(t, float32(0.0), temp)
 }
 
@@ -118,7 +118,7 @@ func TestBMP280TemperatureReadError(t *testing.T) {
 		return 0, errors.New("read error")
 	}
 	temp, err := d.Temperature()
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 	assert.Equal(t, float32(0.0), temp)
 }
 
@@ -130,7 +130,7 @@ func TestBMP280PressureWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	press, err := d.Pressure()
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 	assert.Equal(t, float32(0.0), press)
 }
 
@@ -142,7 +142,7 @@ func TestBMP280PressureReadError(t *testing.T) {
 		return 0, errors.New("read error")
 	}
 	press, err := d.Pressure()
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 	assert.Equal(t, float32(0.0), press)
 }
 

--- a/drivers/i2c/bmp388_driver_test.go
+++ b/drivers/i2c/bmp388_driver_test.go
@@ -102,7 +102,7 @@ func TestBMP388TemperatureWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	temp, err := d.Temperature(2)
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 	assert.Equal(t, float32(0.0), temp)
 }
 
@@ -114,7 +114,7 @@ func TestBMP388TemperatureReadError(t *testing.T) {
 		return 0, errors.New("read error")
 	}
 	temp, err := d.Temperature(2)
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 	assert.Equal(t, float32(0.0), temp)
 }
 
@@ -126,7 +126,7 @@ func TestBMP388PressureWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	press, err := d.Pressure(2)
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 	assert.Equal(t, float32(0.0), press)
 }
 
@@ -138,7 +138,7 @@ func TestBMP388PressureReadError(t *testing.T) {
 		return 0, errors.New("read error")
 	}
 	press, err := d.Pressure(2)
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 	assert.Equal(t, float32(0.0), press)
 }
 

--- a/drivers/i2c/drv2605l_driver_test.go
+++ b/drivers/i2c/drv2605l_driver_test.go
@@ -110,7 +110,7 @@ func TestDRV2605LSetModeReadError(t *testing.T) {
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		return 0, errors.New("read error")
 	}
-	assert.Error(t, d.SetMode(DRV2605ModeIntTrig), "read error")
+	assert.ErrorContains(t, d.SetMode(DRV2605ModeIntTrig), "read error")
 }
 
 func TestDRV2605LSetStandbyMode(t *testing.T) {
@@ -123,7 +123,7 @@ func TestDRV2605LSetStandbyModeReadError(t *testing.T) {
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		return 0, errors.New("read error")
 	}
-	assert.Error(t, d.SetStandbyMode(true), "read error")
+	assert.ErrorContains(t, d.SetStandbyMode(true), "read error")
 }
 
 func TestDRV2605LSelectLibrary(t *testing.T) {

--- a/drivers/i2c/hmc6352_driver_test.go
+++ b/drivers/i2c/hmc6352_driver_test.go
@@ -80,7 +80,7 @@ func TestHMC6352Heading(t *testing.T) {
 
 	heading, err = d.Heading()
 	assert.Equal(t, uint16(0), heading)
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 
 	// when write error
 	d, a = initTestHMC6352DriverWithStubbedAdaptor()
@@ -90,5 +90,5 @@ func TestHMC6352Heading(t *testing.T) {
 
 	heading, err = d.Heading()
 	assert.Equal(t, uint16(0), heading)
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }

--- a/drivers/i2c/i2c_connection_test.go
+++ b/drivers/i2c/i2c_connection_test.go
@@ -87,7 +87,7 @@ func TestI2CRead(t *testing.T) {
 func TestI2CReadAddressError(t *testing.T) {
 	c := NewConnection(initI2CDeviceAddressError(), 0x06)
 	_, err := c.Read([]byte{})
-	assert.Error(t, err, "Setting address failed with syscall.Errno operation not permitted")
+	assert.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
 }
 
 func TestI2CWrite(t *testing.T) {
@@ -99,7 +99,7 @@ func TestI2CWrite(t *testing.T) {
 func TestI2CWriteAddressError(t *testing.T) {
 	c := NewConnection(initI2CDeviceAddressError(), 0x06)
 	_, err := c.Write([]byte{0x01})
-	assert.Error(t, err, "Setting address failed with syscall.Errno operation not permitted")
+	assert.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
 }
 
 func TestI2CReadByte(t *testing.T) {
@@ -111,7 +111,7 @@ func TestI2CReadByte(t *testing.T) {
 func TestI2CReadByteAddressError(t *testing.T) {
 	c := NewConnection(initI2CDeviceAddressError(), 0x06)
 	_, err := c.ReadByte()
-	assert.Error(t, err, "Setting address failed with syscall.Errno operation not permitted")
+	assert.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
 }
 
 func TestI2CReadByteData(t *testing.T) {
@@ -123,7 +123,7 @@ func TestI2CReadByteData(t *testing.T) {
 func TestI2CReadByteDataAddressError(t *testing.T) {
 	c := NewConnection(initI2CDeviceAddressError(), 0x06)
 	_, err := c.ReadByteData(0x01)
-	assert.Error(t, err, "Setting address failed with syscall.Errno operation not permitted")
+	assert.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
 }
 
 func TestI2CReadWordData(t *testing.T) {
@@ -135,7 +135,7 @@ func TestI2CReadWordData(t *testing.T) {
 func TestI2CReadWordDataAddressError(t *testing.T) {
 	c := NewConnection(initI2CDeviceAddressError(), 0x06)
 	_, err := c.ReadWordData(0x01)
-	assert.Error(t, err, "Setting address failed with syscall.Errno operation not permitted")
+	assert.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
 }
 
 func TestI2CWriteByte(t *testing.T) {
@@ -147,7 +147,7 @@ func TestI2CWriteByte(t *testing.T) {
 func TestI2CWriteByteAddressError(t *testing.T) {
 	c := NewConnection(initI2CDeviceAddressError(), 0x06)
 	err := c.WriteByte(0x01)
-	assert.Error(t, err, "Setting address failed with syscall.Errno operation not permitted")
+	assert.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
 }
 
 func TestI2CWriteByteData(t *testing.T) {
@@ -159,7 +159,7 @@ func TestI2CWriteByteData(t *testing.T) {
 func TestI2CWriteByteDataAddressError(t *testing.T) {
 	c := NewConnection(initI2CDeviceAddressError(), 0x06)
 	err := c.WriteByteData(0x01, 0x01)
-	assert.Error(t, err, "Setting address failed with syscall.Errno operation not permitted")
+	assert.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
 }
 
 func TestI2CWriteWordData(t *testing.T) {
@@ -171,7 +171,7 @@ func TestI2CWriteWordData(t *testing.T) {
 func TestI2CWriteWordDataAddressError(t *testing.T) {
 	c := NewConnection(initI2CDeviceAddressError(), 0x06)
 	err := c.WriteWordData(0x01, 0x01)
-	assert.Error(t, err, "Setting address failed with syscall.Errno operation not permitted")
+	assert.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
 }
 
 func TestI2CWriteBlockData(t *testing.T) {
@@ -183,7 +183,7 @@ func TestI2CWriteBlockData(t *testing.T) {
 func TestI2CWriteBlockDataAddressError(t *testing.T) {
 	c := NewConnection(initI2CDeviceAddressError(), 0x06)
 	err := c.WriteBlockData(0x01, []byte{0x01, 0x02})
-	assert.Error(t, err, "Setting address failed with syscall.Errno operation not permitted")
+	assert.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
 }
 
 func Test_setBit(t *testing.T) {

--- a/drivers/i2c/i2c_driver_test.go
+++ b/drivers/i2c/i2c_driver_test.go
@@ -70,7 +70,7 @@ func TestStartConnectError(t *testing.T) {
 	d, a := initDriverWithStubbedAdaptor()
 	a.Testi2cConnectErr(true)
 	// act, assert
-	assert.Error(t, d.Start(), "Invalid i2c connection")
+	assert.ErrorContains(t, d.Start(), "Invalid i2c connection")
 }
 
 func TestHalt(t *testing.T) {

--- a/drivers/i2c/ina3221_driver_test.go
+++ b/drivers/i2c/ina3221_driver_test.go
@@ -70,7 +70,7 @@ func TestINA3221GetBusVoltageReadError(t *testing.T) {
 	}
 
 	_, err := d.GetBusVoltage(INA3221Channel1)
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 }
 
 func TestINA3221GetShuntVoltage(t *testing.T) {
@@ -93,7 +93,7 @@ func TestINA3221GetShuntVoltageReadError(t *testing.T) {
 	}
 
 	_, err := d.GetShuntVoltage(INA3221Channel1)
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 }
 
 func TestINA3221GetCurrent(t *testing.T) {
@@ -116,7 +116,7 @@ func TestINA3221CurrentReadError(t *testing.T) {
 	}
 
 	_, err := d.GetCurrent(INA3221Channel1)
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 }
 
 func TestINA3221GetLoadVoltage(t *testing.T) {
@@ -141,5 +141,5 @@ func TestINA3221GetLoadVoltageReadError(t *testing.T) {
 	}
 
 	_, err := d.GetLoadVoltage(INA3221Channel2)
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 }

--- a/drivers/i2c/jhd1313m1_driver_test.go
+++ b/drivers/i2c/jhd1313m1_driver_test.go
@@ -60,7 +60,7 @@ func TestJHD1313MDriverStart(t *testing.T) {
 func TestJHD1313MStartConnectError(t *testing.T) {
 	d, adaptor := initTestJHD1313M1DriverWithStubbedAdaptor()
 	adaptor.Testi2cConnectErr(true)
-	assert.Error(t, d.Start(), "Invalid i2c connection")
+	assert.ErrorContains(t, d.Start(), "Invalid i2c connection")
 }
 
 func TestJHD1313MDriverStartWriteError(t *testing.T) {
@@ -68,7 +68,7 @@ func TestJHD1313MDriverStartWriteError(t *testing.T) {
 	adaptor.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
-	assert.Error(t, d.Start(), "write error")
+	assert.ErrorContains(t, d.Start(), "write error")
 }
 
 func TestJHD1313MDriverHalt(t *testing.T) {
@@ -90,7 +90,7 @@ func TestJHD1313MDriverSetRgbError(t *testing.T) {
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
-	assert.Error(t, d.SetRGB(0x00, 0x00, 0x00), "write error")
+	assert.ErrorContains(t, d.SetRGB(0x00, 0x00, 0x00), "write error")
 }
 
 func TestJHD1313MDriverClear(t *testing.T) {
@@ -106,7 +106,7 @@ func TestJHD1313MDriverClearError(t *testing.T) {
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
-	assert.Error(t, d.Clear(), "write error")
+	assert.ErrorContains(t, d.Clear(), "write error")
 }
 
 func TestJHD1313MDriverHome(t *testing.T) {
@@ -128,7 +128,7 @@ func TestJHD1313MDriverWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 
-	assert.Error(t, d.Write("Hello"), "write error")
+	assert.ErrorContains(t, d.Write("Hello"), "write error")
 }
 
 func TestJHD1313MDriverWriteTwoLines(t *testing.T) {
@@ -144,7 +144,7 @@ func TestJHD1313MDriverWriteTwoLinesError(t *testing.T) {
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
-	assert.Error(t, d.Write("Hello\nthere"), "write error")
+	assert.ErrorContains(t, d.Write("Hello\nthere"), "write error")
 }
 
 func TestJHD1313MDriverSetPosition(t *testing.T) {
@@ -189,7 +189,7 @@ func TestJHD1313MDriverSetCustomCharError(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	data := [8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 	_ = d.Start()
-	assert.Error(t, d.SetCustomChar(10, data), "can't set a custom character at a position greater than 7")
+	assert.ErrorContains(t, d.SetCustomChar(10, data), "can't set a custom character at a position greater than 7")
 }
 
 func TestJHD1313MDriverSetCustomCharWriteError(t *testing.T) {
@@ -200,7 +200,7 @@ func TestJHD1313MDriverSetCustomCharWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	data := [8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
-	assert.Error(t, d.SetCustomChar(0, data), "write error")
+	assert.ErrorContains(t, d.SetCustomChar(0, data), "write error")
 }
 
 func TestJHD1313MDriverCommands(t *testing.T) {

--- a/drivers/i2c/l3gd20h_driver_test.go
+++ b/drivers/i2c/l3gd20h_driver_test.go
@@ -214,7 +214,7 @@ func TestL3GD20HMeasurementError(t *testing.T) {
 
 	_ = d.Start()
 	_, _, _, err := d.XYZ()
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 }
 
 func TestL3GD20HMeasurementWriteError(t *testing.T) {
@@ -223,7 +223,7 @@ func TestL3GD20HMeasurementWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	_, _, _, err := d.XYZ()
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }
 
 func TestL3GD20H_initialize(t *testing.T) {

--- a/drivers/i2c/lidarlite_driver_test.go
+++ b/drivers/i2c/lidarlite_driver_test.go
@@ -93,7 +93,7 @@ func TestLIDARLiteDriverDistance(t *testing.T) {
 
 	distance, err = d.Distance()
 	assert.Equal(t, int(0), distance)
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 }
 
 func TestLIDARLiteDriverDistanceError1(t *testing.T) {
@@ -104,7 +104,7 @@ func TestLIDARLiteDriverDistanceError1(t *testing.T) {
 
 	distance, err := d.Distance()
 	assert.Equal(t, int(0), distance)
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }
 
 func TestLIDARLiteDriverDistanceError2(t *testing.T) {
@@ -118,7 +118,7 @@ func TestLIDARLiteDriverDistanceError2(t *testing.T) {
 
 	distance, err := d.Distance()
 	assert.Equal(t, int(0), distance)
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }
 
 func TestLIDARLiteDriverDistanceError3(t *testing.T) {
@@ -138,5 +138,5 @@ func TestLIDARLiteDriverDistanceError3(t *testing.T) {
 
 	distance, err := d.Distance()
 	assert.Equal(t, int(0), distance)
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }

--- a/drivers/i2c/mcp23017_driver_test.go
+++ b/drivers/i2c/mcp23017_driver_test.go
@@ -241,7 +241,7 @@ func TestMCP23017CommandsWriteGPIOErrIODIR(t *testing.T) {
 	// act
 	err := d.WriteGPIO(7, "A", 0)
 	// assert
-	assert.Error(t, err, "MCP write-read: MCP write-ReadByteData(reg=0): write error")
+	assert.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=0): write error")
 }
 
 func TestMCP23017CommandsWriteGPIOErrOLAT(t *testing.T) {
@@ -258,7 +258,7 @@ func TestMCP23017CommandsWriteGPIOErrOLAT(t *testing.T) {
 	// act
 	err := d.WriteGPIO(7, "A", 0)
 	// assert
-	assert.Error(t, err, "MCP write-read: MCP write-ReadByteData(reg=20): write error")
+	assert.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=20): write error")
 }
 
 func TestMCP23017ReadGPIO(t *testing.T) {
@@ -381,7 +381,7 @@ func TestMCP23017ReadGPIOErr(t *testing.T) {
 	// act
 	_, err := d.ReadGPIO(7, "A")
 	// assert
-	assert.Error(t, err, "MCP write-read: MCP write-ReadByteData(reg=0): read error")
+	assert.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=0): read error")
 }
 
 func TestMCP23017SetPinMode(t *testing.T) {
@@ -431,7 +431,7 @@ func TestMCP23017SetPinModeErr(t *testing.T) {
 	// act
 	err := d.SetPinMode(7, "A", 0)
 	// assert
-	assert.Error(t, err, "MCP write-read: MCP write-ReadByteData(reg=0): write error")
+	assert.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=0): write error")
 }
 
 func TestMCP23017SetPullUp(t *testing.T) {
@@ -481,7 +481,7 @@ func TestMCP23017SetPullUpErr(t *testing.T) {
 	// act
 	err := d.SetPullUp(7, "A", 0)
 	// assert
-	assert.Error(t, err, "MCP write-read: MCP write-ReadByteData(reg=12): write error")
+	assert.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=12): write error")
 }
 
 func TestMCP23017SetGPIOPolarity(t *testing.T) {
@@ -531,7 +531,7 @@ func TestMCP23017SetGPIOPolarityErr(t *testing.T) {
 	// act
 	err := d.SetGPIOPolarity(7, "A", 0)
 	// assert
-	assert.Error(t, err, "MCP write-read: MCP write-ReadByteData(reg=2): write error")
+	assert.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=2): write error")
 }
 
 func TestMCP23017_write(t *testing.T) {
@@ -553,7 +553,7 @@ func TestMCP23017_write(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	err = d.write(port.IODIR, uint8(7), 0)
-	assert.Error(t, err, "MCP write-read: MCP write-ReadByteData(reg=1): write error")
+	assert.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=1): write error")
 
 	// read error
 	d, a = initTestMCP23017WithStubbedAdaptor(0)
@@ -561,7 +561,7 @@ func TestMCP23017_write(t *testing.T) {
 		return len(b), errors.New("read error")
 	}
 	err = d.write(port.IODIR, uint8(7), 0)
-	assert.Error(t, err, "MCP write-read: MCP write-ReadByteData(reg=1): read error")
+	assert.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=1): read error")
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		return len(b), nil
 	}
@@ -588,7 +588,7 @@ func TestMCP23017_read(t *testing.T) {
 
 	val, err := d.read(port.IODIR)
 	assert.Equal(t, uint8(0), val)
-	assert.Error(t, err, "MCP write-ReadByteData(reg=0): read error")
+	assert.ErrorContains(t, err, "MCP write-ReadByteData(reg=0): read error")
 
 	// read
 	d, a = initTestMCP23017WithStubbedAdaptor(0)

--- a/drivers/i2c/mma7660_driver_test.go
+++ b/drivers/i2c/mma7660_driver_test.go
@@ -90,7 +90,7 @@ func TestMMA7660XYZError(t *testing.T) {
 	}
 
 	_, _, _, err := d.XYZ()
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 }
 
 func TestMMA7660XYZNotReady(t *testing.T) {

--- a/drivers/i2c/mpl115a2_driver_test.go
+++ b/drivers/i2c/mpl115a2_driver_test.go
@@ -101,7 +101,7 @@ func TestMPL115A2ReadDataError(t *testing.T) {
 	}
 	_, err := d.Pressure()
 
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }
 
 func TestMPL115A2_initialization(t *testing.T) {

--- a/drivers/i2c/mpu6050_driver_test.go
+++ b/drivers/i2c/mpu6050_driver_test.go
@@ -124,7 +124,7 @@ func TestMPU6050GetDataReadError(t *testing.T) {
 		return 0, errors.New("read error")
 	}
 
-	assert.Error(t, d.GetData(), "read error")
+	assert.ErrorContains(t, d.GetData(), "read error")
 }
 
 func TestMPU6050GetDataWriteError(t *testing.T) {
@@ -135,7 +135,7 @@ func TestMPU6050GetDataWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 
-	assert.Error(t, d.GetData(), "write error")
+	assert.ErrorContains(t, d.GetData(), "write error")
 }
 
 func TestMPU6050_initialize(t *testing.T) {

--- a/drivers/i2c/pca9685_driver_test.go
+++ b/drivers/i2c/pca9685_driver_test.go
@@ -87,7 +87,7 @@ func TestPCA9685SetPWMError(t *testing.T) {
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
-	assert.Error(t, d.SetPWM(0, 0, 256), "write error")
+	assert.ErrorContains(t, d.SetPWM(0, 0, 256), "write error")
 }
 
 func TestPCA9685SetPWMFreq(t *testing.T) {
@@ -116,7 +116,7 @@ func TestPCA9685SetPWMFreqReadError(t *testing.T) {
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		return 0, errors.New("read error")
 	}
-	assert.Error(t, d.SetPWMFreq(60), "read error")
+	assert.ErrorContains(t, d.SetPWMFreq(60), "read error")
 }
 
 func TestPCA9685SetPWMFreqWriteError(t *testing.T) {
@@ -130,7 +130,7 @@ func TestPCA9685SetPWMFreqWriteError(t *testing.T) {
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
-	assert.Error(t, d.SetPWMFreq(60), "write error")
+	assert.ErrorContains(t, d.SetPWMFreq(60), "write error")
 }
 
 func TestPCA9685Commands(t *testing.T) {

--- a/drivers/i2c/sht2x_driver_test.go
+++ b/drivers/i2c/sht2x_driver_test.go
@@ -116,7 +116,7 @@ func TestSHT2xTemperatureCrcError(t *testing.T) {
 		return buf.Len(), nil
 	}
 	temp, err := d.Temperature()
-	assert.Error(t, err, "Invalid crc")
+	assert.ErrorContains(t, err, "Invalid crc")
 	assert.Equal(t, float32(0.0), temp)
 }
 
@@ -133,7 +133,7 @@ func TestSHT2xHumidityCrcError(t *testing.T) {
 		return buf.Len(), nil
 	}
 	hum, err := d.Humidity()
-	assert.Error(t, err, "Invalid crc")
+	assert.ErrorContains(t, err, "Invalid crc")
 	assert.Equal(t, float32(0.0), hum)
 }
 

--- a/drivers/i2c/ssd1306_driver_test.go
+++ b/drivers/i2c/ssd1306_driver_test.go
@@ -91,7 +91,7 @@ func TestSSD1306StartSizeError(t *testing.T) {
 	)
 	d := NewSSD1306Driver(newI2cTestAdaptor(),
 		WithSSD1306DisplayWidth(width), WithSSD1306DisplayHeight(height), WithSSD1306ExternalVCC(externalVCC))
-	assert.Error(t, d.Start(), "128x54 resolution is unsupported, supported resolutions: 128x64, 128x32, 96x16")
+	assert.ErrorContains(t, d.Start(), "128x54 resolution is unsupported, supported resolutions: 128x64, 128x32, 96x16")
 }
 
 func TestSSD1306Halt(t *testing.T) {
@@ -116,7 +116,7 @@ func TestSSD1306ShowImage(t *testing.T) {
 	s, _ := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
 	_ = s.Start()
 	img := image.NewRGBA(image.Rect(0, 0, 640, 480))
-	assert.Error(t, s.ShowImage(img), "image must match display width and height: 128x64")
+	assert.ErrorContains(t, s.ShowImage(img), "image must match display width and height: 128x64")
 
 	img = image.NewRGBA(image.Rect(0, 0, 128, 64))
 	assert.Nil(t, s.ShowImage(img))

--- a/drivers/i2c/tsl2561_driver_test.go
+++ b/drivers/i2c/tsl2561_driver_test.go
@@ -72,7 +72,7 @@ func TestTSL2561DriverStartNotFound(t *testing.T) {
 		copy(b, buf.Bytes())
 		return buf.Len(), nil
 	}
-	assert.Error(t, d.Start(), "TSL2561 device not found (0x1)")
+	assert.ErrorContains(t, d.Start(), "TSL2561 device not found (0x1)")
 }
 
 func TestTSL2561DriverHalt(t *testing.T) {
@@ -157,7 +157,7 @@ func TestTSL2561DriverGetDataWriteError(t *testing.T) {
 	}
 
 	_, _, err := d.getData()
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }
 
 func TestTSL2561DriverGetDataReadError(t *testing.T) {
@@ -167,7 +167,7 @@ func TestTSL2561DriverGetDataReadError(t *testing.T) {
 	}
 
 	_, _, err := d.getData()
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 }
 
 func TestTSL2561DriverGetLuminocity(t *testing.T) {
@@ -213,7 +213,7 @@ func TestTSL2561SetIntegrationTimeError(t *testing.T) {
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
-	assert.Error(t, d.SetIntegrationTime(TSL2561IntegrationTime101MS), "write error")
+	assert.ErrorContains(t, d.SetIntegrationTime(TSL2561IntegrationTime101MS), "write error")
 }
 
 func TestTSL2561SetGainError(t *testing.T) {
@@ -221,7 +221,7 @@ func TestTSL2561SetGainError(t *testing.T) {
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
-	assert.Error(t, d.SetGain(TSL2561Gain16X), "write error")
+	assert.ErrorContains(t, d.SetGain(TSL2561Gain16X), "write error")
 }
 
 func TestTSL2561getHiLo13MS(t *testing.T) {

--- a/drivers/spi/mcp3002_test.go
+++ b/drivers/spi/mcp3002_test.go
@@ -87,6 +87,6 @@ func TestMCP3002ReadWithError(t *testing.T) {
 	// act
 	got, err := d.Read(0)
 	// assert
-	assert.Error(t, err, "error while SPI read in mock")
+	assert.ErrorContains(t, err, "error while SPI read in mock")
 	assert.Equal(t, 0, got)
 }

--- a/drivers/spi/mcp3004_test.go
+++ b/drivers/spi/mcp3004_test.go
@@ -93,6 +93,6 @@ func TestMCP3004ReadWithError(t *testing.T) {
 	// act
 	got, err := d.Read(0)
 	// assert
-	assert.Error(t, err, "error while SPI read in mock")
+	assert.ErrorContains(t, err, "error while SPI read in mock")
 	assert.Equal(t, 0, got)
 }

--- a/drivers/spi/mcp3008_test.go
+++ b/drivers/spi/mcp3008_test.go
@@ -93,6 +93,6 @@ func TestMCP3008ReadWithError(t *testing.T) {
 	// act
 	got, err := d.Read(0)
 	// assert
-	assert.Error(t, err, "error while SPI read in mock")
+	assert.ErrorContains(t, err, "error while SPI read in mock")
 	assert.Equal(t, 0, got)
 }

--- a/drivers/spi/mcp3202_test.go
+++ b/drivers/spi/mcp3202_test.go
@@ -87,6 +87,6 @@ func TestMCP3202ReadWithError(t *testing.T) {
 	// act
 	got, err := d.Read(0)
 	// assert
-	assert.Error(t, err, "error while SPI read in mock")
+	assert.ErrorContains(t, err, "error while SPI read in mock")
 	assert.Equal(t, 0, got)
 }

--- a/drivers/spi/mcp3204_test.go
+++ b/drivers/spi/mcp3204_test.go
@@ -93,6 +93,6 @@ func TestMCP3204ReadWithError(t *testing.T) {
 	// act
 	got, err := d.Read(0)
 	// assert
-	assert.Error(t, err, "error while SPI read in mock")
+	assert.ErrorContains(t, err, "error while SPI read in mock")
 	assert.Equal(t, 0, got)
 }

--- a/drivers/spi/mcp3208_test.go
+++ b/drivers/spi/mcp3208_test.go
@@ -93,6 +93,6 @@ func TestMCP3208ReadWithError(t *testing.T) {
 	// act
 	got, err := d.Read(0)
 	// assert
-	assert.Error(t, err, "error while SPI read in mock")
+	assert.ErrorContains(t, err, "error while SPI read in mock")
 	assert.Equal(t, 0, got)
 }

--- a/drivers/spi/mcp3304_test.go
+++ b/drivers/spi/mcp3304_test.go
@@ -93,6 +93,6 @@ func TestMCP3304ReadWithError(t *testing.T) {
 	// act
 	got, err := d.Read(0)
 	// assert
-	assert.Error(t, err, "error while SPI read in mock")
+	assert.ErrorContains(t, err, "error while SPI read in mock")
 	assert.Equal(t, 0, got)
 }

--- a/drivers/spi/ssd1306_driver_test.go
+++ b/drivers/spi/ssd1306_driver_test.go
@@ -38,7 +38,7 @@ func TestSSD1306DriverShowImage(t *testing.T) {
 	d := initTestSSDDriver()
 	_ = d.Start()
 	img := image.NewRGBA(image.Rect(0, 0, 640, 480))
-	assert.Error(t, d.ShowImage(img), "Image must match the display width and height")
+	assert.ErrorContains(t, d.ShowImage(img), "Image must match the display width and height")
 
 	img = image.NewRGBA(image.Rect(0, 0, 128, 64))
 	assert.Nil(t, d.ShowImage(img))

--- a/platforms/adaptors/digitalpinsadaptor_test.go
+++ b/platforms/adaptors/digitalpinsadaptor_test.go
@@ -60,10 +60,10 @@ func TestDigitalPinsConnect(t *testing.T) {
 	assert.Equal(t, (map[string]gobot.DigitalPinner)(nil), a.pins)
 
 	_, err := a.DigitalRead("13")
-	assert.Error(t, err, "not connected for pin 13")
+	assert.ErrorContains(t, err, "not connected for pin 13")
 
 	err = a.DigitalWrite("7", 1)
-	assert.Error(t, err, "not connected for pin 7")
+	assert.ErrorContains(t, err, "not connected for pin 7")
 
 	err = a.Connect()
 	assert.Nil(t, err)
@@ -159,12 +159,12 @@ func TestDigitalRead(t *testing.T) {
 	// assert error bubbling for read errors
 	fs.WithReadError = true
 	_, err = a.DigitalRead("13")
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 
 	// assert error bubbling for write errors
 	fs.WithWriteError = true
 	_, err = a.DigitalRead("7")
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }
 
 func TestDigitalReadWithGpiosActiveLow(t *testing.T) {
@@ -228,12 +228,12 @@ func TestDigitalWrite(t *testing.T) {
 	assert.Nil(t, err)
 
 	// assert error on bad id
-	assert.Error(t, a.DigitalWrite("notexist", 1), "not a valid pin")
+	assert.ErrorContains(t, a.DigitalWrite("notexist", 1), "not a valid pin")
 
 	// assert error bubbling
 	fs.WithWriteError = true
 	err = a.DigitalWrite("7", 0)
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }
 
 func TestDigitalWriteWithGpiosActiveLow(t *testing.T) {

--- a/platforms/adaptors/i2cbusadaptor_test.go
+++ b/platforms/adaptors/i2cbusadaptor_test.go
@@ -61,13 +61,13 @@ func TestI2cGetI2cConnection(t *testing.T) {
 	assert.Equal(t, 1, len(a.buses))
 	// assert invalid bus gets error
 	c2, e2 := a.GetI2cConnection(0x01, 99)
-	assert.Error(t, e2, "99 not valid")
+	assert.ErrorContains(t, e2, "99 not valid")
 	assert.Nil(t, c2)
 	assert.Equal(t, 1, len(a.buses))
 	// assert unconnected gets error
 	assert.Nil(t, a.Finalize())
 	c3, e3 := a.GetI2cConnection(0x01, 99)
-	assert.Error(t, e3, "not connected")
+	assert.ErrorContains(t, e3, "not connected")
 	assert.Nil(t, c3)
 	assert.Equal(t, 0, len(a.buses))
 }

--- a/platforms/adaptors/pwmpinsadaptor_test.go
+++ b/platforms/adaptors/pwmpinsadaptor_test.go
@@ -117,7 +117,7 @@ func TestPWMPinsConnect(t *testing.T) {
 	assert.Equal(t, (map[string]gobot.PWMPinner)(nil), a.pins)
 
 	err := a.PwmWrite("33", 1)
-	assert.Error(t, err, "not connected")
+	assert.ErrorContains(t, err, "not connected")
 
 	err = a.Connect()
 	assert.Nil(t, err)
@@ -186,7 +186,7 @@ func TestPwmWrite(t *testing.T) {
 	assert.Equal(t, "normal", fs.Files[pwmPolarityPath].Contents)
 
 	err = a.PwmWrite("notexist", 42)
-	assert.Error(t, err, "'notexist' is not a valid id of a PWM pin")
+	assert.ErrorContains(t, err, "'notexist' is not a valid id of a PWM pin")
 
 	fs.WithWriteError = true
 	err = a.PwmWrite("33", 100)
@@ -214,7 +214,7 @@ func TestServoWrite(t *testing.T) {
 	assert.Equal(t, "2000000", fs.Files[pwmDutyCyclePath].Contents)
 
 	err = a.ServoWrite("notexist", 42)
-	assert.Error(t, err, "'notexist' is not a valid id of a PWM pin")
+	assert.ErrorContains(t, err, "'notexist' is not a valid id of a PWM pin")
 
 	fs.WithWriteError = true
 	err = a.ServoWrite("33", 100)
@@ -266,7 +266,7 @@ func TestSetPeriod(t *testing.T) {
 	// act
 	err = a.SetPeriod("not_exist", newPeriod)
 	// assert
-	assert.Error(t, err, "'not_exist' is not a valid id of a PWM pin")
+	assert.ErrorContains(t, err, "'not_exist' is not a valid id of a PWM pin")
 }
 
 func Test_PWMPin(t *testing.T) {

--- a/platforms/adaptors/spibusadaptor_test.go
+++ b/platforms/adaptors/spibusadaptor_test.go
@@ -40,7 +40,7 @@ func TestNewSpiAdaptor(t *testing.T) {
 	assert.Equal(t, 4, a.SpiDefaultBitCount())
 	assert.Equal(t, int64(5), a.SpiDefaultMaxSpeed())
 	_, err := a.GetSpiConnection(10, 0, 0, 8, 10000000)
-	assert.Error(t, err, "not connected")
+	assert.ErrorContains(t, err, "not connected")
 }
 
 func TestGetSpiConnection(t *testing.T) {
@@ -73,12 +73,12 @@ func TestGetSpiConnection(t *testing.T) {
 	assert.Equal(t, 2, len(a.connections))
 	// assert bus validation error
 	con, err := a.GetSpiConnection(busNum+1, chipNum, mode, bits, maxSpeed)
-	assert.Error(t, err, "16 not valid")
+	assert.ErrorContains(t, err, "16 not valid")
 	assert.Nil(t, con)
 	// assert create error
 	spi.CreateError = true
 	con, err = a.GetSpiConnection(busNum, chipNum+2, mode, bits, maxSpeed)
-	assert.Error(t, err, "error while create SPI connection in mock")
+	assert.ErrorContains(t, err, "error while create SPI connection in mock")
 	assert.Nil(t, con)
 }
 

--- a/platforms/audio/audio_adaptor_test.go
+++ b/platforms/audio/audio_adaptor_test.go
@@ -40,7 +40,7 @@ func TestAudioAdaptorCommandsMp3(t *testing.T) {
 func TestAudioAdaptorCommandsUnknown(t *testing.T) {
 	cmd, err := CommandName("whatever.unk")
 	assert.NotEqual(t, "mpg123", cmd)
-	assert.Error(t, err, "Unknown filetype for audio file.")
+	assert.ErrorContains(t, err, "Unknown filetype for audio file.")
 }
 
 func TestAudioAdaptorSoundWithNoFilename(t *testing.T) {

--- a/platforms/beaglebone/beaglebone_adaptor_test.go
+++ b/platforms/beaglebone/beaglebone_adaptor_test.go
@@ -58,7 +58,7 @@ func TestPWM(t *testing.T) {
 	fs.Files["/sys/devices/platform/ocp/48300000.epwmss/48300200.pwm/pwm/pwmchip0/pwm1/duty_cycle"].Contents = "0"
 	fs.Files["/sys/devices/platform/ocp/48300000.epwmss/48300200.pwm/pwm/pwmchip0/pwm1/period"].Contents = "0"
 
-	assert.Error(t, a.PwmWrite("P9_99", 175), "'P9_99' is not a valid id for a PWM pin")
+	assert.ErrorContains(t, a.PwmWrite("P9_99", 175), "'P9_99' is not a valid id for a PWM pin")
 	_ = a.PwmWrite("P9_21", 175)
 	assert.Equal(
 		t,
@@ -99,11 +99,11 @@ func TestAnalog(t *testing.T) {
 	assert.Nil(t, err)
 
 	_, err = a.AnalogRead("P9_99")
-	assert.Error(t, err, "Not a valid analog pin")
+	assert.ErrorContains(t, err, "Not a valid analog pin")
 
 	fs.WithReadError = true
 	_, err = a.AnalogRead("P9_40")
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 	fs.WithReadError = false
 
 	assert.Nil(t, a.Finalize())
@@ -138,15 +138,15 @@ func TestDigitalIO(t *testing.T) {
 
 	// no such LED
 	err := a.DigitalWrite("usr10101", 1)
-	assert.Error(t, err, " : /sys/class/leds/beaglebone:green:usr10101/brightness: no such file")
+	assert.ErrorContains(t, err, " : /sys/class/leds/beaglebone:green:usr10101/brightness: no such file")
 
 	_ = a.DigitalWrite("P9_12", 1)
 	assert.Equal(t, "1", fs.Files["/sys/class/gpio/gpio60/value"].Contents)
 
-	assert.Error(t, a.DigitalWrite("P9_99", 1), "'P9_99' is not a valid id for a digital pin")
+	assert.ErrorContains(t, a.DigitalWrite("P9_99", 1), "'P9_99' is not a valid id for a digital pin")
 
 	_, err = a.DigitalRead("P9_99")
-	assert.Error(t, err, "'P9_99' is not a valid id for a digital pin")
+	assert.ErrorContains(t, err, "'P9_99' is not a valid id for a digital pin")
 
 	fs.Files["/sys/class/gpio/gpio66/value"].Contents = "1"
 	i, err := a.DigitalRead("P8_07")

--- a/platforms/chip/chip_adaptor_test.go
+++ b/platforms/chip/chip_adaptor_test.go
@@ -105,7 +105,7 @@ func TestDigitalIO(t *testing.T) {
 	i, _ := a.DigitalRead("TWI2-SDA")
 	assert.Equal(t, 1, i)
 
-	assert.Error(t, a.DigitalWrite("XIO-P10", 1), "'XIO-P10' is not a valid id for a digital pin")
+	assert.ErrorContains(t, a.DigitalWrite("XIO-P10", 1), "'XIO-P10' is not a valid id for a digital pin")
 	assert.Nil(t, a.Finalize())
 }
 
@@ -120,7 +120,7 @@ func TestProDigitalIO(t *testing.T) {
 	i, _ := a.DigitalRead("TWI2-SDA")
 	assert.Equal(t, 1, i)
 
-	assert.Error(t, a.DigitalWrite("XIO-P0", 1), "'XIO-P0' is not a valid id for a digital pin")
+	assert.ErrorContains(t, a.DigitalWrite("XIO-P0", 1), "'XIO-P0' is not a valid id for a digital pin")
 	assert.Nil(t, a.Finalize())
 }
 

--- a/platforms/digispark/digispark_adaptor_test.go
+++ b/platforms/digispark/digispark_adaptor_test.go
@@ -112,7 +112,7 @@ func TestDigisparkAdaptorDigitalWrite(t *testing.T) {
 
 	errorFunc = func() error { return errors.New("pin mode error") }
 	err = a.DigitalWrite("0", uint8(1))
-	assert.Error(t, err, "pin mode error")
+	assert.ErrorContains(t, err, "pin mode error")
 }
 
 func TestDigisparkAdaptorServoWrite(t *testing.T) {
@@ -125,7 +125,7 @@ func TestDigisparkAdaptorServoWrite(t *testing.T) {
 	a = initTestAdaptor()
 	errorFunc = func() error { return errors.New("servo error") }
 	err = a.ServoWrite("2", uint8(80))
-	assert.Error(t, err, "servo error")
+	assert.ErrorContains(t, err, "servo error")
 }
 
 func TestDigisparkAdaptorPwmWrite(t *testing.T) {
@@ -138,10 +138,10 @@ func TestDigisparkAdaptorPwmWrite(t *testing.T) {
 	a = initTestAdaptor()
 	pwmInitErrorFunc = func() error { return errors.New("pwminit error") }
 	err = a.PwmWrite("1", uint8(100))
-	assert.Error(t, err, "pwminit error")
+	assert.ErrorContains(t, err, "pwminit error")
 
 	a = initTestAdaptor()
 	errorFunc = func() error { return errors.New("pwm error") }
 	err = a.PwmWrite("1", uint8(100))
-	assert.Error(t, err, "pwm error")
+	assert.ErrorContains(t, err, "pwm error")
 }

--- a/platforms/digispark/digispark_i2c_test.go
+++ b/platforms/digispark/digispark_i2c_test.go
@@ -57,7 +57,7 @@ func TestDigisparkAdaptorI2cGetI2cConnectionFailWithInvalidBus(t *testing.T) {
 	c, err := a.GetI2cConnection(0x40, 1)
 
 	// assert
-	assert.Error(t, err, "Invalid bus number 1, only 0 is supported")
+	assert.ErrorContains(t, err, "Invalid bus number 1, only 0 is supported")
 	assert.Nil(t, c)
 }
 
@@ -72,7 +72,7 @@ func TestDigisparkAdaptorI2cStartFailWithWrongAddress(t *testing.T) {
 
 	// assert
 	assert.Equal(t, 0, count)
-	assert.Error(t, err, "Invalid address, only %d is supported", availableI2cAddress)
+	assert.ErrorContains(t, err, fmt.Sprintf("Invalid address, only %d is supported", availableI2cAddress))
 	assert.Equal(t, maxUint8, a.littleWire.(*i2cMock).direction)
 }
 

--- a/platforms/dragonboard/dragonboard_adaptor_test.go
+++ b/platforms/dragonboard/dragonboard_adaptor_test.go
@@ -54,7 +54,7 @@ func TestDigitalIO(t *testing.T) {
 	i, _ := a.DigitalRead("GPIO_A")
 	assert.Equal(t, 1, i)
 
-	assert.Error(t, a.DigitalWrite("GPIO_M", 1), "'GPIO_M' is not a valid id for a digital pin")
+	assert.ErrorContains(t, a.DigitalWrite("GPIO_M", 1), "'GPIO_M' is not a valid id for a digital pin")
 	assert.Nil(t, a.Finalize())
 }
 

--- a/platforms/firmata/firmata_adaptor_test.go
+++ b/platforms/firmata/firmata_adaptor_test.go
@@ -115,7 +115,7 @@ func TestAdaptorFinalize(t *testing.T) {
 
 	a = initTestAdaptor()
 	a.Board.(*mockFirmataBoard).disconnectError = errors.New("close error")
-	assert.Error(t, a.Finalize(), "close error")
+	assert.ErrorContains(t, a.Finalize(), "close error")
 }
 
 func TestAdaptorConnect(t *testing.T) {
@@ -132,7 +132,7 @@ func TestAdaptorConnect(t *testing.T) {
 	a.PortOpener = func(port string) (io.ReadWriteCloser, error) {
 		return nil, errors.New("connect error")
 	}
-	assert.Error(t, a.Connect(), "connect error")
+	assert.ErrorContains(t, a.Connect(), "connect error")
 
 	a = NewAdaptor(&readWriteCloser{})
 	a.Board = newMockFirmataBoard()

--- a/platforms/firmata/firmata_i2c_test.go
+++ b/platforms/firmata/firmata_i2c_test.go
@@ -243,5 +243,5 @@ func TestDefaultBus(t *testing.T) {
 func TestGetI2cConnectionInvalidBus(t *testing.T) {
 	a := NewAdaptor()
 	_, err := a.GetI2cConnection(0x01, 99)
-	assert.Error(t, err, "Invalid bus number 99, only 0 is supported")
+	assert.ErrorContains(t, err, "Invalid bus number 99, only 0 is supported")
 }

--- a/platforms/intel-iot/curie/imu_driver_test.go
+++ b/platforms/intel-iot/curie/imu_driver_test.go
@@ -123,7 +123,7 @@ func TestIMUDriverReadAccelerometer(t *testing.T) {
 
 func TestIMUDriverReadAccelerometerData(t *testing.T) {
 	_, err := parseAccelerometerData([]byte{})
-	assert.Error(t, err, "Invalid data")
+	assert.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseAccelerometerData([]byte{0xF0, 0x11, 0x00, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7})
 	assert.Nil(t, err)
@@ -138,7 +138,7 @@ func TestIMUDriverReadGyroscope(t *testing.T) {
 
 func TestIMUDriverReadGyroscopeData(t *testing.T) {
 	_, err := parseGyroscopeData([]byte{})
-	assert.Error(t, err, "Invalid data")
+	assert.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseGyroscopeData([]byte{0xF0, 0x11, 0x01, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7})
 	assert.Nil(t, err)
@@ -153,7 +153,7 @@ func TestIMUDriverReadTemperature(t *testing.T) {
 
 func TestIMUDriverReadTemperatureData(t *testing.T) {
 	_, err := parseTemperatureData([]byte{})
-	assert.Error(t, err, "Invalid data")
+	assert.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseTemperatureData([]byte{0xF0, 0x11, 0x02, 0x00, 0x02, 0x03, 0x04, 0xf7})
 	assert.Nil(t, err)
@@ -168,7 +168,7 @@ func TestIMUDriverEnableShockDetection(t *testing.T) {
 
 func TestIMUDriverShockDetectData(t *testing.T) {
 	_, err := parseShockData([]byte{})
-	assert.Error(t, err, "Invalid data")
+	assert.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseShockData([]byte{0xF0, 0x11, 0x03, 0x00, 0x02, 0xf7})
 	assert.Nil(t, err)
@@ -183,7 +183,7 @@ func TestIMUDriverEnableStepCounter(t *testing.T) {
 
 func TestIMUDriverStepCountData(t *testing.T) {
 	_, err := parseStepData([]byte{})
-	assert.Error(t, err, "Invalid data")
+	assert.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseStepData([]byte{0xF0, 0x11, 0x04, 0x00, 0x02, 0xf7})
 	assert.Nil(t, err)
@@ -198,7 +198,7 @@ func TestIMUDriverEnableTapDetection(t *testing.T) {
 
 func TestIMUDriverTapDetectData(t *testing.T) {
 	_, err := parseTapData([]byte{})
-	assert.Error(t, err, "Invalid data")
+	assert.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseTapData([]byte{0xF0, 0x11, 0x05, 0x00, 0x02, 0xf7})
 	assert.Nil(t, err)
@@ -213,7 +213,7 @@ func TestIMUDriverEnableReadMotion(t *testing.T) {
 
 func TestIMUDriverReadMotionData(t *testing.T) {
 	_, err := parseMotionData([]byte{})
-	assert.Error(t, err, "Invalid data")
+	assert.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseMotionData([]byte{0xF0, 0x11, 0x06, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7})
 	assert.Nil(t, err)

--- a/platforms/intel-iot/edison/edison_adaptor_test.go
+++ b/platforms/intel-iot/edison/edison_adaptor_test.go
@@ -276,7 +276,7 @@ func TestArduinoI2CSetupFailTristate(t *testing.T) {
 
 	fs.WithWriteError = true
 	err := a.arduinoI2CSetup()
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }
 
 func TestArduinoI2CSetupFail14(t *testing.T) {
@@ -453,7 +453,7 @@ func TestDigitalWriteError(t *testing.T) {
 	fs.WithWriteError = true
 
 	err := a.DigitalWrite("13", 1)
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }
 
 func TestDigitalReadWriteError(t *testing.T) {
@@ -461,7 +461,7 @@ func TestDigitalReadWriteError(t *testing.T) {
 	fs.WithWriteError = true
 
 	_, err := a.DigitalRead("13")
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }
 
 func TestPwm(t *testing.T) {
@@ -472,7 +472,7 @@ func TestPwm(t *testing.T) {
 	assert.Equal(t, "1960", fs.Files["/sys/class/pwm/pwmchip0/pwm1/duty_cycle"].Contents)
 
 	err = a.PwmWrite("7", 100)
-	assert.Error(t, err, "'7' is not a valid id for a PWM pin")
+	assert.ErrorContains(t, err, "'7' is not a valid id for a PWM pin")
 }
 
 func TestPwmExportError(t *testing.T) {
@@ -501,7 +501,7 @@ func TestPwmWritePinError(t *testing.T) {
 	fs.WithWriteError = true
 
 	err := a.PwmWrite("5", 100)
-	assert.Error(t, err, "write error")
+	assert.ErrorContains(t, err, "write error")
 }
 
 func TestPwmWriteError(t *testing.T) {
@@ -533,7 +533,7 @@ func TestAnalogError(t *testing.T) {
 	fs.WithReadError = true
 
 	_, err := a.AnalogRead("0")
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 }
 
 func TestI2cWorkflow(t *testing.T) {

--- a/platforms/intel-iot/joule/joule_adaptor_test.go
+++ b/platforms/intel-iot/joule/joule_adaptor_test.go
@@ -133,7 +133,7 @@ func TestDigitalIO(t *testing.T) {
 	assert.Equal(t, 0, i)
 
 	_, err = a.DigitalRead("P9_99")
-	assert.Error(t, err, "'P9_99' is not a valid id for a digital pin")
+	assert.ErrorContains(t, err, "'P9_99' is not a valid id for a digital pin")
 }
 
 func TestPwm(t *testing.T) {
@@ -144,10 +144,10 @@ func TestPwm(t *testing.T) {
 	assert.Equal(t, "3921568", fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents)
 
 	err = a.PwmWrite("4", 100)
-	assert.Error(t, err, "'4' is not a valid id for a pin")
+	assert.ErrorContains(t, err, "'4' is not a valid id for a pin")
 
 	err = a.PwmWrite("J12_1", 100)
-	assert.Error(t, err, "'J12_1' is not a valid id for a PWM pin")
+	assert.ErrorContains(t, err, "'J12_1' is not a valid id for a PWM pin")
 }
 
 func TestPwmPinExportError(t *testing.T) {

--- a/platforms/jetson/jetson_adaptor_test.go
+++ b/platforms/jetson/jetson_adaptor_test.go
@@ -67,7 +67,7 @@ func TestPWMPinsConnect(t *testing.T) {
 	assert.Equal(t, (map[string]gobot.PWMPinner)(nil), a.pwmPins)
 
 	err := a.PwmWrite("33", 1)
-	assert.Error(t, err, "not connected")
+	assert.ErrorContains(t, err, "not connected")
 
 	err = a.Connect()
 	assert.Nil(t, err)
@@ -117,7 +117,7 @@ func TestDigitalIO(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, i)
 
-	assert.Error(t, a.DigitalWrite("notexist", 1), "'notexist' is not a valid id for a digital pin")
+	assert.ErrorContains(t, a.DigitalWrite("notexist", 1), "'notexist' is not a valid id for a digital pin")
 	assert.Nil(t, a.Finalize())
 }
 

--- a/platforms/jetson/pwm_pin_test.go
+++ b/platforms/jetson/pwm_pin_test.go
@@ -50,15 +50,15 @@ func TestPwmPin(t *testing.T) {
 	assert.True(t, val)
 
 	_, err := pin.Period()
-	assert.Error(t, err, "Jetson PWM pin period not set")
-	assert.Error(t, pin.SetDutyCycle(10000), "Jetson PWM pin period not set")
+	assert.ErrorContains(t, err, "Jetson PWM pin period not set")
+	assert.ErrorContains(t, pin.SetDutyCycle(10000), "Jetson PWM pin period not set")
 	assert.Equal(t, "", fs.Files[dutyCyclePath].Contents)
 
 	assert.Nil(t, pin.SetPeriod(20000000))
 	// TODO: see PR #990 assert.Equal(t, "20000000", fs.Files[periodPath].Contents)
 	period, _ := pin.Period()
 	assert.Equal(t, uint32(20000000), period)
-	assert.Error(t, pin.SetPeriod(10000000), "Cannot set the period of individual PWM pins on Jetson")
+	assert.ErrorContains(t, pin.SetPeriod(10000000), "Cannot set the period of individual PWM pins on Jetson")
 	// TODO: see PR #990 assert.Equal(t, "20000000", fs.Files[periodPath].Contents)
 
 	dc, _ := pin.DutyCycle()
@@ -69,7 +69,7 @@ func TestPwmPin(t *testing.T) {
 	dc, _ = pin.DutyCycle()
 	assert.Equal(t, uint32(10000), dc)
 
-	assert.Error(t, pin.SetDutyCycle(999999999), "Duty cycle exceeds period")
+	assert.ErrorContains(t, pin.SetDutyCycle(999999999), "Duty cycle exceeds period")
 	dc, _ = pin.DutyCycle()
 	assert.Equal(t, "10000", fs.Files[dutyCyclePath].Contents)
 	assert.Equal(t, uint32(10000), dc)

--- a/platforms/leap/leap_motion_adaptor_test.go
+++ b/platforms/leap/leap_motion_adaptor_test.go
@@ -37,7 +37,7 @@ func TestLeapMotionAdaptorConnect(t *testing.T) {
 	a.connect = func(port string) (io.ReadWriteCloser, error) {
 		return nil, errors.New("connection error")
 	}
-	assert.Error(t, a.Connect(), "connection error")
+	assert.ErrorContains(t, a.Connect(), "connection error")
 }
 
 func TestLeapMotionAdaptorFinalize(t *testing.T) {

--- a/platforms/mavlink/mavlink_adaptor_test.go
+++ b/platforms/mavlink/mavlink_adaptor_test.go
@@ -69,7 +69,7 @@ func TestMavlinkAdaptorConnect(t *testing.T) {
 	assert.Nil(t, a.Connect())
 
 	a.connect = func(port string) (io.ReadWriteCloser, error) { return nil, errors.New("connect error") }
-	assert.Error(t, a.Connect(), "connect error")
+	assert.ErrorContains(t, a.Connect(), "connect error")
 }
 
 func TestMavlinkAdaptorFinalize(t *testing.T) {
@@ -79,5 +79,5 @@ func TestMavlinkAdaptorFinalize(t *testing.T) {
 	testAdaptorClose = func() error {
 		return errors.New("close error")
 	}
-	assert.Error(t, a.Finalize(), "close error")
+	assert.ErrorContains(t, a.Finalize(), "close error")
 }

--- a/platforms/mavlink/mavlink_udp_adaptor_test.go
+++ b/platforms/mavlink/mavlink_udp_adaptor_test.go
@@ -136,5 +136,5 @@ func TestMavlinkReadMAVLinkPacketReadError(t *testing.T) {
 	a.sock = m
 
 	_, err := a.ReadMAVLinkPacket()
-	assert.Error(t, err, "read error")
+	assert.ErrorContains(t, err, "read error")
 }

--- a/platforms/microbit/io_pin_driver_test.go
+++ b/platforms/microbit/io_pin_driver_test.go
@@ -49,7 +49,7 @@ func TestIOPinDriverStartError(t *testing.T) {
 	a.TestReadCharacteristic(func(cUUID string) ([]byte, error) {
 		return nil, errors.New("read error")
 	})
-	assert.Error(t, d.Start(), "read error")
+	assert.ErrorContains(t, d.Start(), "read error")
 }
 
 func TestIOPinDriverDigitalRead(t *testing.T) {
@@ -74,7 +74,7 @@ func TestIOPinDriverDigitalReadInvalidPin(t *testing.T) {
 	assert.NotNil(t, err)
 
 	_, err = d.DigitalRead("6")
-	assert.Error(t, err, "Invalid pin.")
+	assert.ErrorContains(t, err, "Invalid pin.")
 }
 
 func TestIOPinDriverDigitalWrite(t *testing.T) {
@@ -90,7 +90,7 @@ func TestIOPinDriverDigitalWriteInvalidPin(t *testing.T) {
 	d := NewIOPinDriver(a)
 
 	assert.NotNil(t, d.DigitalWrite("A3", 1))
-	assert.Error(t, d.DigitalWrite("6", 1), "Invalid pin.")
+	assert.ErrorContains(t, d.DigitalWrite("6", 1), "Invalid pin.")
 }
 
 func TestIOPinDriverAnalogRead(t *testing.T) {
@@ -115,7 +115,7 @@ func TestIOPinDriverAnalogReadInvalidPin(t *testing.T) {
 	assert.NotNil(t, err)
 
 	_, err = d.AnalogRead("6")
-	assert.Error(t, err, "Invalid pin.")
+	assert.ErrorContains(t, err, "Invalid pin.")
 }
 
 func TestIOPinDriverDigitalAnalogRead(t *testing.T) {

--- a/platforms/mqtt/mqtt_adaptor_test.go
+++ b/platforms/mqtt/mqtt_adaptor_test.go
@@ -85,7 +85,7 @@ func TestMqttAdaptorConnectSSLError(t *testing.T) {
 
 func TestMqttAdaptorConnectWithAuthError(t *testing.T) {
 	a := NewAdaptorWithAuth("xyz://localhost:1883", "client", "user", "pass")
-	assert.Error(t, a.Connect(), "network Error : unknown protocol")
+	assert.ErrorContains(t, a.Connect(), "network Error : unknown protocol")
 }
 
 func TestMqttAdaptorFinalize(t *testing.T) {

--- a/platforms/nanopi/nanopi_adaptor_test.go
+++ b/platforms/nanopi/nanopi_adaptor_test.go
@@ -92,7 +92,7 @@ func TestDigitalIO(t *testing.T) {
 	i, _ := a.DigitalRead("10")
 	assert.Equal(t, 1, i)
 
-	assert.Error(t, a.DigitalWrite("99", 1), "'99' is not a valid id for a digital pin")
+	assert.ErrorContains(t, a.DigitalWrite("99", 1), "'99' is not a valid id for a digital pin")
 	assert.Nil(t, a.Finalize())
 }
 
@@ -101,16 +101,16 @@ func TestInvalidPWMPin(t *testing.T) {
 	preparePwmFs(fs)
 
 	err := a.PwmWrite("666", 42)
-	assert.Error(t, err, "'666' is not a valid id for a PWM pin")
+	assert.ErrorContains(t, err, "'666' is not a valid id for a PWM pin")
 
 	err = a.ServoWrite("666", 120)
-	assert.Error(t, err, "'666' is not a valid id for a PWM pin")
+	assert.ErrorContains(t, err, "'666' is not a valid id for a PWM pin")
 
 	err = a.PwmWrite("3", 42)
-	assert.Error(t, err, "'3' is not a valid id for a PWM pin")
+	assert.ErrorContains(t, err, "'3' is not a valid id for a PWM pin")
 
 	err = a.ServoWrite("3", 120)
-	assert.Error(t, err, "'3' is not a valid id for a PWM pin")
+	assert.ErrorContains(t, err, "'3' is not a valid id for a PWM pin")
 }
 
 func TestPwmWrite(t *testing.T) {

--- a/platforms/nats/nats_adaptor_test.go
+++ b/platforms/nats/nats_adaptor_test.go
@@ -148,7 +148,7 @@ func TestNatsAdaptorFailedConnect(t *testing.T) {
 	if err != nil && strings.Contains(err.Error(), "cannot assign requested address") {
 		t.Skip("FLAKY: Can not test, because IP or port is in use.")
 	}
-	assert.Error(t, err, "nats: no servers available for connection")
+	assert.ErrorContains(t, err, "nats: no servers available for connection")
 }
 
 func TestNatsAdaptorFinalize(t *testing.T) {

--- a/platforms/neurosky/neurosky_adaptor_test.go
+++ b/platforms/neurosky/neurosky_adaptor_test.go
@@ -74,7 +74,7 @@ func TestNeuroskyAdaptorConnect(t *testing.T) {
 	a.connect = func(n *Adaptor) (io.ReadWriteCloser, error) {
 		return nil, errors.New("connection error")
 	}
-	assert.Error(t, a.Connect(), "connection error")
+	assert.ErrorContains(t, a.Connect(), "connection error")
 }
 
 func TestNeuroskyAdaptorFinalize(t *testing.T) {
@@ -88,5 +88,5 @@ func TestNeuroskyAdaptorFinalize(t *testing.T) {
 
 	rwc.CloseError(errors.New("close error"))
 	_ = a.Connect()
-	assert.Error(t, a.Finalize(), "close error")
+	assert.ErrorContains(t, a.Finalize(), "close error")
 }

--- a/platforms/parrot/ardrone/ardrone_adaptor_test.go
+++ b/platforms/parrot/ardrone/ardrone_adaptor_test.go
@@ -34,7 +34,7 @@ func TestArdroneAdaptorConnect(t *testing.T) {
 	a.connect = func(a *Adaptor) (drone, error) {
 		return nil, errors.New("connection error")
 	}
-	assert.Error(t, a.Connect(), "connection error")
+	assert.ErrorContains(t, a.Connect(), "connection error")
 }
 
 func TestArdroneAdaptorName(t *testing.T) {

--- a/platforms/parrot/bebop/bebop_adaptor_test.go
+++ b/platforms/parrot/bebop/bebop_adaptor_test.go
@@ -34,7 +34,7 @@ func TestBebopAdaptorConnect(t *testing.T) {
 	a.connect = func(a *Adaptor) error {
 		return errors.New("connection error")
 	}
-	assert.Error(t, a.Connect(), "connection error")
+	assert.ErrorContains(t, a.Connect(), "connection error")
 }
 
 func TestBebopAdaptorFinalize(t *testing.T) {

--- a/platforms/particle/adaptor_test.go
+++ b/platforms/particle/adaptor_test.go
@@ -254,7 +254,7 @@ func TestAdaptorFunction(t *testing.T) {
 	a.setAPIServer(testServer.URL)
 
 	_, err := a.Function("hello", "")
-	assert.Error(t, err, "timeout")
+	assert.ErrorContains(t, err, "timeout")
 
 	testServer.Close()
 }
@@ -309,7 +309,7 @@ func TestAdaptorVariable(t *testing.T) {
 	a.setAPIServer(testServer.URL)
 
 	_, err := a.Variable("not_existent")
-	assert.Error(t, err, "Variable not found")
+	assert.ErrorContains(t, err, "Variable not found")
 
 	testServer.Close()
 }
@@ -386,14 +386,14 @@ func TestAdaptorEventStream(t *testing.T) {
 	assert.Equal(t, "https://api.particle.io/v1/devices/myDevice/events/ping?access_token=token", url)
 
 	_, err := a.EventStream("nothing", "ping")
-	assert.Error(t, err, "source param should be: all, devices or device")
+	assert.ErrorContains(t, err, "source param should be: all, devices or device")
 
 	eventSource = func(u string) (chan eventsource.Event, chan error, error) {
 		return nil, nil, errors.New("error connecting sse")
 	}
 
 	_, err = a.EventStream("devices", "")
-	assert.Error(t, err, "error connecting sse")
+	assert.ErrorContains(t, err, "error connecting sse")
 
 	eventChan := make(chan eventsource.Event)
 	errorChan := make(chan error)

--- a/platforms/raspi/pwm_pin_test.go
+++ b/platforms/raspi/pwm_pin_test.go
@@ -29,13 +29,13 @@ func TestPwmPin(t *testing.T) {
 	assert.True(t, val)
 
 	_, err := pin.Period()
-	assert.Error(t, err, "Raspi PWM pin period not set")
-	assert.Error(t, pin.SetDutyCycle(10000), "Raspi PWM pin period not set")
+	assert.ErrorContains(t, err, "Raspi PWM pin period not set")
+	assert.ErrorContains(t, pin.SetDutyCycle(10000), "Raspi PWM pin period not set")
 
 	assert.Nil(t, pin.SetPeriod(20000000))
 	period, _ := pin.Period()
 	assert.Equal(t, uint32(20000000), period)
-	assert.Error(t, pin.SetPeriod(10000000), "Cannot set the period of individual PWM pins on Raspi")
+	assert.ErrorContains(t, pin.SetPeriod(10000000), "Cannot set the period of individual PWM pins on Raspi")
 
 	dc, _ := pin.DutyCycle()
 	assert.Equal(t, uint32(0), dc)
@@ -45,7 +45,7 @@ func TestPwmPin(t *testing.T) {
 	dc, _ = pin.DutyCycle()
 	assert.Equal(t, uint32(10000), dc)
 
-	assert.Error(t, pin.SetDutyCycle(999999999), "Duty cycle exceeds period")
+	assert.ErrorContains(t, pin.SetDutyCycle(999999999), "Duty cycle exceeds period")
 	dc, _ = pin.DutyCycle()
 	assert.Equal(t, uint32(10000), dc)
 

--- a/platforms/raspi/raspi_adaptor_test.go
+++ b/platforms/raspi/raspi_adaptor_test.go
@@ -125,8 +125,8 @@ func TestDigitalPWM(t *testing.T) {
 
 	assert.Equal(t, "17=0.5", strings.Split(fs.Files["/dev/pi-blaster"].Contents, "\n")[0])
 
-	assert.Error(t, a.PwmWrite("notexist", 1), "Not a valid pin")
-	assert.Error(t, a.ServoWrite("notexist", 1), "Not a valid pin")
+	assert.ErrorContains(t, a.PwmWrite("notexist", 1), "Not a valid pin")
+	assert.ErrorContains(t, a.ServoWrite("notexist", 1), "Not a valid pin")
 
 	pin, _ = a.PWMPin("12")
 	period, _ = pin.Period()
@@ -160,7 +160,7 @@ func TestDigitalIO(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, i)
 
-	assert.Error(t, a.DigitalWrite("notexist", 1), "Not a valid pin")
+	assert.ErrorContains(t, a.DigitalWrite("notexist", 1), "Not a valid pin")
 	assert.Nil(t, a.Finalize())
 }
 

--- a/platforms/sphero/sphero_adaptor_test.go
+++ b/platforms/sphero/sphero_adaptor_test.go
@@ -89,7 +89,7 @@ func TestSpheroAdaptorFinalize(t *testing.T) {
 	}
 
 	a.connected = true
-	assert.Error(t, a.Finalize(), "close error")
+	assert.ErrorContains(t, a.Finalize(), "close error")
 }
 
 func TestSpheroAdaptorConnect(t *testing.T) {
@@ -100,5 +100,5 @@ func TestSpheroAdaptorConnect(t *testing.T) {
 		return nil, errors.New("connect error")
 	}
 
-	assert.Error(t, a.Connect(), "connect error")
+	assert.ErrorContains(t, a.Connect(), "connect error")
 }

--- a/platforms/tinkerboard/adaptor_test.go
+++ b/platforms/tinkerboard/adaptor_test.go
@@ -92,7 +92,7 @@ func TestDigitalIO(t *testing.T) {
 	i, _ := a.DigitalRead("10")
 	assert.Equal(t, 1, i)
 
-	assert.Error(t, a.DigitalWrite("99", 1), "'99' is not a valid id for a digital pin")
+	assert.ErrorContains(t, a.DigitalWrite("99", 1), "'99' is not a valid id for a digital pin")
 	assert.Nil(t, a.Finalize())
 }
 
@@ -101,16 +101,16 @@ func TestInvalidPWMPin(t *testing.T) {
 	preparePwmFs(fs)
 
 	err := a.PwmWrite("666", 42)
-	assert.Error(t, err, "'666' is not a valid id for a PWM pin")
+	assert.ErrorContains(t, err, "'666' is not a valid id for a PWM pin")
 
 	err = a.ServoWrite("666", 120)
-	assert.Error(t, err, "'666' is not a valid id for a PWM pin")
+	assert.ErrorContains(t, err, "'666' is not a valid id for a PWM pin")
 
 	err = a.PwmWrite("3", 42)
-	assert.Error(t, err, "'3' is not a valid id for a PWM pin")
+	assert.ErrorContains(t, err, "'3' is not a valid id for a PWM pin")
 
 	err = a.ServoWrite("3", 120)
-	assert.Error(t, err, "'3' is not a valid id for a PWM pin")
+	assert.ErrorContains(t, err, "'3' is not a valid id for a PWM pin")
 }
 
 func TestPwmWrite(t *testing.T) {

--- a/platforms/upboard/up2/adaptor_test.go
+++ b/platforms/upboard/up2/adaptor_test.go
@@ -77,7 +77,7 @@ func TestDigitalIO(t *testing.T) {
 		fs.Files["/sys/class/leds/upboard:green:/brightness"].Contents,
 	)
 
-	assert.Error(t, a.DigitalWrite("99", 1), "'99' is not a valid id for a digital pin")
+	assert.ErrorContains(t, a.DigitalWrite("99", 1), "'99' is not a valid id for a digital pin")
 	assert.Nil(t, a.Finalize())
 }
 

--- a/system/digitalpin_sysfs_test.go
+++ b/system/digitalpin_sysfs_test.go
@@ -57,10 +57,10 @@ func TestDigitalPin(t *testing.T) {
 
 	pin2 := newDigitalPinSysfs(fs, "30")
 	err = pin2.Write(1)
-	assert.Error(t, err, "pin has not been exported")
+	assert.ErrorContains(t, err, "pin has not been exported")
 
 	data, err = pin2.Read()
-	assert.Error(t, err, "pin has not been exported")
+	assert.ErrorContains(t, err, "pin has not been exported")
 	assert.Equal(t, 0, data)
 
 	writeFile = func(File, []byte) (int, error) {
@@ -75,7 +75,7 @@ func TestDigitalPin(t *testing.T) {
 	}
 
 	err = pin.Unexport()
-	assert.Error(t, err.(*os.PathError).Err, "write error")
+	assert.ErrorContains(t, err.(*os.PathError).Err, "write error")
 
 	// assert a busy error is dropped (just means "already exported")
 	cnt := 0
@@ -94,7 +94,7 @@ func TestDigitalPin(t *testing.T) {
 		return 0, &os.PathError{Err: errors.New("write error")}
 	}
 	err = pin.Export()
-	assert.Error(t, err.(*os.PathError).Err, "write error")
+	assert.ErrorContains(t, err.(*os.PathError).Err, "write error")
 }
 
 func TestDigitalPinExportError(t *testing.T) {
@@ -109,7 +109,7 @@ func TestDigitalPinExportError(t *testing.T) {
 	}
 
 	err := pin.Export()
-	assert.Error(t, err, " : /sys/class/gpio/gpio10/direction: no such file")
+	assert.ErrorContains(t, err, " : /sys/class/gpio/gpio10/direction: no such file")
 }
 
 func TestDigitalPinUnexportError(t *testing.T) {
@@ -123,5 +123,5 @@ func TestDigitalPinUnexportError(t *testing.T) {
 	}
 
 	err := pin.Unexport()
-	assert.Error(t, err, " : device or resource busy")
+	assert.ErrorContains(t, err, " : device or resource busy")
 }

--- a/system/fs_mock_test.go
+++ b/system/fs_mock_test.go
@@ -20,7 +20,7 @@ func TestMockFilesystemOpen(t *testing.T) {
 	assert.Nil(t, err)
 
 	_, err = fs.openFile("bar", 0, 0o666)
-	assert.Error(t, err, " : bar: no such file")
+	assert.ErrorContains(t, err, " : bar: no such file")
 
 	fs.Add("bar")
 	f4, _ := fs.openFile("bar", 0, 0o666)
@@ -39,7 +39,7 @@ func TestMockFilesystemStat(t *testing.T) {
 	assert.True(t, dirStat.IsDir())
 
 	_, err = fs.stat("plonk")
-	assert.Error(t, err, " : plonk: no such file")
+	assert.ErrorContains(t, err, " : plonk: no such file")
 }
 
 func TestMockFilesystemFind(t *testing.T) {

--- a/system/i2c_device_test.go
+++ b/system/i2c_device_test.go
@@ -79,7 +79,7 @@ func TestNewI2cDevice(t *testing.T) {
 			d, err := a.NewI2cDevice(tc.dev)
 			// assert
 			if tc.wantErr != "" {
-				assert.Error(t, err, tc.wantErr)
+				assert.ErrorContains(t, err, tc.wantErr)
 				assert.Equal(t, (*i2cDevice)(nil), d)
 			} else {
 				var _ gobot.I2cSystemDevicer = d
@@ -142,7 +142,7 @@ func TestReadByte(t *testing.T) {
 			got, err := d.ReadByte(2)
 			// assert
 			if tc.wantErr != "" {
-				assert.Error(t, err, tc.wantErr)
+				assert.ErrorContains(t, err, tc.wantErr)
 			} else {
 				assert.Nil(t, err)
 				assert.Equal(t, want, got)
@@ -189,7 +189,7 @@ func TestReadByteData(t *testing.T) {
 			got, err := d.ReadByteData(3, reg)
 			// assert
 			if tc.wantErr != "" {
-				assert.Error(t, err, tc.wantErr)
+				assert.ErrorContains(t, err, tc.wantErr)
 			} else {
 				assert.Nil(t, err)
 				assert.Equal(t, want, got)
@@ -239,7 +239,7 @@ func TestReadWordData(t *testing.T) {
 			got, err := d.ReadWordData(4, reg)
 			// assert
 			if tc.wantErr != "" {
-				assert.Error(t, err, tc.wantErr)
+				assert.ErrorContains(t, err, tc.wantErr)
 			} else {
 				assert.Nil(t, err)
 				assert.Equal(t, want, got)
@@ -297,7 +297,7 @@ func TestReadBlockData(t *testing.T) {
 			err := d.ReadBlockData(5, reg, buf)
 			// assert
 			if tc.wantErr != "" {
-				assert.Error(t, err, tc.wantErr)
+				assert.ErrorContains(t, err, tc.wantErr)
 			} else {
 				assert.Nil(t, err)
 				assert.Equal(t, msc.dataSlice, buf)
@@ -341,7 +341,7 @@ func TestWriteByte(t *testing.T) {
 			err := d.WriteByte(6, val)
 			// assert
 			if tc.wantErr != "" {
-				assert.Error(t, err, tc.wantErr)
+				assert.ErrorContains(t, err, tc.wantErr)
 			} else {
 				assert.Nil(t, err)
 				assert.Equal(t, d.file, msc.lastFile)
@@ -386,7 +386,7 @@ func TestWriteByteData(t *testing.T) {
 			err := d.WriteByteData(7, reg, val)
 			// assert
 			if tc.wantErr != "" {
-				assert.Error(t, err, tc.wantErr)
+				assert.ErrorContains(t, err, tc.wantErr)
 			} else {
 				assert.Nil(t, err)
 				assert.Equal(t, d.file, msc.lastFile)
@@ -435,7 +435,7 @@ func TestWriteWordData(t *testing.T) {
 			err := d.WriteWordData(8, reg, val)
 			// assert
 			if tc.wantErr != "" {
-				assert.Error(t, err, tc.wantErr)
+				assert.ErrorContains(t, err, tc.wantErr)
 			} else {
 				assert.Nil(t, err)
 				assert.Equal(t, d.file, msc.lastFile)
@@ -492,7 +492,7 @@ func TestWriteBlockData(t *testing.T) {
 			err := d.WriteBlockData(9, reg, data)
 			// assert
 			if tc.wantErr != "" {
-				assert.Error(t, err, tc.wantErr)
+				assert.ErrorContains(t, err, tc.wantErr)
 			} else {
 				assert.Nil(t, err)
 				assert.Equal(t, d.file, msc.lastFile)
@@ -514,7 +514,7 @@ func TestWriteBlockDataTooMuch(t *testing.T) {
 	// act
 	err := d.WriteBlockData(10, 0x01, make([]byte, 33))
 	// assert
-	assert.Error(t, err, "Writing blocks larger than 32 bytes (33) not supported")
+	assert.ErrorContains(t, err, "Writing blocks larger than 32 bytes (33) not supported")
 }
 
 func Test_setAddress(t *testing.T) {
@@ -565,7 +565,7 @@ func Test_queryFunctionality(t *testing.T) {
 			err := d.queryFunctionality(tc.requested, "test"+name)
 			// assert
 			if tc.wantErr != "" {
-				assert.Error(t, err, tc.wantErr)
+				assert.ErrorContains(t, err, tc.wantErr)
 			} else {
 				assert.Nil(t, err)
 			}

--- a/system/pwmpin_sysfs_test.go
+++ b/system/pwmpin_sysfs_test.go
@@ -56,7 +56,7 @@ func TestPwmPin(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "1", fs.Files["/sys/class/pwm/pwmchip0/pwm10/enable"].Contents)
 	err = pin.SetPolarity(true)
-	assert.Error(t, err, "Cannot set PWM polarity when enabled")
+	assert.ErrorContains(t, err, "Cannot set PWM polarity when enabled")
 
 	fs.Files["/sys/class/pwm/pwmchip0/pwm10/period"].Contents = "6"
 	data, _ := pin.Period()
@@ -107,7 +107,7 @@ func TestPwmPinExportError(t *testing.T) {
 
 	// no error indicates that the pin was already exported
 	err := pin.Export()
-	assert.Error(t, err, "Export() failed for id 10 with  : bad address")
+	assert.ErrorContains(t, err, "Export() failed for id 10 with  : bad address")
 }
 
 func TestPwmPinUnxportError(t *testing.T) {
@@ -125,7 +125,7 @@ func TestPwmPinUnxportError(t *testing.T) {
 	}
 
 	err := pin.Unexport()
-	assert.Error(t, err, "Unexport() failed for id 10 with  : device or resource busy")
+	assert.ErrorContains(t, err, "Unexport() failed for id 10 with  : device or resource busy")
 }
 
 func TestPwmPinPeriodError(t *testing.T) {
@@ -143,7 +143,7 @@ func TestPwmPinPeriodError(t *testing.T) {
 	}
 
 	_, err := pin.Period()
-	assert.Error(t, err, "Period() failed for id 10 with  : device or resource busy")
+	assert.ErrorContains(t, err, "Period() failed for id 10 with  : device or resource busy")
 }
 
 func TestPwmPinPolarityError(t *testing.T) {
@@ -161,7 +161,7 @@ func TestPwmPinPolarityError(t *testing.T) {
 	}
 
 	_, err := pin.Polarity()
-	assert.Error(t, err, "Polarity() failed for id 10 with  : device or resource busy")
+	assert.ErrorContains(t, err, "Polarity() failed for id 10 with  : device or resource busy")
 }
 
 func TestPwmPinDutyCycleError(t *testing.T) {
@@ -179,5 +179,5 @@ func TestPwmPinDutyCycleError(t *testing.T) {
 	}
 
 	_, err := pin.DutyCycle()
-	assert.Error(t, err, "DutyCycle() failed for id 10 with  : device or resource busy")
+	assert.ErrorContains(t, err, "DutyCycle() failed for id 10 with  : device or resource busy")
 }


### PR DESCRIPTION
## Solved issues and/or description of the change

fix accidentally used `assert.Error()` (checks only for existing error, the text is used in case of fail) instead of `assert.ErrorContains()` (the text needs to be contained in the error)

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code (no productive code is changed)