### PR TITLE
system(gpio): add edge polling function

### DIFF
--- a/adaptor.go
+++ b/adaptor.go
@@ -21,12 +21,18 @@ type DigitalPinOptioner interface {
 	SetDrive(drive int) (changed bool)
 	// SetDebounce initializes the input pin with the given debounce period.
 	SetDebounce(period time.Duration) (changed bool)
-	// SetEventHandlerForEdge initializes the input pin for edge detection and to call the event handler on specified edge.
+	// SetEventHandlerForEdge initializes the input pin for edge detection to call the event handler on specified edge.
 	// lineOffset is within the GPIO chip (needs to transformed to the pin id), timestamp is the detection time,
 	// detectedEdge contains the direction of the pin changes, seqno is the sequence number for this event in the sequence
 	// of events for all the lines in this line request, lseqno is the same but for this line
 	SetEventHandlerForEdge(handler func(lineOffset int, timestamp time.Duration, detectedEdge string, seqno uint32,
 		lseqno uint32), edge int) (changed bool)
+	// SetPollForEdgeDetection use a discrete input polling method to detect edges. A poll interval of zero or smaller
+	// will deactivate this function. Please note: Using this feature is CPU consuming and less accurate than using cdev
+	// event handler (gpiod implementation) and should be done only if the former is not implemented or not working for
+	// the adaptor. E.g. sysfs driver in gobot has not implemented edge detection yet. The function is only useful
+	// together with SetEventHandlerForEdge() and its corresponding With*() functions.
+	SetPollForEdgeDetection(pollInterval time.Duration, pollQuitChan chan struct{}) (changed bool)
 }
 
 // DigitalPinOptionApplier is the interface to apply options to change pin behavior immediately

--- a/system/GPIO.md
+++ b/system/GPIO.md
@@ -142,6 +142,28 @@ Connect the input header pin26 to +3.3V with an resistor (e.g. 1kOhm).
 1
 ```
 
+### Test edge detection behavior of gpio251 (sysfs Tinkerboard)
+
+investigate status:
+
+```sh
+# cat /sys/class/gpio/gpio251/edge
+none
+```
+
+The file exists only if the pin can be configured as an interrupt generating input pin. To activate edge detection,
+"rising", "falling", or "both" needs to be set.
+
+```sh
+# cat /sys/class/gpio/gpio251/value
+1
+```
+
+If edge detection is activated, a poll will return only when the interrupt was triggered. The new value is written to
+the beginning of the file.
+
+> Not tested yet, not supported by gobot yet.
+
 ### Test output behavior of gpio251 (sysfs Tinkerboard)
 
 Connect the output header pin26 to +3.3V with an resistor (e.g. 1kOhm leads to ~0.3mA, 300Ohm leads to ~10mA).

--- a/system/digitalpin_config_test.go
+++ b/system/digitalpin_config_test.go
@@ -413,3 +413,36 @@ func TestWithPinEventOnBothEdges(t *testing.T) {
 		})
 	}
 }
+
+func TestWithPinPollForEdgeDetection(t *testing.T) {
+	const (
+		oldVal = time.Duration(1)
+		newVal = time.Duration(3)
+	)
+	tests := map[string]struct {
+		oldPollInterval time.Duration
+		want            bool
+		wantVal         time.Duration
+	}{
+		"no_change": {
+			oldPollInterval: newVal,
+		},
+		"change": {
+			oldPollInterval: oldVal,
+			want:            true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			dpc := &digitalPinConfig{pollInterval: tc.oldPollInterval}
+			stopChan := make(chan struct{})
+			defer close(stopChan)
+			// act
+			got := WithPinPollForEdgeDetection(newVal, stopChan)(dpc)
+			// assert
+			assert.Equal(t, tc.want, got)
+			assert.Equal(t, newVal, dpc.pollInterval)
+		})
+	}
+}

--- a/system/digitalpin_gpiod_test.go
+++ b/system/digitalpin_gpiod_test.go
@@ -114,7 +114,7 @@ func TestApplyOptions(t *testing.T) {
 	}
 }
 
-func TestExport(t *testing.T) {
+func TestExportGpiod(t *testing.T) {
 	tests := map[string]struct {
 		simErr           error
 		wantReconfigured int
@@ -155,7 +155,7 @@ func TestExport(t *testing.T) {
 	}
 }
 
-func TestUnexport(t *testing.T) {
+func TestUnexportGpiod(t *testing.T) {
 	tests := map[string]struct {
 		simNoLine        bool
 		simReconfErr     error
@@ -217,7 +217,7 @@ func TestUnexport(t *testing.T) {
 	}
 }
 
-func TestWrite(t *testing.T) {
+func TestWriteGpiod(t *testing.T) {
 	tests := map[string]struct {
 		val     int
 		simErr  error
@@ -266,7 +266,7 @@ func TestWrite(t *testing.T) {
 	}
 }
 
-func TestRead(t *testing.T) {
+func TestReadGpiod(t *testing.T) {
 	tests := map[string]struct {
 		simVal  int
 		simErr  error

--- a/system/digitalpin_poll.go
+++ b/system/digitalpin_poll.go
@@ -1,0 +1,81 @@
+package system
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+func startEdgePolling(
+	pinLabel string,
+	pinReadFunc func() (int, error),
+	pollInterval time.Duration,
+	wantedEdge int,
+	eventHandler func(offset int, t time.Duration, et string, sn uint32, lsn uint32),
+	quitChan chan struct{},
+) error {
+	if eventHandler == nil {
+		return fmt.Errorf("an event handler is mandatory for edge polling")
+	}
+	if quitChan == nil {
+		return fmt.Errorf("the quit channel is mandatory for edge polling")
+	}
+
+	const allEdges = "all"
+
+	triggerEventOn := "none"
+	switch wantedEdge {
+	case digitalPinEventOnFallingEdge:
+		triggerEventOn = DigitalPinEventFallingEdge
+	case digitalPinEventOnRisingEdge:
+		triggerEventOn = DigitalPinEventRisingEdge
+	case digitalPinEventOnBothEdges:
+		triggerEventOn = allEdges
+	default:
+		return fmt.Errorf("unsupported edge type %d for edge polling", wantedEdge)
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		var oldState int
+		var readStart time.Time
+		var firstLoopDone bool
+		for {
+			select {
+			case <-quitChan:
+				return
+			default:
+				// note: pure reading takes between 30us and 1ms on rasperry Pi1, typically 50us, with sysfs also 500us
+				// can happen, so we use the time stamp before start of reading to reduce random duration offset
+				readStart = time.Now()
+				readValue, err := pinReadFunc()
+				if err != nil {
+					fmt.Printf("edge polling error occurred while reading the pin %s: %v", pinLabel, err)
+					readValue = oldState // keep the value
+				}
+				if readValue != oldState {
+					detectedEdge := DigitalPinEventRisingEdge
+					if readValue < oldState {
+						detectedEdge = DigitalPinEventFallingEdge
+					}
+					if firstLoopDone && (triggerEventOn == allEdges || triggerEventOn == detectedEdge) {
+						eventHandler(0, time.Duration(readStart.UnixNano()), detectedEdge, 0, 0)
+					}
+					oldState = readValue
+				}
+				// the real poll interval is increased by the reading time, see also note above
+				// negative or zero duration causes no sleep
+				time.Sleep(pollInterval - time.Since(readStart))
+				if !firstLoopDone {
+					wg.Done()
+					firstLoopDone = true
+				}
+			}
+		}
+	}()
+
+	wg.Wait()
+	return nil
+}

--- a/system/digitalpin_poll_test.go
+++ b/system/digitalpin_poll_test.go
@@ -1,0 +1,175 @@
+package system
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_startEdgePolling(t *testing.T) {
+	type readValue struct {
+		value int
+		err   string
+	}
+	tests := map[string]struct {
+		eventOnEdge            int
+		simulateReadValues     []readValue
+		simulateNoEventHandler bool
+		simulateNoQuitChan     bool
+		wantEdgeTypes          []string
+		wantErr                string
+	}{
+		"edge_falling": {
+			eventOnEdge: digitalPinEventOnFallingEdge,
+			simulateReadValues: []readValue{
+				{value: 1},
+				{value: 0},
+				{value: 1},
+				{value: 0},
+				{value: 0},
+			},
+			wantEdgeTypes: []string{DigitalPinEventFallingEdge, DigitalPinEventFallingEdge},
+		},
+		"no_edge_falling": {
+			eventOnEdge: digitalPinEventOnFallingEdge,
+			simulateReadValues: []readValue{
+				{value: 0},
+				{value: 1},
+				{value: 1},
+			},
+			wantEdgeTypes: nil,
+		},
+		"edge_rising": {
+			eventOnEdge: digitalPinEventOnRisingEdge,
+			simulateReadValues: []readValue{
+				{value: 0},
+				{value: 1},
+				{value: 0},
+				{value: 1},
+				{value: 1},
+			},
+			wantEdgeTypes: []string{DigitalPinEventRisingEdge, DigitalPinEventRisingEdge},
+		},
+		"no_edge_rising": {
+			eventOnEdge: digitalPinEventOnRisingEdge,
+			simulateReadValues: []readValue{
+				{value: 1},
+				{value: 0},
+				{value: 0},
+			},
+			wantEdgeTypes: nil,
+		},
+		"edge_both": {
+			eventOnEdge: digitalPinEventOnBothEdges,
+			simulateReadValues: []readValue{
+				{value: 0},
+				{value: 1},
+				{value: 0},
+				{value: 1},
+				{value: 1},
+			},
+			wantEdgeTypes: []string{DigitalPinEventRisingEdge, DigitalPinEventFallingEdge, DigitalPinEventRisingEdge},
+		},
+		"no_edges_low": {
+			eventOnEdge: digitalPinEventOnBothEdges,
+			simulateReadValues: []readValue{
+				{value: 0},
+				{value: 0},
+				{value: 0},
+			},
+			wantEdgeTypes: nil,
+		},
+		"no_edges_high": {
+			eventOnEdge: digitalPinEventOnBothEdges,
+			simulateReadValues: []readValue{
+				{value: 1},
+				{value: 1},
+				{value: 1},
+			},
+			wantEdgeTypes: nil,
+		},
+		"read_error_keep_state": {
+			eventOnEdge: digitalPinEventOnBothEdges,
+			simulateReadValues: []readValue{
+				{value: 0},
+				{value: 1, err: "read error suppress rising and falling edge"},
+				{value: 0},
+				{value: 1},
+				{value: 1},
+			},
+			wantEdgeTypes: []string{DigitalPinEventRisingEdge},
+		},
+		"error_no_eventhandler": {
+			simulateNoEventHandler: true,
+			wantErr:                "event handler is mandatory",
+		},
+		"error_no_quitchannel": {
+			simulateNoQuitChan: true,
+			wantErr:            "quit channel is mandatory",
+		},
+		"error_unsupported_edgetype_none": {
+			eventOnEdge: digitalPinEventNone,
+			wantErr:     "unsupported edge type 0",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			pinLabel := "test_pin"
+			pollInterval := time.Microsecond // zero is possible, just to show usage
+			// arrange event handler
+			var edgeTypes []string
+			var eventHandler func(int, time.Duration, string, uint32, uint32)
+			if !tc.simulateNoEventHandler {
+				eventHandler = func(offset int, t time.Duration, et string, sn uint32, lsn uint32) {
+					edgeTypes = append(edgeTypes, et)
+				}
+			}
+			// arrange quit channel
+			var quitChan chan struct{}
+			if !tc.simulateNoQuitChan {
+				quitChan = make(chan struct{})
+			}
+			defer func() {
+				if quitChan != nil {
+					close(quitChan)
+				}
+			}()
+			// arrange reads
+			numCallsRead := 0
+			wg := sync.WaitGroup{}
+			if tc.simulateReadValues != nil {
+				wg.Add(1)
+			}
+			readFunc := func() (int, error) {
+				numCallsRead++
+				readVal := tc.simulateReadValues[numCallsRead-1]
+				var err error
+				if readVal.err != "" {
+					err = fmt.Errorf(readVal.err)
+				}
+				if numCallsRead >= len(tc.simulateReadValues) {
+					close(quitChan) // ensure no further read call
+					quitChan = nil  // lets skip defer routine
+					wg.Done()       // release assertions
+				}
+
+				return readVal.value, err
+			}
+			// act
+			err := startEdgePolling(pinLabel, readFunc, pollInterval, tc.eventOnEdge, eventHandler, quitChan)
+			wg.Wait()
+			// assert
+			if tc.wantErr != "" {
+				assert.ErrorContains(t, err, tc.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, len(tc.simulateReadValues), numCallsRead)
+			assert.Equal(t, tc.wantEdgeTypes, edgeTypes)
+		})
+	}
+}

--- a/system/digitalpin_sysfs_test.go
+++ b/system/digitalpin_sysfs_test.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -16,20 +18,333 @@ var (
 	_ gobot.DigitalPinOptionApplier = (*digitalPinSysfs)(nil)
 )
 
-func initTestDigitalPinSysFsWithMockedFilesystem(mockPaths []string) (*digitalPinSysfs, *MockFilesystem) {
+func initTestDigitalPinSysfsWithMockedFilesystem(mockPaths []string) (*digitalPinSysfs, *MockFilesystem) {
 	fs := newMockFilesystem(mockPaths)
 	pin := newDigitalPinSysfs(fs, "10")
 	return pin, fs
 }
 
-func TestDigitalPin(t *testing.T) {
+func Test_newDigitalPinSysfs(t *testing.T) {
+	// arrange
+	m := &MockFilesystem{}
+	const pinID = "1"
+	// act
+	pin := newDigitalPinSysfs(m, pinID, WithPinOpenDrain())
+	// assert
+	assert.Equal(t, pinID, pin.pin)
+	assert.Equal(t, m, pin.fs)
+	assert.Equal(t, "gpio"+pinID, pin.label)
+	assert.Equal(t, "in", pin.direction)
+	assert.Equal(t, 1, pin.drive)
+}
+
+func TestApplyOptionsSysfs(t *testing.T) {
+	tests := map[string]struct {
+		changed    []bool
+		simErr     bool
+		wantExport string
+		wantErr    string
+	}{
+		"both_changed": {
+			changed:    []bool{true, true},
+			wantExport: "10",
+		},
+		"first_changed": {
+			changed:    []bool{true, false},
+			wantExport: "10",
+		},
+		"second_changed": {
+			changed:    []bool{false, true},
+			wantExport: "10",
+		},
+		"none_changed": {
+			changed:    []bool{false, false},
+			wantExport: "",
+		},
+		"error_on_change": {
+			changed:    []bool{false, true},
+			simErr:     true,
+			wantExport: "10",
+			wantErr:    "gpio10/direction: no such file",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			mockPaths := []string{
+				"/sys/class/gpio/export",
+				"/sys/class/gpio/gpio10/value",
+			}
+			if !tc.simErr {
+				mockPaths = append(mockPaths, "/sys/class/gpio/gpio10/direction")
+			}
+			pin, fs := initTestDigitalPinSysfsWithMockedFilesystem(mockPaths)
+
+			optionFunction1 := func(gobot.DigitalPinOptioner) bool {
+				pin.digitalPinConfig.direction = OUT
+				return tc.changed[0]
+			}
+			optionFunction2 := func(gobot.DigitalPinOptioner) bool {
+				pin.digitalPinConfig.drive = 15
+				return tc.changed[1]
+			}
+			// act
+			err := pin.ApplyOptions(optionFunction1, optionFunction2)
+			// assert
+			if tc.wantErr != "" {
+				assert.ErrorContains(t, err, tc.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, OUT, pin.digitalPinConfig.direction)
+			assert.Equal(t, 15, pin.digitalPinConfig.drive)
+			// marker for call of reconfigure, correct reconfigure is tested independently
+			assert.Equal(t, tc.wantExport, fs.Files["/sys/class/gpio/export"].Contents)
+		})
+	}
+}
+
+func TestDirectionBehaviorSysfs(t *testing.T) {
+	// arrange
+	pin := newDigitalPinSysfs(nil, "1")
+	require.Equal(t, "in", pin.direction)
+	pin.direction = "test"
+	// act && assert
+	assert.Equal(t, "test", pin.DirectionBehavior())
+}
+
+func TestDigitalPinExportSysfs(t *testing.T) {
+	// this tests mainly the function reconfigure()
+	const (
+		exportPath   = "/sys/class/gpio/export"
+		dirPath      = "/sys/class/gpio/gpio10/direction"
+		valuePath    = "/sys/class/gpio/gpio10/value"
+		inversePath  = "/sys/class/gpio/gpio10/active_low"
+		unexportPath = "/sys/class/gpio/unexport"
+	)
+	allMockPaths := []string{exportPath, dirPath, valuePath, inversePath, unexportPath}
+	tests := map[string]struct {
+		mockPaths             []string
+		changeDirection       string
+		changeOutInitialState int
+		changeActiveLow       bool
+		changeBias            int
+		changeDrive           int
+		changeDebouncePeriod  time.Duration
+		changeEdge            int
+		changePollInterval    time.Duration
+		simEbusyOnWrite       int
+		wantWrites            int
+		wantExport            string
+		wantUnexport          string
+		wantDirection         string
+		wantValue             string
+		wantInverse           string
+		wantErr               string
+	}{
+		"ok_without_option": {
+			mockPaths:     allMockPaths,
+			wantWrites:    2,
+			wantExport:    "10",
+			wantDirection: "in",
+		},
+		"ok_input_bias_dropped": {
+			mockPaths:     allMockPaths,
+			changeBias:    3,
+			wantWrites:    2,
+			wantExport:    "10",
+			wantDirection: "in",
+		},
+		"ok_input_drive_dropped": {
+			mockPaths:     allMockPaths,
+			changeDrive:   2,
+			wantWrites:    2,
+			wantExport:    "10",
+			wantDirection: "in",
+		},
+		"ok_input_debounce_dropped": {
+			mockPaths:            allMockPaths,
+			changeDebouncePeriod: 2 * time.Second,
+			wantWrites:           2,
+			wantExport:           "10",
+			wantDirection:        "in",
+		},
+		"ok_input_inverse": {
+			mockPaths:       allMockPaths,
+			changeActiveLow: true,
+			wantWrites:      3,
+			wantExport:      "10",
+			wantDirection:   "in",
+			wantInverse:     "1",
+		},
+		"ok_output": {
+			mockPaths:             allMockPaths,
+			changeDirection:       "out",
+			changeOutInitialState: 4,
+			wantWrites:            3,
+			wantExport:            "10",
+			wantDirection:         "out",
+			wantValue:             "4",
+		},
+		"ok_output_bias_dropped": {
+			mockPaths:       allMockPaths,
+			changeDirection: "out",
+			changeBias:      3,
+			wantWrites:      3,
+			wantExport:      "10",
+			wantDirection:   "out",
+			wantValue:       "0",
+		},
+		"ok_output_drive_dropped": {
+			mockPaths:       allMockPaths,
+			changeDirection: "out",
+			changeDrive:     2,
+			wantWrites:      3,
+			wantExport:      "10",
+			wantDirection:   "out",
+			wantValue:       "0",
+		},
+		"ok_output_debounce_dropped": {
+			mockPaths:            allMockPaths,
+			changeDirection:      "out",
+			changeDebouncePeriod: 2 * time.Second,
+			wantWrites:           3,
+			wantExport:           "10",
+			wantDirection:        "out",
+			wantValue:            "0",
+		},
+		"ok_output_inverse": {
+			mockPaths:       allMockPaths,
+			changeDirection: "out",
+			changeActiveLow: true,
+			wantWrites:      4,
+			wantExport:      "10",
+			wantDirection:   "out",
+			wantInverse:     "1",
+			wantValue:       "0",
+		},
+		"ok_already_exported": {
+			mockPaths:       allMockPaths,
+			wantWrites:      2,
+			wantExport:      "10",
+			wantDirection:   "in",
+			simEbusyOnWrite: 1, // just means "already exported"
+		},
+		"error_no_eventhandler_for_polling": { // this only tests the call of function, all other is tested separately
+			mockPaths:          allMockPaths,
+			changePollInterval: 3 * time.Second,
+			wantWrites:         3,
+			wantUnexport:       "10",
+			wantDirection:      "in",
+			wantErr:            "event handler is mandatory",
+		},
+		"error_no_export_file": {
+			mockPaths: []string{unexportPath},
+			wantErr:   "/export: no such file",
+		},
+		"error_no_direction_file": {
+			mockPaths:    []string{exportPath, unexportPath},
+			wantWrites:   2,
+			wantUnexport: "10",
+			wantErr:      "gpio10/direction: no such file",
+		},
+		"error_write_direction_file": {
+			mockPaths:       allMockPaths,
+			wantWrites:      3,
+			wantUnexport:    "10",
+			simEbusyOnWrite: 2,
+			wantErr:         "device or resource busy",
+		},
+		"error_no_value_file": {
+			mockPaths:    []string{exportPath, dirPath, unexportPath},
+			wantWrites:   2,
+			wantUnexport: "10",
+			wantErr:      "gpio10/value: no such file",
+		},
+		"error_no_inverse_file": {
+			mockPaths:       []string{exportPath, dirPath, valuePath, unexportPath},
+			changeActiveLow: true,
+			wantWrites:      3,
+			wantUnexport:    "10",
+			wantErr:         "gpio10/active_low: no such file",
+		},
+		"error_input_edge_without_poll": {
+			mockPaths:    allMockPaths,
+			changeEdge:   2,
+			wantWrites:   3,
+			wantUnexport: "10",
+			wantErr:      "not implemented for sysfs without discrete polling",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			fs := newMockFilesystem(tc.mockPaths)
+			pin := newDigitalPinSysfs(fs, "10")
+			if tc.changeDirection != "" {
+				pin.direction = tc.changeDirection
+			}
+			if tc.changeOutInitialState != 0 {
+				pin.outInitialState = tc.changeOutInitialState
+			}
+			if tc.changeActiveLow {
+				pin.activeLow = tc.changeActiveLow
+			}
+			if tc.changeBias != 0 {
+				pin.bias = tc.changeBias
+			}
+			if tc.changeDrive != 0 {
+				pin.drive = tc.changeDrive
+			}
+			if tc.changeDebouncePeriod != 0 {
+				pin.debouncePeriod = tc.changeDebouncePeriod
+			}
+			if tc.changeEdge != 0 {
+				pin.edge = tc.changeEdge
+			}
+			if tc.changePollInterval != 0 {
+				pin.pollInterval = tc.changePollInterval
+			}
+			// arrange write function
+			oldWriteFunc := writeFile
+			numCallsWrite := 0
+			writeFile = func(f File, data []byte) error {
+				numCallsWrite++
+				require.NoError(t, oldWriteFunc(f, data))
+				if numCallsWrite == tc.simEbusyOnWrite {
+					return &os.PathError{Err: Syscall_EBUSY}
+				}
+				return nil
+			}
+			defer func() { writeFile = oldWriteFunc }()
+			// act
+			err := pin.Export()
+			// assert
+			if tc.wantErr != "" {
+				assert.ErrorContains(t, err, tc.wantErr)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, pin.valFile)
+				assert.NotNil(t, pin.dirFile)
+				assert.Equal(t, tc.wantDirection, fs.Files[dirPath].Contents)
+				assert.Equal(t, tc.wantExport, fs.Files[exportPath].Contents)
+				assert.Equal(t, tc.wantValue, fs.Files[valuePath].Contents)
+				assert.Equal(t, tc.wantInverse, fs.Files[inversePath].Contents)
+			}
+			assert.Equal(t, tc.wantUnexport, fs.Files[unexportPath].Contents)
+			assert.Equal(t, tc.wantWrites, numCallsWrite)
+		})
+	}
+}
+
+func TestDigitalPinSysfs(t *testing.T) {
 	mockPaths := []string{
 		"/sys/class/gpio/export",
 		"/sys/class/gpio/unexport",
 		"/sys/class/gpio/gpio10/value",
 		"/sys/class/gpio/gpio10/direction",
 	}
-	pin, fs := initTestDigitalPinSysFsWithMockedFilesystem(mockPaths)
+	pin, fs := initTestDigitalPinSysfsWithMockedFilesystem(mockPaths)
 
 	assert.Equal(t, "10", pin.pin)
 	assert.Equal(t, "gpio10", pin.label)
@@ -39,10 +354,7 @@ func TestDigitalPin(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "10", fs.Files["/sys/class/gpio/unexport"].Contents)
 
-	err = pin.Export()
-	assert.NoError(t, err)
-	assert.Equal(t, "10", fs.Files["/sys/class/gpio/export"].Contents)
-	assert.NotNil(t, pin.valFile)
+	require.NoError(t, pin.Export())
 
 	err = pin.Write(1)
 	assert.NoError(t, err)
@@ -63,63 +375,29 @@ func TestDigitalPin(t *testing.T) {
 	assert.ErrorContains(t, err, "pin has not been exported")
 	assert.Equal(t, 0, data)
 
-	writeFile = func(File, []byte) (int, error) {
-		return 0, &os.PathError{Err: Syscall_EINVAL}
+	writeFile = func(File, []byte) error {
+		return &os.PathError{Err: Syscall_EINVAL}
 	}
 
 	err = pin.Unexport()
 	assert.NoError(t, err)
 
-	writeFile = func(File, []byte) (int, error) {
-		return 0, &os.PathError{Err: errors.New("write error")}
+	writeFile = func(File, []byte) error {
+		return &os.PathError{Err: errors.New("write error")}
 	}
 
 	err = pin.Unexport()
 	assert.ErrorContains(t, err.(*os.PathError).Err, "write error")
-
-	// assert a busy error is dropped (just means "already exported")
-	cnt := 0
-	writeFile = func(File, []byte) (int, error) {
-		cnt++
-		if cnt == 1 {
-			return 0, &os.PathError{Err: Syscall_EBUSY}
-		}
-		return 0, nil
-	}
-	err = pin.Export()
-	assert.NoError(t, err)
-
-	// assert write error on export
-	writeFile = func(File, []byte) (int, error) {
-		return 0, &os.PathError{Err: errors.New("write error")}
-	}
-	err = pin.Export()
-	assert.ErrorContains(t, err.(*os.PathError).Err, "write error")
 }
 
-func TestDigitalPinExportError(t *testing.T) {
-	mockPaths := []string{
-		"/sys/class/gpio/export",
-		"/sys/class/gpio/gpio11/direction",
-	}
-	pin, _ := initTestDigitalPinSysFsWithMockedFilesystem(mockPaths)
-
-	writeFile = func(File, []byte) (int, error) {
-		return 0, &os.PathError{Err: Syscall_EBUSY}
-	}
-
-	err := pin.Export()
-	assert.ErrorContains(t, err, " : /sys/class/gpio/gpio10/direction: no such file")
-}
-
-func TestDigitalPinUnexportError(t *testing.T) {
+func TestDigitalPinUnexportErrorSysfs(t *testing.T) {
 	mockPaths := []string{
 		"/sys/class/gpio/unexport",
 	}
-	pin, _ := initTestDigitalPinSysFsWithMockedFilesystem(mockPaths)
+	pin, _ := initTestDigitalPinSysfsWithMockedFilesystem(mockPaths)
 
-	writeFile = func(File, []byte) (int, error) {
-		return 0, &os.PathError{Err: Syscall_EBUSY}
+	writeFile = func(File, []byte) error {
+		return &os.PathError{Err: Syscall_EBUSY}
 	}
 
 	err := pin.Unexport()


### PR DESCRIPTION
## Solved issues and/or description of the change

this prepares the usage of upcoming HC-SR04 driver, see #1012, independently of cdev event-handler

additionally:
* fix that all sysfs options are applied, not only the first one
* fix in sysfs that Unexport() will be called always after an export was successfully
* fix in sysf that the originated error will be returned if Unexport() was called successfully
* tests for sysfs improved

## Manual test

- OS and Version (Win/Mac/Linux): Linux
- Adaptor(s) and/or driver(s):
  - [x] raspberry
  - [x] tinkerboard

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code
- [x] The gpio README is extended