### PR TITLE
test(all): substitude assert.Nil by assert.NoError if useful

### DIFF
--- a/drivers/aio/analog_actuator_driver_test.go
+++ b/drivers/aio/analog_actuator_driver_test.go
@@ -15,12 +15,12 @@ func TestAnalogActuatorDriver(t *testing.T) {
 	assert.Equal(t, "47", d.Pin())
 
 	err := d.RawWrite(100)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(a.written))
 	assert.Equal(t, 100, a.written[0])
 
 	err = d.Write(247.0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, len(a.written))
 	assert.Equal(t, 247, a.written[1])
 	assert.Equal(t, 247, d.RawValue())
@@ -76,7 +76,7 @@ func TestAnalogActuatorDriverLinearScaler(t *testing.T) {
 			// act
 			err := d.Write(tt.input)
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, 1, len(a.written))
 			assert.Equal(t, tt.want, a.written[0])
 		})
@@ -85,12 +85,12 @@ func TestAnalogActuatorDriverLinearScaler(t *testing.T) {
 
 func TestAnalogActuatorDriverStart(t *testing.T) {
 	d := NewAnalogActuatorDriver(newAioTestAdaptor(), "1")
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestAnalogActuatorDriverHalt(t *testing.T) {
 	d := NewAnalogActuatorDriver(newAioTestAdaptor(), "1")
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestAnalogActuatorDriverDefaultName(t *testing.T) {

--- a/drivers/aio/analog_sensor_driver_test.go
+++ b/drivers/aio/analog_sensor_driver_test.go
@@ -48,7 +48,7 @@ func TestAnalogSensorDriver(t *testing.T) {
 	})
 	assert.Equal(t, 0.0, d.Value())
 	val, err := d.Read()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 150.0, val)
 	assert.Equal(t, 150.0, d.Value())
 	assert.Equal(t, 150, d.RawValue())
@@ -84,7 +84,7 @@ func TestAnalogSensorDriverWithLinearScaler(t *testing.T) {
 			// act
 			got, err := d.Read()
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -113,7 +113,7 @@ func TestAnalogSensorDriverStart(t *testing.T) {
 		return
 	})
 
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 
 	select {
 	case <-sem:
@@ -169,7 +169,7 @@ func TestAnalogSensorDriverHalt(t *testing.T) {
 		<-d.halt
 		close(done)
 	}()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 	select {
 	case <-done:
 	case <-time.After(100 * time.Millisecond):

--- a/drivers/aio/grove_drivers_test.go
+++ b/drivers/aio/grove_drivers_test.go
@@ -90,7 +90,7 @@ func TestDriverPublishesError(t *testing.T) {
 		}
 		testAdaptor.TestAdaptorAnalogRead(returnErr)
 
-		assert.Nil(t, driver.Start())
+		assert.NoError(t, driver.Start())
 
 		// expect error
 		_ = driver.Once(driver.Event(Error), func(data interface{}) {

--- a/drivers/aio/grove_temperature_sensor_driver_test.go
+++ b/drivers/aio/grove_temperature_sensor_driver_test.go
@@ -47,7 +47,7 @@ func TestGroveTemperatureSensorDriverScaling(t *testing.T) {
 			// act
 			got, err := d.Read()
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -66,7 +66,7 @@ func TestGroveTempSensorPublishesTemperatureInCelsius(t *testing.T) {
 		assert.Equal(t, "31.62", fmt.Sprintf("%.2f", data.(float64)))
 		sem <- true
 	})
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 
 	select {
 	case <-sem:

--- a/drivers/aio/temperature_sensor_driver_test.go
+++ b/drivers/aio/temperature_sensor_driver_test.go
@@ -48,7 +48,7 @@ func TestTemperatureSensorDriverNtcScaling(t *testing.T) {
 			// act
 			got, err := d.Read()
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -83,7 +83,7 @@ func TestTemperatureSensorDriverLinearScaling(t *testing.T) {
 			// act
 			got, err := d.Read()
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -104,7 +104,7 @@ func TestTempSensorPublishesTemperatureInCelsius(t *testing.T) {
 		assert.Equal(t, "31.62", fmt.Sprintf("%.2f", data.(float64)))
 		sem <- true
 	})
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 
 	select {
 	case <-sem:
@@ -126,7 +126,7 @@ func TestTempSensorPublishesError(t *testing.T) {
 		return
 	})
 
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 
 	// expect error
 	_ = d.Once(d.Event(Error), func(data interface{}) {
@@ -148,7 +148,7 @@ func TestTempSensorHalt(t *testing.T) {
 		<-d.halt
 		close(done)
 	}()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 	select {
 	case <-done:
 	case <-time.After(100 * time.Millisecond):

--- a/drivers/common/mfrc522/mfrc522_pcd_test.go
+++ b/drivers/common/mfrc522/mfrc522_pcd_test.go
@@ -63,7 +63,7 @@ func TestInitialize(t *testing.T) {
 	// act
 	err := d.Initialize(c)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, c, d.connection)
 	assert.Equal(t, wantSoftReset, c.written[:3])
 	assert.Equal(t, wantInit, c.written[3:21])
@@ -80,7 +80,7 @@ func Test_getVersion(t *testing.T) {
 	// act
 	got, err := d.getVersion()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, want, got)
 	assert.Equal(t, wantWritten, c.written)
 }
@@ -120,7 +120,7 @@ func Test_switchAntenna(t *testing.T) {
 			// act
 			err := d.switchAntenna(tc.target)
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.wantWritten, c.written)
 		})
 	}
@@ -134,7 +134,7 @@ func Test_stopCrypto1(t *testing.T) {
 	// act
 	err := d.stopCrypto1()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, wantWritten, c.written)
 }
 
@@ -158,7 +158,7 @@ func Test_communicateWithPICC(t *testing.T) {
 	// transceive, all 8 bits, no CRC
 	err := d.communicateWithPICC(0x0C, dataToFifo, backData, 0x00, false)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, writtenPrepare, c.written[:8])
 	assert.Equal(t, writtenWriteFifo, c.written[8:12])
 	assert.Equal(t, writtenTransceive, c.written[12:16])
@@ -181,7 +181,7 @@ func Test_calculateCRC(t *testing.T) {
 	// act
 	err := d.calculateCRC(dataToFifo, gotCrcBack)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, writtenPrepare, c.written[:6])
 	assert.Equal(t, writtenFifo, c.written[6:10])
 	assert.Equal(t, writtenCalc, c.written[10:15])
@@ -197,7 +197,7 @@ func Test_writeFifo(t *testing.T) {
 	// act
 	err := d.writeFifo(dataToFifo)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, wantWritten, c.written)
 }
 
@@ -210,7 +210,7 @@ func Test_readFifo(t *testing.T) {
 	// act
 	_, err := d.readFifo(backData)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, wantWritten, c.written)
 	assert.Equal(t, c.simFifo, backData)
 }

--- a/drivers/gpio/aip1640_driver_test.go
+++ b/drivers/gpio/aip1640_driver_test.go
@@ -32,12 +32,12 @@ func TestAIP1640Driver(t *testing.T) {
 
 func TestAIP1640DriverStart(t *testing.T) {
 	d := initTestAIP1640Driver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestAIP1640DriverHalt(t *testing.T) {
 	d := initTestAIP1640Driver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestAIP1640DriverDefaultName(t *testing.T) {

--- a/drivers/gpio/button_driver_test.go
+++ b/drivers/gpio/button_driver_test.go
@@ -23,7 +23,7 @@ func TestButtonDriverHalt(t *testing.T) {
 	go func() {
 		<-d.halt
 	}()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestButtonDriver(t *testing.T) {
@@ -49,7 +49,7 @@ func TestButtonDriverStart(t *testing.T) {
 		return
 	})
 
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 
 	select {
 	case <-sem:
@@ -122,7 +122,7 @@ func TestButtonDriverDefaultState(t *testing.T) {
 		return
 	})
 
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 
 	select {
 	case <-sem:

--- a/drivers/gpio/buzzer_driver_test.go
+++ b/drivers/gpio/buzzer_driver_test.go
@@ -28,12 +28,12 @@ func TestBuzzerDriverSetName(t *testing.T) {
 
 func TestBuzzerDriverStart(t *testing.T) {
 	d := initTestBuzzerDriver(newGpioTestAdaptor())
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestBuzzerDriverHalt(t *testing.T) {
 	d := initTestBuzzerDriver(newGpioTestAdaptor())
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestBuzzerDriverToggle(t *testing.T) {
@@ -47,7 +47,7 @@ func TestBuzzerDriverToggle(t *testing.T) {
 
 func TestBuzzerDriverTone(t *testing.T) {
 	d := initTestBuzzerDriver(newGpioTestAdaptor())
-	assert.Nil(t, d.Tone(100, 0.01))
+	assert.NoError(t, d.Tone(100, 0.01))
 }
 
 func TestBuzzerDriverOnError(t *testing.T) {

--- a/drivers/gpio/direct_pin_driver_test.go
+++ b/drivers/gpio/direct_pin_driver_test.go
@@ -54,12 +54,12 @@ func TestDirectPinDriver(t *testing.T) {
 
 func TestDirectPinDriverStart(t *testing.T) {
 	d := initTestDirectPinDriver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestDirectPinDriverHalt(t *testing.T) {
 	d := initTestDirectPinDriver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestDirectPinDriverOff(t *testing.T) {
@@ -68,7 +68,7 @@ func TestDirectPinDriverOff(t *testing.T) {
 
 	a := newGpioTestAdaptor()
 	d = NewDirectPinDriver(a, "1")
-	assert.Nil(t, d.Off())
+	assert.NoError(t, d.Off())
 }
 
 func TestDirectPinDriverOffNotSupported(t *testing.T) {
@@ -80,7 +80,7 @@ func TestDirectPinDriverOffNotSupported(t *testing.T) {
 func TestDirectPinDriverOn(t *testing.T) {
 	a := newGpioTestAdaptor()
 	d := NewDirectPinDriver(a, "1")
-	assert.Nil(t, d.On())
+	assert.NoError(t, d.On())
 }
 
 func TestDirectPinDriverOnError(t *testing.T) {
@@ -97,7 +97,7 @@ func TestDirectPinDriverOnNotSupported(t *testing.T) {
 func TestDirectPinDriverDigitalWrite(t *testing.T) {
 	adaptor := newGpioTestAdaptor()
 	d := NewDirectPinDriver(adaptor, "1")
-	assert.Nil(t, d.DigitalWrite(1))
+	assert.NoError(t, d.DigitalWrite(1))
 }
 
 func TestDirectPinDriverDigitalWriteNotSupported(t *testing.T) {
@@ -115,7 +115,7 @@ func TestDirectPinDriverDigitalRead(t *testing.T) {
 	d := initTestDirectPinDriver()
 	ret, err := d.DigitalRead()
 	assert.Equal(t, 1, ret)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestDirectPinDriverDigitalReadNotSupported(t *testing.T) {
@@ -128,7 +128,7 @@ func TestDirectPinDriverDigitalReadNotSupported(t *testing.T) {
 func TestDirectPinDriverPwmWrite(t *testing.T) {
 	a := newGpioTestAdaptor()
 	d := NewDirectPinDriver(a, "1")
-	assert.Nil(t, d.PwmWrite(1))
+	assert.NoError(t, d.PwmWrite(1))
 }
 
 func TestDirectPinDriverPwmWriteNotSupported(t *testing.T) {
@@ -145,7 +145,7 @@ func TestDirectPinDriverPwmWriteError(t *testing.T) {
 func TestDirectPinDriverServoWrite(t *testing.T) {
 	a := newGpioTestAdaptor()
 	d := NewDirectPinDriver(a, "1")
-	assert.Nil(t, d.ServoWrite(1))
+	assert.NoError(t, d.ServoWrite(1))
 }
 
 func TestDirectPinDriverServoWriteNotSupported(t *testing.T) {

--- a/drivers/gpio/grove_drivers_test.go
+++ b/drivers/gpio/grove_drivers_test.go
@@ -91,7 +91,7 @@ func TestDriverPublishesError(t *testing.T) {
 		}
 		testAdaptor.testAdaptorDigitalRead = returnErr
 
-		assert.Nil(t, driver.Start())
+		assert.NoError(t, driver.Start())
 
 		// expect error
 		_ = driver.Once(driver.Event(Error), func(data interface{}) {

--- a/drivers/gpio/hd44780_driver_test.go
+++ b/drivers/gpio/hd44780_driver_test.go
@@ -61,7 +61,7 @@ func TestHD44780Driver(t *testing.T) {
 
 func TestHD44780DriverHalt(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestHD44780DriverDefaultName(t *testing.T) {
@@ -77,7 +77,7 @@ func TestHD44780DriverSetName(t *testing.T) {
 
 func TestHD44780DriverStart(t *testing.T) {
 	d, _ := initTestHD44780Driver4BitModeWithStubbedAdaptor()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestHD44780DriverStartError(t *testing.T) {
@@ -114,11 +114,11 @@ func TestHD44780DriverWrite(t *testing.T) {
 
 	d, _ = initTestHD44780Driver4BitModeWithStubbedAdaptor()
 	_ = d.Start()
-	assert.Nil(t, d.Write("hello gobot"))
+	assert.NoError(t, d.Write("hello gobot"))
 
 	d, _ = initTestHD44780Driver8BitModeWithStubbedAdaptor()
 	_ = d.Start()
-	assert.Nil(t, d.Write("hello gobot"))
+	assert.NoError(t, d.Write("hello gobot"))
 }
 
 func TestHD44780DriverWriteError(t *testing.T) {
@@ -142,17 +142,17 @@ func TestHD44780DriverWriteError(t *testing.T) {
 
 func TestHD44780DriverClear(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.Nil(t, d.Clear())
+	assert.NoError(t, d.Clear())
 }
 
 func TestHD44780DriverHome(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.Nil(t, d.Home())
+	assert.NoError(t, d.Home())
 }
 
 func TestHD44780DriverSetCursor(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.Nil(t, d.SetCursor(0, 3))
+	assert.NoError(t, d.SetCursor(0, 3))
 }
 
 func TestHD44780DriverSetCursorInvalid(t *testing.T) {
@@ -166,68 +166,68 @@ func TestHD44780DriverSetCursorInvalid(t *testing.T) {
 
 func TestHD44780DriverDisplayOn(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.Nil(t, d.Display(true))
+	assert.NoError(t, d.Display(true))
 }
 
 func TestHD44780DriverDisplayOff(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.Nil(t, d.Display(false))
+	assert.NoError(t, d.Display(false))
 }
 
 func TestHD44780DriverCursorOn(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.Nil(t, d.Cursor(true))
+	assert.NoError(t, d.Cursor(true))
 }
 
 func TestHD44780DriverCursorOff(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.Nil(t, d.Cursor(false))
+	assert.NoError(t, d.Cursor(false))
 }
 
 func TestHD44780DriverBlinkOn(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.Nil(t, d.Blink(true))
+	assert.NoError(t, d.Blink(true))
 }
 
 func TestHD44780DriverBlinkOff(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.Nil(t, d.Blink(false))
+	assert.NoError(t, d.Blink(false))
 }
 
 func TestHD44780DriverScrollLeft(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.Nil(t, d.ScrollLeft())
+	assert.NoError(t, d.ScrollLeft())
 }
 
 func TestHD44780DriverScrollRight(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.Nil(t, d.ScrollRight())
+	assert.NoError(t, d.ScrollRight())
 }
 
 func TestHD44780DriverLeftToRight(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.Nil(t, d.LeftToRight())
+	assert.NoError(t, d.LeftToRight())
 }
 
 func TestHD44780DriverRightToLeft(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.Nil(t, d.RightToLeft())
+	assert.NoError(t, d.RightToLeft())
 }
 
 func TestHD44780DriverSendCommand(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.Nil(t, d.SendCommand(0x33))
+	assert.NoError(t, d.SendCommand(0x33))
 }
 
 func TestHD44780DriverWriteChar(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.Nil(t, d.WriteChar(0x41))
+	assert.NoError(t, d.WriteChar(0x41))
 }
 
 func TestHD44780DriverCreateChar(t *testing.T) {
 	d := initTestHD44780Driver()
 	charMap := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
-	assert.Nil(t, d.CreateChar(0, charMap))
+	assert.NoError(t, d.CreateChar(0, charMap))
 }
 
 func TestHD44780DriverCreateCharError(t *testing.T) {

--- a/drivers/gpio/led_driver_test.go
+++ b/drivers/gpio/led_driver_test.go
@@ -52,12 +52,12 @@ func TestLedDriver(t *testing.T) {
 
 func TestLedDriverStart(t *testing.T) {
 	d := initTestLedDriver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestLedDriverHalt(t *testing.T) {
 	d := initTestLedDriver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestLedDriverToggle(t *testing.T) {

--- a/drivers/gpio/makey_button_driver_test.go
+++ b/drivers/gpio/makey_button_driver_test.go
@@ -24,7 +24,7 @@ func TestMakeyButtonDriverHalt(t *testing.T) {
 		<-d.halt
 		close(done)
 	}()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 	select {
 	case <-done:
 	case <-time.After(makeyTestDelay * time.Millisecond):
@@ -47,7 +47,7 @@ func TestMakeyButtonDriverStart(t *testing.T) {
 	a := newGpioTestAdaptor()
 	d := NewMakeyButtonDriver(a, "1")
 
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 
 	_ = d.Once(ButtonPush, func(data interface{}) {
 		assert.True(t, d.Active)

--- a/drivers/gpio/max7219_driver_test.go
+++ b/drivers/gpio/max7219_driver_test.go
@@ -32,12 +32,12 @@ func TestMAX7219Driver(t *testing.T) {
 
 func TestMAX7219DriverStart(t *testing.T) {
 	d := initTestMAX7219Driver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestMAX7219DriverHalt(t *testing.T) {
 	d := initTestMAX7219Driver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestMAX7219DriverDefaultName(t *testing.T) {

--- a/drivers/gpio/motor_driver_test.go
+++ b/drivers/gpio/motor_driver_test.go
@@ -21,12 +21,12 @@ func TestMotorDriver(t *testing.T) {
 
 func TestMotorDriverStart(t *testing.T) {
 	d := initTestMotorDriver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestMotorDriverHalt(t *testing.T) {
 	d := initTestMotorDriver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestMotorDriverIsOn(t *testing.T) {

--- a/drivers/gpio/pir_motion_driver_test.go
+++ b/drivers/gpio/pir_motion_driver_test.go
@@ -23,7 +23,7 @@ func TestPIRMotionDriverHalt(t *testing.T) {
 	go func() {
 		<-d.halt
 	}()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestPIRMotionDriver(t *testing.T) {
@@ -39,7 +39,7 @@ func TestPIRMotionDriverStart(t *testing.T) {
 	a := newGpioTestAdaptor()
 	d := NewPIRMotionDriver(a, "1")
 
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 
 	_ = d.Once(MotionDetected, func(data interface{}) {
 		assert.True(t, d.Active)

--- a/drivers/gpio/relay_driver_test.go
+++ b/drivers/gpio/relay_driver_test.go
@@ -38,12 +38,12 @@ func TestRelayDriverSetName(t *testing.T) {
 
 func TestRelayDriverStart(t *testing.T) {
 	d, _ := initTestRelayDriver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestRelayDriverHalt(t *testing.T) {
 	d, _ := initTestRelayDriver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestRelayDriverToggle(t *testing.T) {

--- a/drivers/gpio/rgb_led_driver_test.go
+++ b/drivers/gpio/rgb_led_driver_test.go
@@ -56,12 +56,12 @@ func TestRgbLedDriver(t *testing.T) {
 
 func TestRgbLedDriverStart(t *testing.T) {
 	d := initTestRgbLedDriver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestRgbLedDriverHalt(t *testing.T) {
 	d := initTestRgbLedDriver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestRgbLedDriverToggle(t *testing.T) {
@@ -76,7 +76,7 @@ func TestRgbLedDriverToggle(t *testing.T) {
 func TestRgbLedDriverSetLevel(t *testing.T) {
 	a := newGpioTestAdaptor()
 	d := NewRgbLedDriver(a, "1", "2", "3")
-	assert.Nil(t, d.SetLevel("1", 150))
+	assert.NoError(t, d.SetLevel("1", 150))
 
 	d = NewRgbLedDriver(a, "1", "2", "3")
 	a.testAdaptorPwmWrite = func(string, byte) (err error) {

--- a/drivers/gpio/servo_driver_test.go
+++ b/drivers/gpio/servo_driver_test.go
@@ -43,12 +43,12 @@ func TestServoDriver(t *testing.T) {
 
 func TestServoDriverStart(t *testing.T) {
 	d := initTestServoDriver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestServoDriverHalt(t *testing.T) {
 	d := initTestServoDriver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestServoDriverMove(t *testing.T) {

--- a/drivers/gpio/tm1638_driver_test.go
+++ b/drivers/gpio/tm1638_driver_test.go
@@ -32,12 +32,12 @@ func TestTM1638Driver(t *testing.T) {
 
 func TestTM1638DriverStart(t *testing.T) {
 	d := initTestTM1638Driver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestTM1638DriverHalt(t *testing.T) {
 	d := initTestTM1638Driver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestTM1638DriverDefaultName(t *testing.T) {

--- a/drivers/i2c/adafruit1109_driver_test.go
+++ b/drivers/i2c/adafruit1109_driver_test.go
@@ -49,12 +49,12 @@ func TestNewAdafruit1109Driver(t *testing.T) {
 
 func TestAdafruit1109Connect(t *testing.T) {
 	d, _ := initTestAdafruit1109WithStubbedAdaptor()
-	assert.Nil(t, d.Connect())
+	assert.NoError(t, d.Connect())
 }
 
 func TestAdafruit1109Finalize(t *testing.T) {
 	d, _ := initTestAdafruit1109WithStubbedAdaptor()
-	assert.Nil(t, d.Finalize())
+	assert.NoError(t, d.Finalize())
 }
 
 func TestAdafruit1109SetName(t *testing.T) {
@@ -65,7 +65,7 @@ func TestAdafruit1109SetName(t *testing.T) {
 
 func TestAdafruit1109Start(t *testing.T) {
 	d, _ := initTestAdafruit1109WithStubbedAdaptor()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestAdafruit1109StartWriteErr(t *testing.T) {
@@ -87,7 +87,7 @@ func TestAdafruit1109StartReadErr(t *testing.T) {
 func TestAdafruit1109Halt(t *testing.T) {
 	d, _ := initTestAdafruit1109WithStubbedAdaptor()
 	_ = d.Start()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestAdafruit1109DigitalRead(t *testing.T) {
@@ -128,7 +128,7 @@ func TestAdafruit1109DigitalRead(t *testing.T) {
 			// act
 			got, err := d.DigitalRead(name)
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, 1, numCallsRead)
 			assert.Equal(t, 1, len(a.written))
 			assert.Equal(t, tc.wantReg, a.written[0])
@@ -160,7 +160,7 @@ func TestAdafruit1109SelectButton(t *testing.T) {
 			// act
 			got, err := d.SelectButton()
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, 1, numCallsRead)
 			assert.Equal(t, tc.want, got)
 		})
@@ -190,7 +190,7 @@ func TestAdafruit1109UpButton(t *testing.T) {
 			// act
 			got, err := d.UpButton()
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, 1, numCallsRead)
 			assert.Equal(t, tc.want, got)
 		})
@@ -220,7 +220,7 @@ func TestAdafruit1109DownButton(t *testing.T) {
 			// act
 			got, err := d.DownButton()
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, 1, numCallsRead)
 			assert.Equal(t, tc.want, got)
 		})
@@ -250,7 +250,7 @@ func TestAdafruit1109LeftButton(t *testing.T) {
 			// act
 			got, err := d.LeftButton()
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, 1, numCallsRead)
 			assert.Equal(t, tc.want, got)
 		})
@@ -280,7 +280,7 @@ func TestAdafruit1109RightButton(t *testing.T) {
 			// act
 			got, err := d.RightButton()
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, 1, numCallsRead)
 			assert.Equal(t, tc.want, got)
 		})

--- a/drivers/i2c/adafruit_driver_test.go
+++ b/drivers/i2c/adafruit_driver_test.go
@@ -37,7 +37,7 @@ func TestNewAdafruitMotorHatDriver(t *testing.T) {
 func TestAdafruitMotorHatDriverStart(t *testing.T) {
 	ada, _ := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
 	assert.NotNil(t, ada.Connection())
-	assert.Nil(t, ada.Start())
+	assert.NoError(t, ada.Start())
 }
 
 func TestAdafruitMotorHatDriverStartWriteError(t *testing.T) {
@@ -65,7 +65,7 @@ func TestAdafruitMotorHatDriverStartConnectError(t *testing.T) {
 func TestAdafruitMotorHatDriverHalt(t *testing.T) {
 	ada, _ := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
 
-	assert.Nil(t, ada.Halt())
+	assert.NoError(t, ada.Halt())
 }
 
 func TestSetHatAddresses(t *testing.T) {
@@ -73,24 +73,24 @@ func TestSetHatAddresses(t *testing.T) {
 
 	motorHatAddr := 0x61
 	servoHatAddr := 0x41
-	assert.Nil(t, ada.SetMotorHatAddress(motorHatAddr))
-	assert.Nil(t, ada.SetServoHatAddress(servoHatAddr))
+	assert.NoError(t, ada.SetMotorHatAddress(motorHatAddr))
+	assert.NoError(t, ada.SetServoHatAddress(servoHatAddr))
 }
 
 func TestAdafruitMotorHatDriverSetServoMotorFreq(t *testing.T) {
 	ada, _ := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
 
-	assert.Nil(t, ada.Start())
+	assert.NoError(t, ada.Start())
 
 	freq := 60.0
 	err := ada.SetServoMotorFreq(freq)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAdafruitMotorHatDriverSetServoMotorFreqError(t *testing.T) {
 	ada, a := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
 
-	assert.Nil(t, ada.Start())
+	assert.NoError(t, ada.Start())
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
@@ -102,19 +102,19 @@ func TestAdafruitMotorHatDriverSetServoMotorFreqError(t *testing.T) {
 func TestAdafruitMotorHatDriverSetServoMotorPulse(t *testing.T) {
 	ada, _ := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
 
-	assert.Nil(t, ada.Start())
+	assert.NoError(t, ada.Start())
 
 	var channel byte = 7
 	var on int32 = 1234
 	var off int32 = 4321
 	err := ada.SetServoMotorPulse(channel, on, off)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAdafruitMotorHatDriverSetServoMotorPulseError(t *testing.T) {
 	ada, a := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
 
-	assert.Nil(t, ada.Start())
+	assert.NoError(t, ada.Start())
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
@@ -128,18 +128,18 @@ func TestAdafruitMotorHatDriverSetServoMotorPulseError(t *testing.T) {
 func TestAdafruitMotorHatDriverSetDCMotorSpeed(t *testing.T) {
 	ada, _ := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
 
-	assert.Nil(t, ada.Start())
+	assert.NoError(t, ada.Start())
 
 	dcMotor := 1
 	var speed int32 = 255
 	err := ada.SetDCMotorSpeed(dcMotor, speed)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAdafruitMotorHatDriverSetDCMotorSpeedError(t *testing.T) {
 	ada, a := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
 
-	assert.Nil(t, ada.Start())
+	assert.NoError(t, ada.Start())
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
@@ -150,17 +150,17 @@ func TestAdafruitMotorHatDriverSetDCMotorSpeedError(t *testing.T) {
 func TestAdafruitMotorHatDriverRunDCMotor(t *testing.T) {
 	ada, _ := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
 
-	assert.Nil(t, ada.Start())
+	assert.NoError(t, ada.Start())
 
 	dcMotor := 1
-	assert.Nil(t, ada.RunDCMotor(dcMotor, AdafruitForward))
-	assert.Nil(t, ada.RunDCMotor(dcMotor, AdafruitBackward))
-	assert.Nil(t, ada.RunDCMotor(dcMotor, AdafruitRelease))
+	assert.NoError(t, ada.RunDCMotor(dcMotor, AdafruitForward))
+	assert.NoError(t, ada.RunDCMotor(dcMotor, AdafruitBackward))
+	assert.NoError(t, ada.RunDCMotor(dcMotor, AdafruitRelease))
 }
 
 func TestAdafruitMotorHatDriverRunDCMotorError(t *testing.T) {
 	ada, a := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
-	assert.Nil(t, ada.Start())
+	assert.NoError(t, ada.Start())
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
@@ -174,63 +174,63 @@ func TestAdafruitMotorHatDriverRunDCMotorError(t *testing.T) {
 func TestAdafruitMotorHatDriverSetStepperMotorSpeed(t *testing.T) {
 	ada, _ := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
 
-	assert.Nil(t, ada.Start())
+	assert.NoError(t, ada.Start())
 
 	stepperMotor := 1
 	rpm := 30
-	assert.Nil(t, ada.SetStepperMotorSpeed(stepperMotor, rpm))
+	assert.NoError(t, ada.SetStepperMotorSpeed(stepperMotor, rpm))
 }
 
 func TestAdafruitMotorHatDriverStepperMicroStep(t *testing.T) {
 	ada, _ := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
 
-	assert.Nil(t, ada.Start())
+	assert.NoError(t, ada.Start())
 
 	// NOTE: not using the direction and style constants to prevent importing
 	// the i2c package
 	stepperMotor := 0
 	steps := 50
 	err := ada.Step(stepperMotor, steps, 1, 3)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAdafruitMotorHatDriverStepperSingleStep(t *testing.T) {
 	ada, _ := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
 
-	assert.Nil(t, ada.Start())
+	assert.NoError(t, ada.Start())
 
 	// NOTE: not using the direction and style constants to prevent importing
 	// the i2c package
 	stepperMotor := 0
 	steps := 50
 	err := ada.Step(stepperMotor, steps, 1, 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAdafruitMotorHatDriverStepperDoubleStep(t *testing.T) {
 	ada, _ := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
 
-	assert.Nil(t, ada.Start())
+	assert.NoError(t, ada.Start())
 
 	// NOTE: not using the direction and style constants to prevent importing
 	// the i2c package
 	stepperMotor := 0
 	steps := 50
 	err := ada.Step(stepperMotor, steps, 1, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAdafruitMotorHatDriverStepperInterleaveStep(t *testing.T) {
 	ada, _ := initTestAdafruitMotorHatDriverWithStubbedAdaptor()
 
-	assert.Nil(t, ada.Start())
+	assert.NoError(t, ada.Start())
 
 	// NOTE: not using the direction and style constants to prevent importing
 	// the i2c package
 	stepperMotor := 0
 	steps := 50
 	err := ada.Step(stepperMotor, steps, 1, 2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAdafruitMotorHatDriverSetName(t *testing.T) {

--- a/drivers/i2c/ads1x15_driver_1015_test.go
+++ b/drivers/i2c/ads1x15_driver_1015_test.go
@@ -73,35 +73,35 @@ func TestADS1015AnalogRead(t *testing.T) {
 
 	val, err := d.AnalogRead("0")
 	assert.Equal(t, 32767, val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	val, err = d.AnalogRead("1")
 	assert.Equal(t, 32767, val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	val, err = d.AnalogRead("2")
 	assert.Equal(t, 32767, val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	val, err = d.AnalogRead("3")
 	assert.Equal(t, 32767, val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	val, err = d.AnalogRead("0-1")
 	assert.Equal(t, 32767, val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	val, err = d.AnalogRead("0-3")
 	assert.Equal(t, 32767, val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	val, err = d.AnalogRead("1-3")
 	assert.Equal(t, 32767, val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	val, err = d.AnalogRead("2-3")
 	assert.Equal(t, 32767, val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	_, err = d.AnalogRead("3-2")
 	assert.NotNil(t, err.Error())
@@ -269,7 +269,7 @@ func TestADS1015_rawRead(t *testing.T) {
 			// act
 			got, err := d.rawRead(channel, channelOffset, tt.gain, tt.dataRate)
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, 3, numCallsRead)
 			assert.Equal(t, 6, len(a.written))

--- a/drivers/i2c/ads1x15_driver_1115_test.go
+++ b/drivers/i2c/ads1x15_driver_1115_test.go
@@ -73,35 +73,35 @@ func TestADS1115AnalogRead(t *testing.T) {
 
 	val, err := d.AnalogRead("0")
 	assert.Equal(t, 32767, val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	val, err = d.AnalogRead("1")
 	assert.Equal(t, 32767, val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	val, err = d.AnalogRead("2")
 	assert.Equal(t, 32767, val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	val, err = d.AnalogRead("3")
 	assert.Equal(t, 32767, val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	val, err = d.AnalogRead("0-1")
 	assert.Equal(t, 32767, val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	val, err = d.AnalogRead("0-3")
 	assert.Equal(t, 32767, val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	val, err = d.AnalogRead("1-3")
 	assert.Equal(t, 32767, val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	val, err = d.AnalogRead("2-3")
 	assert.Equal(t, 32767, val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	_, err = d.AnalogRead("3-2")
 	assert.NotNil(t, err.Error())
@@ -269,7 +269,7 @@ func TestADS1115_rawRead(t *testing.T) {
 			// act
 			got, err := d.rawRead(channel, channelOffset, tt.gain, tt.dataRate)
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, 3, numCallsRead)
 			assert.Equal(t, 6, len(a.written))

--- a/drivers/i2c/adxl345_driver_test.go
+++ b/drivers/i2c/adxl345_driver_test.go
@@ -85,7 +85,7 @@ func TestADXL345UseLowPower(t *testing.T) {
 	// act
 	err := d.UseLowPower(setVal)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, setVal, d.bwRate.lowPower)
 	assert.Equal(t, 2, len(a.written))
 	assert.Equal(t, wantReg, a.written[0])
@@ -107,7 +107,7 @@ func TestADXL345SetRate(t *testing.T) {
 	// act
 	err := d.SetRate(setVal)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, setVal, d.bwRate.rate)
 	assert.Equal(t, 2, len(a.written))
 	assert.Equal(t, wantReg, a.written[0])
@@ -129,7 +129,7 @@ func TestADXL345SetRange(t *testing.T) {
 	// act
 	err := d.SetRange(setVal)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, setVal, d.dataFormat.fullScaleRange)
 	assert.Equal(t, 2, len(a.written))
 	assert.Equal(t, wantReg, a.written[0])
@@ -184,7 +184,7 @@ func TestADXL345RawXYZ(t *testing.T) {
 			// act
 			gotX, gotY, gotZ, err := d.RawXYZ()
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.wantX, gotX)
 			assert.Equal(t, tc.wantY, gotY)
 			assert.Equal(t, tc.wantZ, gotZ)
@@ -292,7 +292,7 @@ func TestADXL345_initialize(t *testing.T) {
 	// act, assert - initialize() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 6, len(a.written))
 	assert.Equal(t, wantRateReg, a.written[0])
 	assert.Equal(t, wantRateRegVal, a.written[1])
@@ -316,7 +316,7 @@ func TestADXL345_shutdown(t *testing.T) {
 	// act, assert - shutdown() must be called on Halt()
 	err := d.Halt()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, len(a.written))
 	assert.Equal(t, wantReg, a.written[0])
 	assert.Equal(t, wantVal, a.written[1])

--- a/drivers/i2c/bh1750_driver_test.go
+++ b/drivers/i2c/bh1750_driver_test.go
@@ -43,12 +43,12 @@ func TestBH1750Options(t *testing.T) {
 
 func TestBH1750Start(t *testing.T) {
 	d := NewBH1750Driver(newI2cTestAdaptor())
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestBH1750Halt(t *testing.T) {
 	d, _ := initTestBH1750DriverWithStubbedAdaptor()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestBH1750NullLux(t *testing.T) {

--- a/drivers/i2c/blinkm_driver_test.go
+++ b/drivers/i2c/blinkm_driver_test.go
@@ -42,12 +42,12 @@ func TestBlinkMOptions(t *testing.T) {
 
 func TestBlinkMStart(t *testing.T) {
 	d := NewBlinkMDriver(newI2cTestAdaptor())
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestBlinkMHalt(t *testing.T) {
 	d, _ := initTestBlinkMDriverWithStubbedAdaptor()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 // Commands

--- a/drivers/i2c/bme280_driver_test.go
+++ b/drivers/i2c/bme280_driver_test.go
@@ -72,7 +72,7 @@ func TestBME280Measurements(t *testing.T) {
 	}
 	_ = bme280.Start()
 	hum, err := bme280.Humidity()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, float32(51.20179), hum)
 }
 
@@ -186,5 +186,5 @@ func TestBME280_initializationBME280(t *testing.T) {
 		}
 		return 0, nil
 	}
-	assert.Nil(t, bme280.Start())
+	assert.NoError(t, bme280.Start())
 }

--- a/drivers/i2c/bmp180_driver_test.go
+++ b/drivers/i2c/bmp180_driver_test.go
@@ -72,10 +72,10 @@ func TestBMP180Measurements(t *testing.T) {
 	}
 	_ = bmp180.Start()
 	temp, err := bmp180.Temperature()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, float32(15.0), temp)
 	pressure, err := bmp180.Pressure()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, float32(69964), pressure)
 }
 
@@ -183,7 +183,7 @@ func TestBMP180_initialization(t *testing.T) {
 	// act, assert - initialization() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, numCallsRead)
 	assert.Equal(t, 1, len(a.written))
 	assert.Equal(t, uint8(0xAA), a.written[0])

--- a/drivers/i2c/bmp280_driver_test.go
+++ b/drivers/i2c/bmp280_driver_test.go
@@ -88,13 +88,13 @@ func TestBMP280Measurements(t *testing.T) {
 	}
 	_ = d.Start()
 	temp, err := d.Temperature()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, float32(25.014637), temp)
 	pressure, err := d.Pressure()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, float32(99545.414), pressure)
 	alt, err := d.Altitude()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, float32(149.22713), alt)
 }
 
@@ -188,7 +188,7 @@ func TestBMP280_initialization(t *testing.T) {
 	// act, assert - initialization() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, numCallsRead)
 	assert.Equal(t, 5, len(a.written))
 	assert.Equal(t, wantCalibReg, a.written[0])

--- a/drivers/i2c/bmp388_driver_test.go
+++ b/drivers/i2c/bmp388_driver_test.go
@@ -84,13 +84,13 @@ func TestBMP388Measurements(t *testing.T) {
 	}
 	_ = d.Start()
 	temp, err := d.Temperature(2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, float32(22.906143), temp)
 	pressure, err := d.Pressure(2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, float32(98874.85), pressure)
 	alt, err := d.Altitude(2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, float32(205.89395), alt)
 }
 
@@ -176,7 +176,7 @@ func TestBMP388_initialization(t *testing.T) {
 	// act, assert - initialization() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, numCallsRead)
 	assert.Equal(t, 6, len(a.written))
 	assert.Equal(t, wantChipIDReg, a.written[0])

--- a/drivers/i2c/ccs811_driver_test.go
+++ b/drivers/i2c/ccs811_driver_test.go
@@ -255,7 +255,7 @@ func TestCCS811_initialize(t *testing.T) {
 	// arrange, act - initialize() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, numCallsRead)
 	assert.Equal(t, 9, len(a.written))
 	assert.Equal(t, wantChipIDReg, a.written[0])

--- a/drivers/i2c/drv2605l_driver_test.go
+++ b/drivers/i2c/drv2605l_driver_test.go
@@ -51,7 +51,7 @@ func TestDRV2605LOptions(t *testing.T) {
 
 func TestDRV2605LStart(t *testing.T) {
 	d := NewDRV2605LDriver(newI2cTestAdaptor())
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestDRV2605LHalt(t *testing.T) {
@@ -62,7 +62,7 @@ func TestDRV2605LHalt(t *testing.T) {
 	writeNewStandbyModeData := []byte{drv2605RegMode, 42 | drv2605Standby}
 	d, a := initTestDRV2605LDriverWithStubbedAdaptor()
 	a.written = []byte{}
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 	assert.Equal(t, append(append(writeStopPlaybackData, readCurrentStandbyModeData), writeNewStandbyModeData...), a.written)
 }
 
@@ -76,7 +76,7 @@ func TestDRV2605LGetPause(t *testing.T) {
 func TestDRV2605LSequenceTermination(t *testing.T) {
 	d, a := initTestDRV2605LDriverWithStubbedAdaptor()
 	a.written = []byte{}
-	assert.Nil(t, d.SetSequence([]byte{1, 2}))
+	assert.NoError(t, d.SetSequence([]byte{1, 2}))
 	assert.Equal(t, []byte{
 		drv2605RegWaveSeq1, 1,
 		drv2605RegWaveSeq2, 2,
@@ -87,7 +87,7 @@ func TestDRV2605LSequenceTermination(t *testing.T) {
 func TestDRV2605LSequenceTruncation(t *testing.T) {
 	d, a := initTestDRV2605LDriverWithStubbedAdaptor()
 	a.written = []byte{}
-	assert.Nil(t, d.SetSequence([]byte{1, 2, 3, 4, 5, 6, 7, 8, 99, 100}))
+	assert.NoError(t, d.SetSequence([]byte{1, 2, 3, 4, 5, 6, 7, 8, 99, 100}))
 	assert.Equal(t, []byte{
 		drv2605RegWaveSeq1, 1,
 		drv2605RegWaveSeq2, 2,
@@ -102,7 +102,7 @@ func TestDRV2605LSequenceTruncation(t *testing.T) {
 
 func TestDRV2605LSetMode(t *testing.T) {
 	d, _ := initTestDRV2605LDriverWithStubbedAdaptor()
-	assert.Nil(t, d.SetMode(DRV2605ModeIntTrig))
+	assert.NoError(t, d.SetMode(DRV2605ModeIntTrig))
 }
 
 func TestDRV2605LSetModeReadError(t *testing.T) {
@@ -115,7 +115,7 @@ func TestDRV2605LSetModeReadError(t *testing.T) {
 
 func TestDRV2605LSetStandbyMode(t *testing.T) {
 	d, _ := initTestDRV2605LDriverWithStubbedAdaptor()
-	assert.Nil(t, d.SetStandbyMode(true))
+	assert.NoError(t, d.SetStandbyMode(true))
 }
 
 func TestDRV2605LSetStandbyModeReadError(t *testing.T) {
@@ -128,10 +128,10 @@ func TestDRV2605LSetStandbyModeReadError(t *testing.T) {
 
 func TestDRV2605LSelectLibrary(t *testing.T) {
 	d, _ := initTestDRV2605LDriverWithStubbedAdaptor()
-	assert.Nil(t, d.SelectLibrary(1))
+	assert.NoError(t, d.SelectLibrary(1))
 }
 
 func TestDRV2605LGo(t *testing.T) {
 	d, _ := initTestDRV2605LDriverWithStubbedAdaptor()
-	assert.Nil(t, d.Go())
+	assert.NoError(t, d.Go())
 }

--- a/drivers/i2c/grovepi_driver_test.go
+++ b/drivers/i2c/grovepi_driver_test.go
@@ -219,7 +219,7 @@ func TestGrovePiSomeWrite(t *testing.T) {
 				return
 			}
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.wantWritten, a.written)
 		})
 	}

--- a/drivers/i2c/hmc5883l_driver_test.go
+++ b/drivers/i2c/hmc5883l_driver_test.go
@@ -121,7 +121,7 @@ func TestHMC5883LRead(t *testing.T) {
 			// act
 			gotX, gotY, gotZ, err := d.Read()
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.wantX, gotX)
 			assert.Equal(t, tc.wantY, gotY)
 			assert.Equal(t, tc.wantZ, gotZ)
@@ -177,7 +177,7 @@ func TestHMC5883L_readRawData(t *testing.T) {
 			// act
 			gotX, gotY, gotZ, err := d.readRawData()
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.wantX, gotX)
 			assert.Equal(t, tc.wantY, gotY)
 			assert.Equal(t, tc.wantZ, gotZ)
@@ -203,7 +203,7 @@ func TestHMC5883L_initialize(t *testing.T) {
 	// act, assert - initialize() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 6, len(a.written))
 	assert.Equal(t, uint8(hmc5883lRegA), a.written[0])
 	assert.Equal(t, wantRegA, a.written[1])

--- a/drivers/i2c/hmc6352_driver_test.go
+++ b/drivers/i2c/hmc6352_driver_test.go
@@ -42,12 +42,12 @@ func TestHMC6352Options(t *testing.T) {
 
 func TestHMC6352Start(t *testing.T) {
 	d := NewHMC6352Driver(newI2cTestAdaptor())
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestHMC6352Halt(t *testing.T) {
 	d, _ := initTestHMC6352DriverWithStubbedAdaptor()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestHMC6352Heading(t *testing.T) {

--- a/drivers/i2c/i2c_connection_test.go
+++ b/drivers/i2c/i2c_connection_test.go
@@ -75,7 +75,7 @@ func TestI2CAddress(t *testing.T) {
 
 func TestI2CClose(t *testing.T) {
 	c := NewConnection(initI2CDevice(), 0x06)
-	assert.Nil(t, c.Close())
+	assert.NoError(t, c.Close())
 }
 
 func TestI2CRead(t *testing.T) {
@@ -141,7 +141,7 @@ func TestI2CReadWordDataAddressError(t *testing.T) {
 func TestI2CWriteByte(t *testing.T) {
 	c := NewConnection(initI2CDevice(), 0x06)
 	err := c.WriteByte(0x01)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestI2CWriteByteAddressError(t *testing.T) {
@@ -153,7 +153,7 @@ func TestI2CWriteByteAddressError(t *testing.T) {
 func TestI2CWriteByteData(t *testing.T) {
 	c := NewConnection(initI2CDevice(), 0x06)
 	err := c.WriteByteData(0x01, 0x01)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestI2CWriteByteDataAddressError(t *testing.T) {
@@ -165,7 +165,7 @@ func TestI2CWriteByteDataAddressError(t *testing.T) {
 func TestI2CWriteWordData(t *testing.T) {
 	c := NewConnection(initI2CDevice(), 0x06)
 	err := c.WriteWordData(0x01, 0x01)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestI2CWriteWordDataAddressError(t *testing.T) {
@@ -177,7 +177,7 @@ func TestI2CWriteWordDataAddressError(t *testing.T) {
 func TestI2CWriteBlockData(t *testing.T) {
 	c := NewConnection(initI2CDevice(), 0x06)
 	err := c.WriteBlockData(0x01, []byte{0x01, 0x02})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestI2CWriteBlockDataAddressError(t *testing.T) {

--- a/drivers/i2c/i2c_driver_test.go
+++ b/drivers/i2c/i2c_driver_test.go
@@ -34,8 +34,8 @@ func TestNewDriver(t *testing.T) {
 	assert.Equal(t, 0x15, d.defaultAddress)
 	assert.Equal(t, a, d.connector)
 	assert.Nil(t, d.connection)
-	assert.Nil(t, d.afterStart())
-	assert.Nil(t, d.beforeHalt())
+	assert.NoError(t, d.afterStart())
+	assert.NoError(t, d.beforeHalt())
 	assert.NotNil(t, d.Config)
 	assert.NotNil(t, d.Commander)
 	assert.NotNil(t, d.mutex)
@@ -61,7 +61,7 @@ func TestStart(t *testing.T) {
 	// arrange
 	d, a := initDriverWithStubbedAdaptor()
 	// act, assert
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 	assert.Equal(t, a.address, 0x15)
 }
 
@@ -77,7 +77,7 @@ func TestHalt(t *testing.T) {
 	// arrange
 	d := initTestDriver()
 	// act, assert
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestWrite(t *testing.T) {
@@ -98,7 +98,7 @@ func TestWrite(t *testing.T) {
 	// act
 	err := d.Write(address, value)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, numCallsWrite)
 	assert.Equal(t, wantAddress, a.written[0])
 	assert.Equal(t, uint8(value), a.written[1])
@@ -129,7 +129,7 @@ func TestRead(t *testing.T) {
 	// act
 	val, err := d.Read(address)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, int(want), val)
 	assert.Equal(t, 1, numCallsWrite)
 	assert.Equal(t, wantAddress, a.written[0])

--- a/drivers/i2c/ina3221_driver_test.go
+++ b/drivers/i2c/ina3221_driver_test.go
@@ -42,12 +42,12 @@ func TestINA3221Options(t *testing.T) {
 
 func TestINA3221Start(t *testing.T) {
 	d := NewINA3221Driver(newI2cTestAdaptor())
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestINA3221Halt(t *testing.T) {
 	d, _ := initTestINA3221DriverWithStubbedAdaptor()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestINA3221GetBusVoltage(t *testing.T) {
@@ -60,7 +60,7 @@ func TestINA3221GetBusVoltage(t *testing.T) {
 
 	v, err := d.GetBusVoltage(INA3221Channel1)
 	assert.Equal(t, float64(13.928), v)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestINA3221GetBusVoltageReadError(t *testing.T) {
@@ -83,7 +83,7 @@ func TestINA3221GetShuntVoltage(t *testing.T) {
 
 	v, err := d.GetShuntVoltage(INA3221Channel1)
 	assert.Equal(t, float64(7.48), v)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestINA3221GetShuntVoltageReadError(t *testing.T) {
@@ -106,7 +106,7 @@ func TestINA3221GetCurrent(t *testing.T) {
 
 	v, err := d.GetCurrent(INA3221Channel1)
 	assert.Equal(t, float64(74.8), v)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestINA3221CurrentReadError(t *testing.T) {
@@ -131,7 +131,7 @@ func TestINA3221GetLoadVoltage(t *testing.T) {
 
 	v, err := d.GetLoadVoltage(INA3221Channel2)
 	assert.Equal(t, float64(13.935480), v)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestINA3221GetLoadVoltageReadError(t *testing.T) {

--- a/drivers/i2c/jhd1313m1_driver_test.go
+++ b/drivers/i2c/jhd1313m1_driver_test.go
@@ -54,7 +54,7 @@ func TestJHD1313MDriverOptions(t *testing.T) {
 
 func TestJHD1313MDriverStart(t *testing.T) {
 	d := initTestJHD1313M1Driver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestJHD1313MStartConnectError(t *testing.T) {
@@ -74,13 +74,13 @@ func TestJHD1313MDriverStartWriteError(t *testing.T) {
 func TestJHD1313MDriverHalt(t *testing.T) {
 	d := initTestJHD1313M1Driver()
 	_ = d.Start()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestJHD1313MDriverSetRgb(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	_ = d.Start()
-	assert.Nil(t, d.SetRGB(0x00, 0x00, 0x00))
+	assert.NoError(t, d.SetRGB(0x00, 0x00, 0x00))
 }
 
 func TestJHD1313MDriverSetRgbError(t *testing.T) {
@@ -96,7 +96,7 @@ func TestJHD1313MDriverSetRgbError(t *testing.T) {
 func TestJHD1313MDriverClear(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	_ = d.Start()
-	assert.Nil(t, d.Clear())
+	assert.NoError(t, d.Clear())
 }
 
 func TestJHD1313MDriverClearError(t *testing.T) {
@@ -112,13 +112,13 @@ func TestJHD1313MDriverClearError(t *testing.T) {
 func TestJHD1313MDriverHome(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	_ = d.Start()
-	assert.Nil(t, d.Home())
+	assert.NoError(t, d.Home())
 }
 
 func TestJHD1313MDriverWrite(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	_ = d.Start()
-	assert.Nil(t, d.Write("Hello"))
+	assert.NoError(t, d.Write("Hello"))
 }
 
 func TestJHD1313MDriverWriteError(t *testing.T) {
@@ -134,7 +134,7 @@ func TestJHD1313MDriverWriteError(t *testing.T) {
 func TestJHD1313MDriverWriteTwoLines(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	_ = d.Start()
-	assert.Nil(t, d.Write("Hello\nthere"))
+	assert.NoError(t, d.Write("Hello\nthere"))
 }
 
 func TestJHD1313MDriverWriteTwoLinesError(t *testing.T) {
@@ -150,13 +150,13 @@ func TestJHD1313MDriverWriteTwoLinesError(t *testing.T) {
 func TestJHD1313MDriverSetPosition(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	_ = d.Start()
-	assert.Nil(t, d.SetPosition(2))
+	assert.NoError(t, d.SetPosition(2))
 }
 
 func TestJHD1313MDriverSetSecondLinePosition(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	_ = d.Start()
-	assert.Nil(t, d.SetPosition(18))
+	assert.NoError(t, d.SetPosition(18))
 }
 
 func TestJHD1313MDriverSetPositionInvalid(t *testing.T) {
@@ -169,20 +169,20 @@ func TestJHD1313MDriverSetPositionInvalid(t *testing.T) {
 func TestJHD1313MDriverScroll(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	_ = d.Start()
-	assert.Nil(t, d.Scroll(true))
+	assert.NoError(t, d.Scroll(true))
 }
 
 func TestJHD1313MDriverReverseScroll(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	_ = d.Start()
-	assert.Nil(t, d.Scroll(false))
+	assert.NoError(t, d.Scroll(false))
 }
 
 func TestJHD1313MDriverSetCustomChar(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	data := [8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 	_ = d.Start()
-	assert.Nil(t, d.SetCustomChar(0, data))
+	assert.NoError(t, d.SetCustomChar(0, data))
 }
 
 func TestJHD1313MDriverSetCustomCharError(t *testing.T) {

--- a/drivers/i2c/l3gd20h_driver_test.go
+++ b/drivers/i2c/l3gd20h_driver_test.go
@@ -130,7 +130,7 @@ func TestL3GD20HFullScaleRange(t *testing.T) {
 	// act
 	got, err := d.FullScaleRange()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(a.written))
 	assert.Equal(t, uint8(0x23), a.written[0])
 	assert.Equal(t, readValue, got)
@@ -196,7 +196,7 @@ func TestL3GD20HMeasurement(t *testing.T) {
 			// act
 			x, y, z, err := d.XYZ()
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, 1, len(a.written))
 			assert.Equal(t, uint8(0xA8), a.written[0])
 			assert.Equal(t, tc.wantX, x)

--- a/drivers/i2c/lidarlite_driver_test.go
+++ b/drivers/i2c/lidarlite_driver_test.go
@@ -48,12 +48,12 @@ func TestLIDARLiteDriverOptions(t *testing.T) {
 
 func TestLIDARLiteDriverStart(t *testing.T) {
 	d := NewLIDARLiteDriver(newI2cTestAdaptor())
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestLIDARLiteDriverHalt(t *testing.T) {
 	d := initTestLIDARLiteDriver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestLIDARLiteDriverDistance(t *testing.T) {
@@ -72,7 +72,7 @@ func TestLIDARLiteDriverDistance(t *testing.T) {
 
 	distance, err := d.Distance()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, int(25345), distance)
 
 	// when insufficient bytes have been read

--- a/drivers/i2c/mcp23017_driver_test.go
+++ b/drivers/i2c/mcp23017_driver_test.go
@@ -147,7 +147,7 @@ func TestMCP23017WriteGPIO(t *testing.T) {
 		// act
 		err := d.WriteGPIO(testPin, testPort, uint8(bitState))
 		// assert
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 6, len(a.written))
 		assert.Equal(t, wantReg1, a.written[0])
 		assert.Equal(t, wantReg1, a.written[1])
@@ -186,7 +186,7 @@ func TestMCP23017WriteGPIONoRefresh(t *testing.T) {
 		// act
 		err := d.WriteGPIO(testPin, testPort, uint8(bitState))
 		// assert
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 2, len(a.written))
 		assert.Equal(t, wantReg1, a.written[0])
 		assert.Equal(t, wantReg2, a.written[1])
@@ -223,7 +223,7 @@ func TestMCP23017WriteGPIONoAutoDir(t *testing.T) {
 		// act
 		err := d.WriteGPIO(testPin, testPort, uint8(bitState))
 		// assert
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 3, len(a.written))
 		assert.Equal(t, wantReg, a.written[0])
 		assert.Equal(t, wantReg, a.written[1])
@@ -290,7 +290,7 @@ func TestMCP23017ReadGPIO(t *testing.T) {
 		// act
 		val, err := d.ReadGPIO(testPin, testPort)
 		// assert
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 2, numCallsRead)
 		assert.Equal(t, 4, len(a.written))
 		assert.Equal(t, wantReg1, a.written[0])
@@ -328,7 +328,7 @@ func TestMCP23017ReadGPIONoRefresh(t *testing.T) {
 		// act
 		val, err := d.ReadGPIO(testPin, testPort)
 		// assert
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 2, numCallsRead)
 		assert.Equal(t, 2, len(a.written))
 		assert.Equal(t, wantReg1, a.written[0])
@@ -363,7 +363,7 @@ func TestMCP23017ReadGPIONoAutoDir(t *testing.T) {
 		// act
 		val, err := d.ReadGPIO(testPin, testPort)
 		// assert
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 1, numCallsRead)
 		assert.Equal(t, 1, len(a.written))
 		assert.Equal(t, wantReg2, a.written[0])
@@ -413,7 +413,7 @@ func TestMCP23017SetPinMode(t *testing.T) {
 		// act
 		err := d.SetPinMode(testPin, testPort, uint8(bitState))
 		// assert
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 3, len(a.written))
 		assert.Equal(t, wantReg, a.written[0])
 		assert.Equal(t, wantReg, a.written[1])
@@ -463,7 +463,7 @@ func TestMCP23017SetPullUp(t *testing.T) {
 		// act
 		err := d.SetPullUp(testPin, testPort, uint8(bitState))
 		// assert
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 3, len(a.written))
 		assert.Equal(t, wantReg, a.written[0])
 		assert.Equal(t, wantReg, a.written[1])
@@ -513,7 +513,7 @@ func TestMCP23017SetGPIOPolarity(t *testing.T) {
 		// act
 		err := d.SetGPIOPolarity(testPin, testPort, uint8(bitState))
 		// assert
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 3, len(a.written))
 		assert.Equal(t, wantReg, a.written[0])
 		assert.Equal(t, wantReg, a.written[1])
@@ -539,13 +539,13 @@ func TestMCP23017_write(t *testing.T) {
 	d, _ := initTestMCP23017WithStubbedAdaptor(0)
 	port := d.getPort("A")
 	err := d.write(port.IODIR, uint8(7), 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// set bit
 	d, _ = initTestMCP23017WithStubbedAdaptor(0)
 	port = d.getPort("B")
 	err = d.write(port.IODIR, uint8(7), 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// write error
 	d, a := initTestMCP23017WithStubbedAdaptor(0)
@@ -566,7 +566,7 @@ func TestMCP23017_write(t *testing.T) {
 		return len(b), nil
 	}
 	err = d.write(port.IODIR, uint8(7), 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestMCP23017_read(t *testing.T) {

--- a/drivers/i2c/mma7660_driver_test.go
+++ b/drivers/i2c/mma7660_driver_test.go
@@ -43,12 +43,12 @@ func TestMMA7660Options(t *testing.T) {
 
 func TestMMA7660Start(t *testing.T) {
 	d := NewMMA7660Driver(newI2cTestAdaptor())
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestMMA7660Halt(t *testing.T) {
 	d, _ := initTestMMA7660DriverWithStubbedAdaptor()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestMMA7660Acceleration(t *testing.T) {

--- a/drivers/i2c/mpl115a2_driver_test.go
+++ b/drivers/i2c/mpl115a2_driver_test.go
@@ -78,8 +78,8 @@ func TestMPL115A2ReadData(t *testing.T) {
 	press, errP := d.Pressure()
 	temp, errT := d.Temperature()
 	// assert
-	assert.Nil(t, errP)
-	assert.Nil(t, errT)
+	assert.NoError(t, errP)
+	assert.NoError(t, errT)
 	assert.Equal(t, 2, readCallCounter)
 	assert.Equal(t, 6, len(a.written))
 	assert.Equal(t, uint8(0x12), a.written[0])
@@ -124,7 +124,7 @@ func TestMPL115A2_initialization(t *testing.T) {
 	// act, assert - initialization() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, readCallCounter)
 	assert.Equal(t, 1, len(a.written))
 	assert.Equal(t, uint8(0x04), a.written[0])

--- a/drivers/i2c/mpu6050_driver_test.go
+++ b/drivers/i2c/mpu6050_driver_test.go
@@ -172,7 +172,7 @@ func TestMPU6050_initialize(t *testing.T) {
 	// act, assert - initialize() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, readCallCounter)
 	assert.Equal(t, 13, len(a.written))
 	assert.Equal(t, uint8(0x6B), a.written[0])

--- a/drivers/i2c/pca9501_driver_test.go
+++ b/drivers/i2c/pca9501_driver_test.go
@@ -160,7 +160,7 @@ func TestPCA9501WriteGPIO(t *testing.T) {
 			// act
 			err := d.WriteGPIO(tc.pin, tc.setVal)
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, 2, numCallsRead)
 			assert.Equal(t, 2, len(a.written))
 			assert.Equal(t, tc.wantPin, a.written[0])
@@ -254,7 +254,7 @@ func TestPCA9501ReadGPIO(t *testing.T) {
 			// act
 			got, err := d.ReadGPIO(pin)
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.want, got)
 			assert.Equal(t, 2, numCallsRead)
 			assert.Equal(t, 1, len(a.written))
@@ -334,7 +334,7 @@ func TestPCA9501WriteEEPROM(t *testing.T) {
 	// act
 	err := d.WriteEEPROM(addressEEPROM, want)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, numCallsWrite)
 	assert.Equal(t, addressEEPROM, a.written[0])
 	assert.Equal(t, want, a.written[1])
@@ -363,7 +363,7 @@ func TestPCA9501ReadEEPROM(t *testing.T) {
 	// act
 	val, err := d.ReadEEPROM(addressEEPROM)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, want, val)
 	assert.Equal(t, 1, numCallsWrite)
 	assert.Equal(t, addressEEPROM, a.written[0])
@@ -419,6 +419,6 @@ func TestPCA9501_initialize(t *testing.T) {
 	// act
 	err := d.initialize()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, want, a.address)
 }

--- a/drivers/i2c/pca953x_driver_test.go
+++ b/drivers/i2c/pca953x_driver_test.go
@@ -200,7 +200,7 @@ func TestPCA953xWritePeriod(t *testing.T) {
 			// act
 			err := d.WritePeriod(tc.idx, tc.val)
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.wantWritten, a.written)
 		})
 	}
@@ -291,7 +291,7 @@ func TestPCA953xWriteFrequency(t *testing.T) {
 			// act
 			err := d.WriteFrequency(tc.idx, tc.val)
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.wantWritten, a.written)
 		})
 	}
@@ -382,7 +382,7 @@ func TestPCA953xWriteDutyCyclePercent(t *testing.T) {
 			// act
 			err := d.WriteDutyCyclePercent(tc.idx, tc.val)
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.wantWritten, a.written)
 		})
 	}
@@ -465,7 +465,7 @@ func TestPCA953x_readRegister(t *testing.T) {
 	// act
 	val, err := d.readRegister(wantRegAddress)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, numCallsRead)
 	assert.Equal(t, 1, numCallsWrite)
 	assert.Equal(t, wantRegVal, val)
@@ -491,7 +491,7 @@ func TestPCA953x_writeRegister(t *testing.T) {
 	// act
 	err := d.writeRegister(wantRegAddress, wantRegVal)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, numCallsWrite)
 	assert.Equal(t, 1, numCallsWrite)
 	assert.Equal(t, wantByteCount, len(a.written))

--- a/drivers/i2c/pca9685_driver_test.go
+++ b/drivers/i2c/pca9685_driver_test.go
@@ -54,7 +54,7 @@ func TestPCA9685Start(t *testing.T) {
 		copy(b, []byte{0x01})
 		return 1, nil
 	}
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestPCA9685Halt(t *testing.T) {
@@ -63,8 +63,8 @@ func TestPCA9685Halt(t *testing.T) {
 		copy(b, []byte{0x01})
 		return 1, nil
 	}
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Halt())
 }
 
 func TestPCA9685SetPWM(t *testing.T) {
@@ -73,8 +73,8 @@ func TestPCA9685SetPWM(t *testing.T) {
 		copy(b, []byte{0x01})
 		return 1, nil
 	}
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.SetPWM(0, 0, 256))
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.SetPWM(0, 0, 256))
 }
 
 func TestPCA9685SetPWMError(t *testing.T) {
@@ -83,7 +83,7 @@ func TestPCA9685SetPWMError(t *testing.T) {
 		copy(b, []byte{0x01})
 		return 1, nil
 	}
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
@@ -96,13 +96,13 @@ func TestPCA9685SetPWMFreq(t *testing.T) {
 		copy(b, []byte{0x01})
 		return 1, nil
 	}
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		copy(b, []byte{0x01})
 		return 1, nil
 	}
-	assert.Nil(t, d.SetPWMFreq(60))
+	assert.NoError(t, d.SetPWMFreq(60))
 }
 
 func TestPCA9685SetPWMFreqReadError(t *testing.T) {
@@ -111,7 +111,7 @@ func TestPCA9685SetPWMFreqReadError(t *testing.T) {
 		copy(b, []byte{0x01})
 		return 1, nil
 	}
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		return 0, errors.New("read error")
@@ -125,7 +125,7 @@ func TestPCA9685SetPWMFreqWriteError(t *testing.T) {
 		copy(b, []byte{0x01})
 		return 1, nil
 	}
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")

--- a/drivers/i2c/pcf8583_driver_test.go
+++ b/drivers/i2c/pcf8583_driver_test.go
@@ -210,7 +210,7 @@ func TestPCF8583WriteTime(t *testing.T) {
 	// act
 	err := d.WriteTime(initDate)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, initDate.Year(), d.yearOffset)
 	assert.Equal(t, 1, numCallsRead)
 	assert.Equal(t, 11, len(a.written))
@@ -292,7 +292,7 @@ func TestPCF8583ReadTime(t *testing.T) {
 	// act
 	got, err := d.ReadTime()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(a.written))
 	assert.Equal(t, uint8(pcf8583Reg_CTRL), a.written[0])
 	assert.Equal(t, 2, numCallsRead)
@@ -357,7 +357,7 @@ func TestPCF8583WriteCounter(t *testing.T) {
 	// act
 	err := d.WriteCounter(initCount)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, numCallsRead)
 	assert.Equal(t, 8, len(a.written))
 	assert.Equal(t, uint8(pcf8583Reg_CTRL), a.written[0])
@@ -430,7 +430,7 @@ func TestPCF8583ReadCounter(t *testing.T) {
 	// act
 	got, err := d.ReadCounter()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(a.written))
 	assert.Equal(t, uint8(pcf8583Reg_CTRL), a.written[0])
 	assert.Equal(t, 2, numCallsRead)
@@ -480,7 +480,7 @@ func TestPCF8583WriteRam(t *testing.T) {
 	// act
 	err := d.WriteRAM(wantRAMAddress-pcf8583RamOffset, wantRAMValue)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, len(a.written))
 	assert.Equal(t, wantRAMAddress, a.written[0])
 	assert.Equal(t, wantRAMValue, a.written[1])
@@ -521,7 +521,7 @@ func TestPCF8583ReadRam(t *testing.T) {
 	// act
 	got, err := d.ReadRAM(wantRAMAddress - pcf8583RamOffset)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, want, got)
 	assert.Equal(t, 1, len(a.written))
 	assert.Equal(t, wantRAMAddress, a.written[0])
@@ -572,7 +572,7 @@ func TestPCF8583_initializeNoModeSwitch(t *testing.T) {
 	// act, assert - initialize() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, numCallsRead)
 	assert.Equal(t, 1, len(a.written))
 	assert.Equal(t, uint8(pcf8583Reg_CTRL), a.written[0])
@@ -604,7 +604,7 @@ func TestPCF8583_initializeWithModeSwitch(t *testing.T) {
 	// act, assert - initialize() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, numCallsRead)
 	assert.Equal(t, 3, len(a.written))
 	assert.Equal(t, uint8(pcf8583Reg_CTRL), a.written[0])

--- a/drivers/i2c/pcf8591_driver_test.go
+++ b/drivers/i2c/pcf8591_driver_test.go
@@ -35,12 +35,12 @@ func TestNewPCF8591Driver(t *testing.T) {
 
 func TestPCF8591Start(t *testing.T) {
 	d := NewPCF8591Driver(newI2cTestAdaptor())
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestPCF8591Halt(t *testing.T) {
 	d := NewPCF8591Driver(newI2cTestAdaptor())
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestPCF8591WithPCF8591With400kbitStabilization(t *testing.T) {
@@ -78,7 +78,7 @@ func TestPCF8591AnalogReadSingle(t *testing.T) {
 	// act
 	got, err := d.AnalogRead(description)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(a.written))
 	assert.Equal(t, ctrlByteOn, a.written[0])
 	assert.Equal(t, 2, numCallsRead)
@@ -120,7 +120,7 @@ func TestPCF8591AnalogReadDiff(t *testing.T) {
 	// act
 	got, err := d.AnalogRead(description)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(a.written))
 	assert.Equal(t, ctrlByteOn, a.written[0])
 	assert.Equal(t, 2, numCallsRead)
@@ -146,7 +146,7 @@ func TestPCF8591AnalogWrite(t *testing.T) {
 	// act
 	err := d.AnalogWrite("", int(want))
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, len(a.written))
 	assert.Equal(t, ctrlByteOn, a.written[0])
 	assert.Equal(t, want, a.written[1])
@@ -171,7 +171,7 @@ func TestPCF8591AnalogOutputState(t *testing.T) {
 		// act
 		err := d.AnalogOutputState(bitState == 1)
 		// assert
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 1, len(a.written))
 		assert.Equal(t, wantCtrlByteVal, a.written[0])
 	}

--- a/drivers/i2c/sht2x_driver_test.go
+++ b/drivers/i2c/sht2x_driver_test.go
@@ -42,12 +42,12 @@ func TestSHT2xOptions(t *testing.T) {
 
 func TestSHT2xStart(t *testing.T) {
 	d := NewSHT2xDriver(newI2cTestAdaptor())
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestSHT2xHalt(t *testing.T) {
 	d, _ := initTestSHT2xDriverWithStubbedAdaptor()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestSHT2xReset(t *testing.T) {
@@ -57,7 +57,7 @@ func TestSHT2xReset(t *testing.T) {
 	}
 	_ = d.Start()
 	err := d.Reset()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSHT2xMeasurements(t *testing.T) {
@@ -75,10 +75,10 @@ func TestSHT2xMeasurements(t *testing.T) {
 	}
 	_ = d.Start()
 	temp, err := d.Temperature()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, float32(18.809052), temp)
 	hum, err := d.Humidity()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, float32(40.279907), hum)
 }
 
@@ -100,7 +100,7 @@ func TestSHT2xAccuracy(t *testing.T) {
 	_ = d.SetAccuracy(SHT2xAccuracyLow)
 	assert.Equal(t, SHT2xAccuracyLow, d.Accuracy())
 	err := d.sendAccuracy()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSHT2xTemperatureCrcError(t *testing.T) {

--- a/drivers/i2c/sht3x_driver_test.go
+++ b/drivers/i2c/sht3x_driver_test.go
@@ -42,12 +42,12 @@ func TestSHT3xOptions(t *testing.T) {
 
 func TestSHT3xStart(t *testing.T) {
 	d := NewSHT3xDriver(newI2cTestAdaptor())
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestSHT3xHalt(t *testing.T) {
 	d, _ := initTestSHT3xDriverWithStubbedAdaptor()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestSHT3xSampleNormal(t *testing.T) {
@@ -155,7 +155,7 @@ func TestSHT3xHeater(t *testing.T) {
 	}
 
 	status, err := d.Heater()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, status)
 
 	// heater disabled
@@ -165,7 +165,7 @@ func TestSHT3xHeater(t *testing.T) {
 	}
 
 	status, err = d.Heater()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, status)
 
 	// heater crc failed
@@ -199,11 +199,11 @@ func TestSHT3xSetAccuracy(t *testing.T) {
 	assert.Equal(t, byte(SHT3xAccuracyHigh), d.Accuracy())
 
 	err := d.SetAccuracy(SHT3xAccuracyMedium)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, byte(SHT3xAccuracyMedium), d.Accuracy())
 
 	err = d.SetAccuracy(SHT3xAccuracyLow)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, byte(SHT3xAccuracyLow), d.Accuracy())
 
 	err = d.SetAccuracy(0xff)
@@ -219,6 +219,6 @@ func TestSHT3xSerialNumber(t *testing.T) {
 
 	sn, err := d.SerialNumber()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(0x2000beef), sn)
 }

--- a/drivers/i2c/ssd1306_driver_test.go
+++ b/drivers/i2c/ssd1306_driver_test.go
@@ -47,7 +47,7 @@ func TestSSD1306StartDefault(t *testing.T) {
 	)
 	d := NewSSD1306Driver(newI2cTestAdaptor(),
 		WithSSD1306DisplayWidth(width), WithSSD1306DisplayHeight(height), WithSSD1306ExternalVCC(externalVCC))
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestSSD1306Start128x32(t *testing.T) {
@@ -58,7 +58,7 @@ func TestSSD1306Start128x32(t *testing.T) {
 	)
 	d := NewSSD1306Driver(newI2cTestAdaptor(),
 		WithSSD1306DisplayWidth(width), WithSSD1306DisplayHeight(height), WithSSD1306ExternalVCC(externalVCC))
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestSSD1306Start96x16(t *testing.T) {
@@ -69,7 +69,7 @@ func TestSSD1306Start96x16(t *testing.T) {
 	)
 	d := NewSSD1306Driver(newI2cTestAdaptor(),
 		WithSSD1306DisplayWidth(width), WithSSD1306DisplayHeight(height), WithSSD1306ExternalVCC(externalVCC))
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestSSD1306StartExternalVCC(t *testing.T) {
@@ -80,7 +80,7 @@ func TestSSD1306StartExternalVCC(t *testing.T) {
 	)
 	d := NewSSD1306Driver(newI2cTestAdaptor(),
 		WithSSD1306DisplayWidth(width), WithSSD1306DisplayHeight(height), WithSSD1306ExternalVCC(externalVCC))
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestSSD1306StartSizeError(t *testing.T) {
@@ -96,7 +96,7 @@ func TestSSD1306StartSizeError(t *testing.T) {
 
 func TestSSD1306Halt(t *testing.T) {
 	s, _ := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
-	assert.Nil(t, s.Halt())
+	assert.NoError(t, s.Halt())
 }
 
 func TestSSD1306Options(t *testing.T) {
@@ -109,7 +109,7 @@ func TestSSD1306Options(t *testing.T) {
 func TestSSD1306Display(t *testing.T) {
 	s, _ := initTestSSD1306DriverWithStubbedAdaptor(96, 16, false)
 	_ = s.Start()
-	assert.Nil(t, s.Display())
+	assert.NoError(t, s.Display())
 }
 
 func TestSSD1306ShowImage(t *testing.T) {
@@ -119,7 +119,7 @@ func TestSSD1306ShowImage(t *testing.T) {
 	assert.ErrorContains(t, s.ShowImage(img), "image must match display width and height: 128x64")
 
 	img = image.NewRGBA(image.Rect(0, 0, 128, 64))
-	assert.Nil(t, s.ShowImage(img))
+	assert.NoError(t, s.ShowImage(img))
 }
 
 func TestSSD1306Command(t *testing.T) {
@@ -135,7 +135,7 @@ func TestSSD1306Command(t *testing.T) {
 		return 0, nil
 	}
 	err := s.command(0xFF)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSSD1306Commands(t *testing.T) {
@@ -151,7 +151,7 @@ func TestSSD1306Commands(t *testing.T) {
 		return 0, nil
 	}
 	err := s.commands([]byte{0x00, 0xFF})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSSD1306On(t *testing.T) {
@@ -167,7 +167,7 @@ func TestSSD1306On(t *testing.T) {
 		return 0, nil
 	}
 	err := s.On()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSSD1306Off(t *testing.T) {
@@ -183,7 +183,7 @@ func TestSSD1306Off(t *testing.T) {
 		return 0, nil
 	}
 	err := s.Off()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSSD1306Reset(t *testing.T) {
@@ -200,7 +200,7 @@ func TestSSD1306Reset(t *testing.T) {
 		return 0, nil
 	}
 	err := s.Reset()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 // COMMANDS

--- a/drivers/i2c/th02_driver_test.go
+++ b/drivers/i2c/th02_driver_test.go
@@ -102,7 +102,7 @@ func TestTH02FastMode(t *testing.T) {
 			// act
 			got, err := d.FastMode()
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, 1, len(a.written))
 			assert.Equal(t, uint8(0x03), a.written[0])
 			assert.Equal(t, tc.want, got)
@@ -130,7 +130,7 @@ func TestTH02SetHeater(t *testing.T) {
 			// act
 			err := d.SetHeater(tc.heater)
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.heater, d.heating)
 			assert.Equal(t, 2, len(a.written))
 			assert.Equal(t, uint8(0x03), a.written[0])
@@ -162,7 +162,7 @@ func TestTH02Heater(t *testing.T) {
 			// act
 			got, err := d.Heater()
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, 1, len(a.written))
 			assert.Equal(t, uint8(0x03), a.written[0])
 			assert.Equal(t, tc.want, got)
@@ -186,7 +186,7 @@ func TestTH02SerialNumber(t *testing.T) {
 	// act
 	sn, err := d.SerialNumber()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(a.written))
 	assert.Equal(t, uint8(0x11), a.written[0])
 	assert.Equal(t, want, sn)
@@ -297,7 +297,7 @@ func TestTH02Sample(t *testing.T) {
 			// act
 			temp, rh, err := d.Sample()
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.wantRH, rh)
 			assert.Equal(t, tc.wantT, temp)
 		})

--- a/drivers/i2c/tsl2561_driver_test.go
+++ b/drivers/i2c/tsl2561_driver_test.go
@@ -60,7 +60,7 @@ func TestTSL2561DriverStart(t *testing.T) {
 	d := NewTSL2561Driver(a)
 	a.i2cReadImpl = testIDReader
 
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestTSL2561DriverStartNotFound(t *testing.T) {
@@ -77,7 +77,7 @@ func TestTSL2561DriverStartNotFound(t *testing.T) {
 
 func TestTSL2561DriverHalt(t *testing.T) {
 	d, _ := initTestTSL2561Driver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestTSL2561DriverRead16(t *testing.T) {
@@ -93,7 +93,7 @@ func TestTSL2561DriverRead16(t *testing.T) {
 		return buf.Len(), nil
 	}
 	val, err := d.connection.ReadWordData(1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint16(0xAEEA), val)
 }
 
@@ -180,7 +180,7 @@ func TestTSL2561DriverGetLuminocity(t *testing.T) {
 		return buf.Len(), nil
 	}
 	bb, ir, err := d.GetLuminocity()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint16(12365), bb)
 	assert.Equal(t, uint16(12365), ir)
 	assert.Equal(t, uint32(72), d.CalculateLux(bb, ir))
@@ -202,7 +202,7 @@ func TestTSL2561DriverGetLuminocityAutoGain(t *testing.T) {
 
 	_ = d.Start()
 	bb, ir, err := d.GetLuminocity()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint16(12365), bb)
 	assert.Equal(t, uint16(12365), ir)
 	assert.Equal(t, uint32(72), d.CalculateLux(bb, ir))

--- a/drivers/i2c/wiichuck_driver_test.go
+++ b/drivers/i2c/wiichuck_driver_test.go
@@ -44,7 +44,7 @@ func TestWiichuckDriverStart(t *testing.T) {
 	d.interval = 1 * time.Millisecond
 	sem := make(chan bool)
 
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 
 	go func() {
 		for {
@@ -67,7 +67,7 @@ func TestWiichuckDriverStart(t *testing.T) {
 
 func TestWiichuckDriverHalt(t *testing.T) {
 	d := initTestWiichuckDriverWithStubbedAdaptor()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestWiichuckDriverCanParse(t *testing.T) {

--- a/drivers/i2c/yl40_driver_test.go
+++ b/drivers/i2c/yl40_driver_test.go
@@ -107,12 +107,12 @@ func TestYL40DriverReadBrightness(t *testing.T) {
 	got, err := yl.ReadBrightness()
 	got2, err2 := yl.Brightness()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(adaptor.written))
 	assert.Equal(t, ctrlByteOn, adaptor.written[0])
 	assert.Equal(t, 2, numCallsRead)
 	assert.Equal(t, want, got)
-	assert.Nil(t, err2)
+	assert.NoError(t, err2)
 	assert.Equal(t, want, got2)
 }
 
@@ -143,12 +143,12 @@ func TestYL40DriverReadTemperature(t *testing.T) {
 	got, err := yl.ReadTemperature()
 	got2, err2 := yl.Temperature()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(adaptor.written))
 	assert.Equal(t, ctrlByteOn, adaptor.written[0])
 	assert.Equal(t, 2, numCallsRead)
 	assert.Equal(t, want, got)
-	assert.Nil(t, err2)
+	assert.NoError(t, err2)
 	assert.Equal(t, want, got2)
 }
 
@@ -178,12 +178,12 @@ func TestYL40DriverReadAIN2(t *testing.T) {
 	got, err := yl.ReadAIN2()
 	got2, err2 := yl.AIN2()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(adaptor.written))
 	assert.Equal(t, ctrlByteOn, adaptor.written[0])
 	assert.Equal(t, 2, numCallsRead)
 	assert.Equal(t, want, got)
-	assert.Nil(t, err2)
+	assert.NoError(t, err2)
 	assert.Equal(t, want, got2)
 }
 
@@ -213,12 +213,12 @@ func TestYL40DriverReadPotentiometer(t *testing.T) {
 	got, err := yl.ReadPotentiometer()
 	got2, err2 := yl.Potentiometer()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(adaptor.written))
 	assert.Equal(t, ctrlByteOn, adaptor.written[0])
 	assert.Equal(t, 2, numCallsRead)
 	assert.Equal(t, want, got)
-	assert.Nil(t, err2)
+	assert.NoError(t, err2)
 	assert.Equal(t, want, got2)
 }
 
@@ -238,7 +238,7 @@ func TestYL40DriverAnalogWrite(t *testing.T) {
 	// act
 	err := pcf.Write(write)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, len(adaptor.written))
 	assert.Equal(t, ctrlByteOn, adaptor.written[0])
 	assert.Equal(t, want, adaptor.written[1])
@@ -246,12 +246,12 @@ func TestYL40DriverAnalogWrite(t *testing.T) {
 
 func TestYL40DriverStart(t *testing.T) {
 	yl := NewYL40Driver(newI2cTestAdaptor())
-	assert.Nil(t, yl.Start())
+	assert.NoError(t, yl.Start())
 }
 
 func TestYL40DriverHalt(t *testing.T) {
 	yl := NewYL40Driver(newI2cTestAdaptor())
-	assert.Nil(t, yl.Halt())
+	assert.NoError(t, yl.Halt())
 }
 
 func fEqual(want interface{}, got interface{}) bool {

--- a/drivers/spi/apa102_test.go
+++ b/drivers/spi/apa102_test.go
@@ -40,5 +40,5 @@ func TestDriverLEDs(t *testing.T) {
 	d.SetRGBA(2, color.RGBA{255, 255, 255, 15})
 	d.SetRGBA(3, color.RGBA{255, 255, 255, 15})
 
-	assert.Nil(t, d.Draw())
+	assert.NoError(t, d.Draw())
 }

--- a/drivers/spi/mfrc522_driver_test.go
+++ b/drivers/spi/mfrc522_driver_test.go
@@ -39,6 +39,6 @@ func TestMFRC522WriteByteData(t *testing.T) {
 	// act
 	err := d.connection.WriteByteData(0x00, 0x00)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte{0x00, 0x00}, a.spi.Written())
 }

--- a/drivers/spi/spi_connection_test.go
+++ b/drivers/spi/spi_connection_test.go
@@ -38,7 +38,7 @@ func TestReadCommandData(t *testing.T) {
 	got := []byte{0x01, 0x02}
 	err := c.ReadCommandData(command, got)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, command, sysdev.Written())
 	assert.Equal(t, want, got)
 }
@@ -54,7 +54,7 @@ func TestReadByteData(t *testing.T) {
 	// act
 	got, err := c.ReadByteData(reg)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte{reg, 0x00}, sysdev.Written()) // for read register we need n+1 bytes
 	assert.Equal(t, want, got)
 }
@@ -71,7 +71,7 @@ func TestReadBlockData(t *testing.T) {
 	got := make([]byte, 4)
 	err := c.ReadBlockData(reg, got)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte{reg, 0x00, 0x00, 0x00, 0x00}, sysdev.Written()) // for read registers we need n+1 bytes
 	assert.Equal(t, want, got)
 }
@@ -83,7 +83,7 @@ func TestWriteByte(t *testing.T) {
 	// act
 	err := c.WriteByte(want)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte{want}, sysdev.Written())
 }
 
@@ -97,7 +97,7 @@ func TestWriteByteData(t *testing.T) {
 	// act
 	err := c.WriteByteData(reg, val)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte{reg, val}, sysdev.Written())
 }
 
@@ -109,7 +109,7 @@ func TestWriteBlockData(t *testing.T) {
 	// act
 	err := c.WriteBlockData(reg, data)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, append([]byte{reg}, data...), sysdev.Written())
 }
 
@@ -120,6 +120,6 @@ func TestWriteBytes(t *testing.T) {
 	// act
 	err := c.WriteBytes(want)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, want, sysdev.Written())
 }

--- a/drivers/spi/spi_driver_test.go
+++ b/drivers/spi/spi_driver_test.go
@@ -30,12 +30,12 @@ func TestNewDriver(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	d := NewDriver(newSpiTestAdaptor(), "SPI_BASIC")
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestHalt(t *testing.T) {
 	d, _ := initTestDriverWithStubbedAdaptor()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestSetName(t *testing.T) {

--- a/drivers/spi/ssd1306_driver_test.go
+++ b/drivers/spi/ssd1306_driver_test.go
@@ -19,19 +19,19 @@ func initTestSSDDriver() *SSD1306Driver {
 
 func TestDriverSSDStart(t *testing.T) {
 	d := initTestSSDDriver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestDriverSSDHalt(t *testing.T) {
 	d := initTestSSDDriver()
 	_ = d.Start()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestDriverSSDDisplay(t *testing.T) {
 	d := initTestSSDDriver()
 	_ = d.Start()
-	assert.Nil(t, d.Display())
+	assert.NoError(t, d.Display())
 }
 
 func TestSSD1306DriverShowImage(t *testing.T) {
@@ -41,7 +41,7 @@ func TestSSD1306DriverShowImage(t *testing.T) {
 	assert.ErrorContains(t, d.ShowImage(img), "Image must match the display width and height")
 
 	img = image.NewRGBA(image.Rect(0, 0, 128, 64))
-	assert.Nil(t, d.ShowImage(img))
+	assert.NoError(t, d.ShowImage(img))
 }
 
 type gpioTestAdaptor struct {

--- a/master_test.go
+++ b/master_test.go
@@ -41,7 +41,7 @@ func TestNullReadWriteCloser(t *testing.T) {
 	assert.Equal(t, 3, i)
 	i, _ = n.Read(make([]byte, 10))
 	assert.Equal(t, 10, i)
-	assert.Nil(t, n.Close())
+	assert.NoError(t, n.Close())
 }
 
 func TestMasterRobot(t *testing.T) {
@@ -69,8 +69,8 @@ func TestMasterToJSON(t *testing.T) {
 
 func TestMasterStart(t *testing.T) {
 	g := initTestMaster()
-	assert.Nil(t, g.Start())
-	assert.Nil(t, g.Stop())
+	assert.NoError(t, g.Start())
+	assert.NoError(t, g.Stop())
 	assert.False(t, g.Running())
 }
 
@@ -82,7 +82,7 @@ func TestMasterStartAutoRun(t *testing.T) {
 	assert.True(t, g.Running())
 
 	// stop it
-	assert.Nil(t, g.Stop())
+	assert.NoError(t, g.Stop())
 	assert.False(t, g.Running())
 }
 
@@ -99,7 +99,7 @@ func TestMasterStartDriverErrors(t *testing.T) {
 	want = multierror.Append(want, e)
 
 	assert.Equal(t, want, g.Start())
-	assert.Nil(t, g.Stop())
+	assert.NoError(t, g.Stop())
 
 	testDriverStart = func() (err error) { return }
 }
@@ -138,7 +138,7 @@ func TestMasterStartRobotAdaptorErrors(t *testing.T) {
 	}
 
 	assert.Equal(t, want, g.Start())
-	assert.Nil(t, g.Stop())
+	assert.NoError(t, g.Stop())
 
 	testAdaptorConnect = func() (err error) { return }
 }

--- a/platforms/adaptors/digitalpinsadaptor_test.go
+++ b/platforms/adaptors/digitalpinsadaptor_test.go
@@ -66,7 +66,7 @@ func TestDigitalPinsConnect(t *testing.T) {
 	assert.ErrorContains(t, err, "not connected for pin 7")
 
 	err = a.Connect()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotEqual(t, (map[string]gobot.DigitalPinner)(nil), a.pins)
 	assert.Equal(t, 0, len(a.pins))
 }
@@ -83,21 +83,21 @@ func TestDigitalPinsFinalize(t *testing.T) {
 	fs := sys.UseMockFilesystem(mockedPaths)
 	a := NewDigitalPinsAdaptor(sys, testDigitalPinTranslator)
 	// assert that finalize before connect is working
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 	// arrange
-	assert.Nil(t, a.Connect())
-	assert.Nil(t, a.DigitalWrite("3", 1))
+	assert.NoError(t, a.Connect())
+	assert.NoError(t, a.DigitalWrite("3", 1))
 	assert.Equal(t, 1, len(a.pins))
 	// act
 	err := a.Finalize()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, len(a.pins))
 	// assert that finalize after finalize is working
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 	// arrange missing sysfs file
-	assert.Nil(t, a.Connect())
-	assert.Nil(t, a.DigitalWrite("3", 2))
+	assert.NoError(t, a.Connect())
+	assert.NoError(t, a.DigitalWrite("3", 2))
 	delete(fs.Files, "/sys/class/gpio/unexport")
 	err = a.Finalize()
 	assert.Contains(t, err.Error(), "/sys/class/gpio/unexport: no such file")
@@ -112,13 +112,13 @@ func TestDigitalPinsReConnect(t *testing.T) {
 		"/sys/class/gpio/gpio15/value",
 	}
 	a, _ := initTestDigitalPinsAdaptorWithMockedFilesystem(mockedPaths)
-	assert.Nil(t, a.DigitalWrite("4", 1))
+	assert.NoError(t, a.DigitalWrite("4", 1))
 	assert.Equal(t, 1, len(a.pins))
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 	// act
 	err := a.Connect()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, a.pins)
 	assert.Equal(t, 0, len(a.pins))
 }
@@ -133,10 +133,10 @@ func TestDigitalIO(t *testing.T) {
 	a, _ := initTestDigitalPinsAdaptorWithMockedFilesystem(mockedPaths)
 
 	err := a.DigitalWrite("14", 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	i, err := a.DigitalRead("14")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, i)
 }
 
@@ -153,7 +153,7 @@ func TestDigitalRead(t *testing.T) {
 
 	// assert read correct value without error
 	i, err := a.DigitalRead("13")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, i)
 
 	// assert error bubbling for read errors
@@ -193,8 +193,8 @@ func TestDigitalReadWithGpiosActiveLow(t *testing.T) {
 	got1, err1 := a.DigitalRead("14") // for a new pin
 	got2, err2 := a.DigitalRead("15") // for an existing pin (calls ApplyOptions())
 	// assert
-	assert.Nil(t, err1)
-	assert.Nil(t, err2)
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
 	assert.Equal(t, 1, got1) // there is no mechanism to negate mocked values
 	assert.Equal(t, 0, got2)
 	assert.Equal(t, "1", fs.Files["/sys/class/gpio/gpio25/active_low"].Contents)
@@ -216,7 +216,7 @@ func TestDigitalWrite(t *testing.T) {
 	WithGpiosOpenDrain("7")(a)
 	WithGpioEventOnFallingEdge("7", gpioEventHandler)(a)
 	err := a.DigitalWrite("7", 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "1", fs.Files["/sys/class/gpio/gpio18/value"].Contents)
 
 	// assert second write to same pin without error and just ignore unsupported options
@@ -225,7 +225,7 @@ func TestDigitalWrite(t *testing.T) {
 	WithGpioDebounce("7", 2*time.Second)(a)
 	WithGpioEventOnRisingEdge("7", gpioEventHandler)(a)
 	err = a.DigitalWrite("7", 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// assert error on bad id
 	assert.ErrorContains(t, a.DigitalWrite("notexist", 1), "not a valid pin")
@@ -251,7 +251,7 @@ func TestDigitalWriteWithGpiosActiveLow(t *testing.T) {
 	// act
 	err := a.DigitalWrite("8", 2)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "2", fs.Files["/sys/class/gpio/gpio19/value"].Contents)
 	assert.Equal(t, "1", fs.Files["/sys/class/gpio/gpio19/active_low"].Contents)
 }

--- a/platforms/adaptors/i2cbusadaptor_test.go
+++ b/platforms/adaptors/i2cbusadaptor_test.go
@@ -36,18 +36,18 @@ func TestI2cWorkflow(t *testing.T) {
 	assert.Equal(t, 0, len(a.buses))
 
 	con, err := a.GetI2cConnection(0xff, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(a.buses))
 
 	_, err = con.Write([]byte{0x00, 0x01})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	data := []byte{42, 42}
 	_, err = con.Read(data)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte{0x00, 0x01}, data)
 
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 	assert.Equal(t, 0, len(a.buses))
 }
 
@@ -56,7 +56,7 @@ func TestI2cGetI2cConnection(t *testing.T) {
 	a, _ := initTestI2cAdaptorWithMockedFilesystem([]string{i2cBus1})
 	// assert working connection
 	c1, e1 := a.GetI2cConnection(0xff, 1)
-	assert.Nil(t, e1)
+	assert.NoError(t, e1)
 	assert.NotNil(t, c1)
 	assert.Equal(t, 1, len(a.buses))
 	// assert invalid bus gets error
@@ -65,7 +65,7 @@ func TestI2cGetI2cConnection(t *testing.T) {
 	assert.Nil(t, c2)
 	assert.Equal(t, 1, len(a.buses))
 	// assert unconnected gets error
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 	c3, e3 := a.GetI2cConnection(0x01, 99)
 	assert.ErrorContains(t, e3, "not connected")
 	assert.Nil(t, c3)
@@ -76,18 +76,18 @@ func TestI2cFinalize(t *testing.T) {
 	// arrange
 	a, fs := initTestI2cAdaptorWithMockedFilesystem([]string{i2cBus1})
 	// assert that finalize before connect is working
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 	// arrange
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 	_, _ = a.GetI2cConnection(0xaf, 1)
 	assert.Equal(t, 1, len(a.buses))
 	// assert that Finalize after GetI2cConnection is working and clean up
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 	assert.Equal(t, 0, len(a.buses))
 	// assert that finalize after finalize is working
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 	// assert that close error is recognized
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 	con, _ := a.GetI2cConnection(0xbf, 1)
 	assert.Equal(t, 1, len(a.buses))
 	_, _ = con.Write([]byte{0xbf})
@@ -99,9 +99,9 @@ func TestI2cFinalize(t *testing.T) {
 func TestI2cReConnect(t *testing.T) {
 	// arrange
 	a, _ := initTestI2cAdaptorWithMockedFilesystem([]string{i2cBus1})
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 	// act
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 	// assert
 	assert.NotNil(t, a.buses)
 	assert.Equal(t, 0, len(a.buses))

--- a/platforms/adaptors/pwmpinsadaptor_test.go
+++ b/platforms/adaptors/pwmpinsadaptor_test.go
@@ -120,7 +120,7 @@ func TestPWMPinsConnect(t *testing.T) {
 	assert.ErrorContains(t, err, "not connected")
 
 	err = a.Connect()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotEqual(t, (map[string]gobot.PWMPinner)(nil), a.pins)
 	assert.Equal(t, 0, len(a.pins))
 }
@@ -133,27 +133,27 @@ func TestPWMPinsFinalize(t *testing.T) {
 	fs.Files[pwmPeriodPath].Contents = "0"
 	fs.Files[pwmDutyCyclePath].Contents = "0"
 	// assert that finalize before connect is working
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 	// arrange
-	assert.Nil(t, a.Connect())
-	assert.Nil(t, a.PwmWrite("33", 1))
+	assert.NoError(t, a.Connect())
+	assert.NoError(t, a.PwmWrite("33", 1))
 	assert.Equal(t, 1, len(a.pins))
 	// act
 	err := a.Finalize()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, len(a.pins))
 	// assert that finalize after finalize is working
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 	// arrange missing sysfs file
-	assert.Nil(t, a.Connect())
-	assert.Nil(t, a.PwmWrite("33", 2))
+	assert.NoError(t, a.Connect())
+	assert.NoError(t, a.PwmWrite("33", 2))
 	delete(fs.Files, pwmUnexportPath)
 	err = a.Finalize()
 	assert.Contains(t, err.Error(), pwmUnexportPath+": no such file")
 	// arrange write error
-	assert.Nil(t, a.Connect())
-	assert.Nil(t, a.PwmWrite("33", 2))
+	assert.NoError(t, a.Connect())
+	assert.NoError(t, a.PwmWrite("33", 2))
 	fs.WithWriteError = true
 	err = a.Finalize()
 	assert.Contains(t, err.Error(), "write error")
@@ -162,13 +162,13 @@ func TestPWMPinsFinalize(t *testing.T) {
 func TestPWMPinsReConnect(t *testing.T) {
 	// arrange
 	a, _ := initTestPWMPinsAdaptorWithMockedFilesystem(pwmMockPaths)
-	assert.Nil(t, a.PwmWrite("33", 1))
+	assert.NoError(t, a.PwmWrite("33", 1))
 	assert.Equal(t, 1, len(a.pins))
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 	// act
 	err := a.Connect()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, a.pins)
 	assert.Equal(t, 0, len(a.pins))
 }
@@ -177,7 +177,7 @@ func TestPwmWrite(t *testing.T) {
 	a, fs := initTestPWMPinsAdaptorWithMockedFilesystem(pwmMockPaths)
 
 	err := a.PwmWrite("33", 100)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "44", fs.Files[pwmExportPath].Contents)
 	assert.Equal(t, "1", fs.Files[pwmEnablePath].Contents)
@@ -207,10 +207,10 @@ func TestServoWrite(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%d", a.periodDefault), fs.Files[pwmPeriodPath].Contents)
 	assert.Equal(t, "500000", fs.Files[pwmDutyCyclePath].Contents)
 	assert.Equal(t, "normal", fs.Files[pwmPolarityPath].Contents)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = a.ServoWrite("33", 180)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "2000000", fs.Files[pwmDutyCyclePath].Contents)
 
 	err = a.ServoWrite("notexist", 42)
@@ -233,7 +233,7 @@ func TestSetPeriod(t *testing.T) {
 	// act
 	err := a.SetPeriod("33", newPeriod)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "44", fs.Files[pwmExportPath].Contents)
 	assert.Equal(t, "1", fs.Files[pwmEnablePath].Contents)
 	assert.Equal(t, fmt.Sprintf("%d", newPeriod), fs.Files[pwmPeriodPath].Contents)
@@ -242,7 +242,7 @@ func TestSetPeriod(t *testing.T) {
 
 	// arrange test for automatic adjustment of duty cycle to lower value
 	err = a.PwmWrite("33", 127) // 127 is a little bit smaller than 50% of period
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("%d", 1270000), fs.Files[pwmDutyCyclePath].Contents)
 	newPeriod = newPeriod / 10
 
@@ -250,7 +250,7 @@ func TestSetPeriod(t *testing.T) {
 	err = a.SetPeriod("33", newPeriod)
 
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("%d", 127000), fs.Files[pwmDutyCyclePath].Contents)
 
 	// arrange test for automatic adjustment of duty cycle to higher value
@@ -260,7 +260,7 @@ func TestSetPeriod(t *testing.T) {
 	err = a.SetPeriod("33", newPeriod)
 
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("%d", 2540000), fs.Files[pwmDutyCyclePath].Contents)
 
 	// act
@@ -346,7 +346,7 @@ func Test_PWMPin(t *testing.T) {
 			got, err := a.PWMPin(tc.pin)
 			// assert
 			if tc.wantErr == "" {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.NotNil(t, got)
 			} else {
 				if !strings.Contains(err.Error(), tc.wantErr) {

--- a/platforms/adaptors/spibusadaptor_test.go
+++ b/platforms/adaptors/spibusadaptor_test.go
@@ -57,17 +57,17 @@ func TestGetSpiConnection(t *testing.T) {
 	// act
 	con1, err1 := a.GetSpiConnection(busNum, chipNum, mode, bits, maxSpeed)
 	// assert
-	assert.Nil(t, err1)
+	assert.NoError(t, err1)
 	assert.NotNil(t, con1)
 	assert.Equal(t, 1, len(a.connections))
 	// assert cached connection
 	con1a, err2 := a.GetSpiConnection(busNum, chipNum, mode, bits, maxSpeed)
-	assert.Nil(t, err2)
+	assert.NoError(t, err2)
 	assert.Equal(t, con1, con1a)
 	assert.Equal(t, 1, len(a.connections))
 	// assert second connection
 	con2, err3 := a.GetSpiConnection(busNum, chipNum+1, mode, bits, maxSpeed)
-	assert.Nil(t, err3)
+	assert.NoError(t, err3)
 	assert.NotNil(t, con2)
 	assert.NotEqual(t, con1, con2)
 	assert.Equal(t, 2, len(a.connections))
@@ -86,12 +86,12 @@ func TestSpiFinalize(t *testing.T) {
 	// arrange
 	a, _ := initTestSpiBusAdaptorWithMockedSpi()
 	_, e := a.GetSpiConnection(spiTestAllowedBus, 2, 3, 4, 5)
-	assert.Nil(t, e)
+	assert.NoError(t, e)
 	assert.Equal(t, 1, len(a.connections))
 	// act
 	err := a.Finalize()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, len(a.connections))
 }
 
@@ -99,7 +99,7 @@ func TestSpiFinalizeWithError(t *testing.T) {
 	// arrange
 	a, spi := initTestSpiBusAdaptorWithMockedSpi()
 	_, e := a.GetSpiConnection(spiTestAllowedBus, 2, 3, 4, 5)
-	assert.Nil(t, e)
+	assert.NoError(t, e)
 	spi.SetCloseError(true)
 	// act
 	err := a.Finalize()
@@ -110,9 +110,9 @@ func TestSpiFinalizeWithError(t *testing.T) {
 func TestSpiReConnect(t *testing.T) {
 	// arrange
 	a, _ := initTestSpiBusAdaptorWithMockedSpi()
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 	// act
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 	// assert
 	assert.NotNil(t, a.connections)
 	assert.Equal(t, 0, len(a.connections))

--- a/platforms/audio/audio_adaptor_test.go
+++ b/platforms/audio/audio_adaptor_test.go
@@ -16,8 +16,8 @@ var _ gobot.Adaptor = (*Adaptor)(nil)
 func TestAudioAdaptor(t *testing.T) {
 	a := NewAdaptor()
 
-	assert.Nil(t, a.Connect())
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Connect())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestAudioAdaptorName(t *testing.T) {

--- a/platforms/audio/audio_driver_test.go
+++ b/platforms/audio/audio_driver_test.go
@@ -20,9 +20,9 @@ func TestAudioDriver(t *testing.T) {
 
 	assert.NotNil(t, d.Connection())
 
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestAudioDriverName(t *testing.T) {

--- a/platforms/beaglebone/beaglebone_adaptor_test.go
+++ b/platforms/beaglebone/beaglebone_adaptor_test.go
@@ -83,7 +83,7 @@ func TestPWM(t *testing.T) {
 		fs.Files["/sys/devices/platform/ocp/48300000.epwmss/48300200.pwm/pwm/pwmchip0/pwm1/duty_cycle"].Contents,
 	)
 
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestAnalog(t *testing.T) {
@@ -96,7 +96,7 @@ func TestAnalog(t *testing.T) {
 	fs.Files["/sys/bus/iio/devices/iio:device0/in_voltage1_raw"].Contents = "567\n"
 	i, err := a.AnalogRead("P9_40")
 	assert.Equal(t, 567, i)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	_, err = a.AnalogRead("P9_99")
 	assert.ErrorContains(t, err, "Not a valid analog pin")
@@ -106,7 +106,7 @@ func TestAnalog(t *testing.T) {
 	assert.ErrorContains(t, err, "read error")
 	fs.WithReadError = false
 
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestDigitalIO(t *testing.T) {
@@ -151,9 +151,9 @@ func TestDigitalIO(t *testing.T) {
 	fs.Files["/sys/class/gpio/gpio66/value"].Contents = "1"
 	i, err := a.DigitalRead("P8_07")
 	assert.Equal(t, 1, i)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestName(t *testing.T) {
@@ -202,7 +202,7 @@ func TestDigitalPinFinalizeFileError(t *testing.T) {
 	a, _ := initTestAdaptorWithMockedFilesystem(mockPaths)
 
 	err := a.DigitalWrite("P9_12", 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = a.Finalize()
 	assert.Contains(t, err.Error(), "/sys/class/gpio/unexport: no such file")
@@ -233,11 +233,11 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a := NewAdaptor()
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-2"})
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 	con, err := a.GetI2cConnection(0xff, 2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	_, err = con.Write([]byte{0xbf})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/ble/battery_driver_test.go
+++ b/platforms/ble/battery_driver_test.go
@@ -24,8 +24,8 @@ func TestBatteryDriver(t *testing.T) {
 
 func TestBatteryDriverStartAndHalt(t *testing.T) {
 	d := initTestBatteryDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Halt())
 }
 
 func TestBatteryDriverRead(t *testing.T) {

--- a/platforms/ble/device_information_driver_test.go
+++ b/platforms/ble/device_information_driver_test.go
@@ -24,8 +24,8 @@ func TestDeviceInformationDriver(t *testing.T) {
 
 func TestDeviceInformationDriverStartAndHalt(t *testing.T) {
 	d := initTestDeviceInformationDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Halt())
 }
 
 func TestDeviceInformationDriverGetModelNumber(t *testing.T) {

--- a/platforms/ble/generic_access_driver_test.go
+++ b/platforms/ble/generic_access_driver_test.go
@@ -24,8 +24,8 @@ func TestGenericAccessDriver(t *testing.T) {
 
 func TestGenericAccessDriverStartAndHalt(t *testing.T) {
 	d := initTestGenericAccessDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Halt())
 }
 
 func TestGenericAccessDriverGetDeviceName(t *testing.T) {

--- a/platforms/chip/chip_adaptor_test.go
+++ b/platforms/chip/chip_adaptor_test.go
@@ -71,8 +71,8 @@ func TestNewProAdaptor(t *testing.T) {
 
 func TestFinalizeErrorAfterGPIO(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem()
-	assert.Nil(t, a.Connect())
-	assert.Nil(t, a.DigitalWrite("CSID7", 1))
+	assert.NoError(t, a.Connect())
+	assert.NoError(t, a.DigitalWrite("CSID7", 1))
 
 	fs.WithWriteError = true
 
@@ -85,8 +85,8 @@ func TestFinalizeErrorAfterPWM(t *testing.T) {
 	fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents = "0"
 	fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents = "0"
 
-	assert.Nil(t, a.Connect())
-	assert.Nil(t, a.PwmWrite("PWM0", 100))
+	assert.NoError(t, a.Connect())
+	assert.NoError(t, a.PwmWrite("PWM0", 100))
 
 	fs.WithWriteError = true
 
@@ -106,7 +106,7 @@ func TestDigitalIO(t *testing.T) {
 	assert.Equal(t, 1, i)
 
 	assert.ErrorContains(t, a.DigitalWrite("XIO-P10", 1), "'XIO-P10' is not a valid id for a digital pin")
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestProDigitalIO(t *testing.T) {
@@ -121,7 +121,7 @@ func TestProDigitalIO(t *testing.T) {
 	assert.Equal(t, 1, i)
 
 	assert.ErrorContains(t, a.DigitalWrite("XIO-P0", 1), "'XIO-P0' is not a valid id for a digital pin")
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestPWM(t *testing.T) {
@@ -132,7 +132,7 @@ func TestPWM(t *testing.T) {
 	_ = a.Connect()
 
 	err := a.PwmWrite("PWM0", 100)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "0", fs.Files["/sys/class/pwm/pwmchip0/export"].Contents)
 	assert.Equal(t, "1", fs.Files["/sys/class/pwm/pwmchip0/pwm0/enable"].Contents)
@@ -141,18 +141,18 @@ func TestPWM(t *testing.T) {
 	assert.Equal(t, "normal", fs.Files["/sys/class/pwm/pwmchip0/pwm0/polarity"].Contents)
 
 	err = a.ServoWrite("PWM0", 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "500000", fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents)
 	assert.Equal(t, "10000000", fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents)
 
 	err = a.ServoWrite("PWM0", 180)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "2000000", fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents)
 	assert.Equal(t, "10000000", fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents) // pwmPeriodDefault
 
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestI2cDefaultBus(t *testing.T) {
@@ -165,11 +165,11 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a := NewAdaptor()
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-2"})
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 	con, err := a.GetI2cConnection(0xff, 2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	_, err = con.Write([]byte{0xbf})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/dexter/gopigo3/driver_test.go
+++ b/platforms/dexter/gopigo3/driver_test.go
@@ -22,12 +22,12 @@ func initTestDriver() *Driver {
 
 func TestDriverStart(t *testing.T) {
 	d := initTestDriver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestDriverHalt(t *testing.T) {
 	d := initTestDriver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestDriverManufacturerName(t *testing.T) {

--- a/platforms/digispark/digispark_adaptor_test.go
+++ b/platforms/digispark/digispark_adaptor_test.go
@@ -92,18 +92,18 @@ func TestDigisparkAdaptorName(t *testing.T) {
 
 func TestDigisparkAdaptorConnect(t *testing.T) {
 	a := initTestAdaptor()
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 }
 
 func TestDigisparkAdaptorFinalize(t *testing.T) {
 	a := initTestAdaptor()
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestDigisparkAdaptorDigitalWrite(t *testing.T) {
 	a := initTestAdaptor()
 	err := a.DigitalWrite("0", uint8(1))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint8(0), a.littleWire.(*mock).pin)
 	assert.Equal(t, uint8(1), a.littleWire.(*mock).state)
 
@@ -118,7 +118,7 @@ func TestDigisparkAdaptorDigitalWrite(t *testing.T) {
 func TestDigisparkAdaptorServoWrite(t *testing.T) {
 	a := initTestAdaptor()
 	err := a.ServoWrite("2", uint8(80))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint8(80), a.littleWire.(*mock).locationA)
 	assert.Equal(t, uint8(80), a.littleWire.(*mock).locationB)
 
@@ -131,7 +131,7 @@ func TestDigisparkAdaptorServoWrite(t *testing.T) {
 func TestDigisparkAdaptorPwmWrite(t *testing.T) {
 	a := initTestAdaptor()
 	err := a.PwmWrite("1", uint8(100))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint8(100), a.littleWire.(*mock).pwmChannelA)
 	assert.Equal(t, uint8(100), a.littleWire.(*mock).pwmChannelB)
 

--- a/platforms/digispark/digispark_i2c_test.go
+++ b/platforms/digispark/digispark_i2c_test.go
@@ -45,7 +45,7 @@ func TestDigisparkAdaptorI2cGetI2cConnection(t *testing.T) {
 	c, err = a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, c)
 }
 
@@ -87,7 +87,7 @@ func TestDigisparkAdaptorI2cWrite(t *testing.T) {
 	count, err := c.Write(data)
 
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.False(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(0), a.littleWire.(*i2cMock).direction)
@@ -107,7 +107,7 @@ func TestDigisparkAdaptorI2cWriteByte(t *testing.T) {
 	err := c.WriteByte(data)
 
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.False(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(0), a.littleWire.(*i2cMock).direction)
@@ -127,7 +127,7 @@ func TestDigisparkAdaptorI2cWriteByteData(t *testing.T) {
 	err := c.WriteByteData(reg, data)
 
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.False(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(0), a.littleWire.(*i2cMock).direction)
@@ -147,7 +147,7 @@ func TestDigisparkAdaptorI2cWriteWordData(t *testing.T) {
 	err := c.WriteWordData(reg, data)
 
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.False(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(0), a.littleWire.(*i2cMock).direction)
@@ -167,7 +167,7 @@ func TestDigisparkAdaptorI2cWriteBlockData(t *testing.T) {
 	err := c.WriteBlockData(reg, data)
 
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.False(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(0), a.littleWire.(*i2cMock).direction)
@@ -188,7 +188,7 @@ func TestDigisparkAdaptorI2cRead(t *testing.T) {
 
 	// assert
 	assert.Equal(t, dataLen, count)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.True(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(1), a.littleWire.(*i2cMock).direction)
@@ -206,7 +206,7 @@ func TestDigisparkAdaptorI2cReadByte(t *testing.T) {
 	data, err := c.ReadByte()
 
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.True(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(1), a.littleWire.(*i2cMock).direction)
@@ -225,7 +225,7 @@ func TestDigisparkAdaptorI2cReadByteData(t *testing.T) {
 	data, err := c.ReadByteData(reg)
 
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.True(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(1), a.littleWire.(*i2cMock).direction)
@@ -247,7 +247,7 @@ func TestDigisparkAdaptorI2cReadWordData(t *testing.T) {
 	data, err := c.ReadWordData(reg)
 
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.True(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(1), a.littleWire.(*i2cMock).direction)
@@ -269,7 +269,7 @@ func TestDigisparkAdaptorI2cReadBlockData(t *testing.T) {
 	err := c.ReadBlockData(reg, data)
 
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.True(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(1), a.littleWire.(*i2cMock).direction)
@@ -288,7 +288,7 @@ func TestDigisparkAdaptorI2cUpdateDelay(t *testing.T) {
 	err := c.(*digisparkI2cConnection).UpdateDelay(uint(100))
 
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint(100), a.littleWire.(*i2cMock).duration)
 }
 

--- a/platforms/dragonboard/dragonboard_adaptor_test.go
+++ b/platforms/dragonboard/dragonboard_adaptor_test.go
@@ -55,7 +55,7 @@ func TestDigitalIO(t *testing.T) {
 	assert.Equal(t, 1, i)
 
 	assert.ErrorContains(t, a.DigitalWrite("GPIO_M", 1), "'GPIO_M' is not a valid id for a digital pin")
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestFinalizeErrorAfterGPIO(t *testing.T) {
@@ -70,8 +70,8 @@ func TestFinalizeErrorAfterGPIO(t *testing.T) {
 	}
 	fs := a.sys.UseMockFilesystem(mockPaths)
 
-	assert.Nil(t, a.Connect())
-	assert.Nil(t, a.DigitalWrite("GPIO_B", 1))
+	assert.NoError(t, a.Connect())
+	assert.NoError(t, a.DigitalWrite("GPIO_B", 1))
 
 	fs.WithWriteError = true
 
@@ -89,11 +89,11 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a := NewAdaptor()
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-1"})
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 	con, err := a.GetI2cConnection(0xff, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	_, err = con.Write([]byte{0xbf})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/firmata/client/client_test.go
+++ b/platforms/firmata/client/client_test.go
@@ -120,17 +120,17 @@ func TestPins(t *testing.T) {
 
 func TestProtocolVersionQuery(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
-	assert.Nil(t, b.ProtocolVersionQuery())
+	assert.NoError(t, b.ProtocolVersionQuery())
 }
 
 func TestFirmwareQuery(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
-	assert.Nil(t, b.FirmwareQuery())
+	assert.NoError(t, b.FirmwareQuery())
 }
 
 func TestPinStateQuery(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
-	assert.Nil(t, b.PinStateQuery(1))
+	assert.NoError(t, b.PinStateQuery(1))
 }
 
 func TestProcessProtocolVersion(t *testing.T) {
@@ -232,23 +232,23 @@ func TestProcessDigitalRead4(t *testing.T) {
 
 func TestDigitalWrite(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name(), testDataCapabilitiesResponse)
-	assert.Nil(t, b.DigitalWrite(13, 0))
+	assert.NoError(t, b.DigitalWrite(13, 0))
 }
 
 func TestSetPinMode(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name(), testDataCapabilitiesResponse)
-	assert.Nil(t, b.SetPinMode(13, Output))
+	assert.NoError(t, b.SetPinMode(13, Output))
 }
 
 func TestAnalogWrite(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name(), testDataCapabilitiesResponse)
-	assert.Nil(t, b.AnalogWrite(0, 128))
+	assert.NoError(t, b.AnalogWrite(0, 128))
 }
 
 func TestReportAnalog(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
-	assert.Nil(t, b.ReportAnalog(0, 1))
-	assert.Nil(t, b.ReportAnalog(0, 0))
+	assert.NoError(t, b.ReportAnalog(0, 1))
+	assert.NoError(t, b.ReportAnalog(0, 0))
 }
 
 func TestProcessPinState13(t *testing.T) {
@@ -272,22 +272,22 @@ func TestProcessPinState13(t *testing.T) {
 
 func TestI2cConfig(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
-	assert.Nil(t, b.I2cConfig(100))
+	assert.NoError(t, b.I2cConfig(100))
 }
 
 func TestI2cWrite(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
-	assert.Nil(t, b.I2cWrite(0x00, []byte{0x01, 0x02}))
+	assert.NoError(t, b.I2cWrite(0x00, []byte{0x01, 0x02}))
 }
 
 func TestI2cRead(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
-	assert.Nil(t, b.I2cRead(0x00, 10))
+	assert.NoError(t, b.I2cRead(0x00, 10))
 }
 
 func TestWriteSysex(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
-	assert.Nil(t, b.WriteSysex([]byte{0x01, 0x02}))
+	assert.NoError(t, b.WriteSysex([]byte{0x01, 0x02}))
 }
 
 func TestProcessI2cReply(t *testing.T) {
@@ -373,9 +373,9 @@ func TestConnect(t *testing.T) {
 		rwc.addTestReadData(testDataProtocolResponse)
 	})
 
-	assert.Nil(t, b.Connect(rwc))
+	assert.NoError(t, b.Connect(rwc))
 	time.Sleep(150 * time.Millisecond)
-	assert.Nil(t, b.Disconnect())
+	assert.NoError(t, b.Disconnect())
 }
 
 func TestServoConfig(t *testing.T) {

--- a/platforms/firmata/firmata_adaptor_test.go
+++ b/platforms/firmata/firmata_adaptor_test.go
@@ -111,7 +111,7 @@ func TestNewAdaptor(t *testing.T) {
 
 func TestAdaptorFinalize(t *testing.T) {
 	a := initTestAdaptor()
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 
 	a = initTestAdaptor()
 	a.Board.(*mockFirmataBoard).disconnectError = errors.New("close error")
@@ -125,7 +125,7 @@ func TestAdaptorConnect(t *testing.T) {
 	a := NewAdaptor("/dev/null")
 	a.PortOpener = openSP
 	a.Board = newMockFirmataBoard()
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 
 	a = NewAdaptor("/dev/null")
 	a.Board = newMockFirmataBoard()
@@ -136,16 +136,16 @@ func TestAdaptorConnect(t *testing.T) {
 
 	a = NewAdaptor(&readWriteCloser{})
 	a.Board = newMockFirmataBoard()
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 
 	a = NewAdaptor("/dev/null")
 	a.Board = nil
-	assert.Nil(t, a.Disconnect())
+	assert.NoError(t, a.Disconnect())
 }
 
 func TestAdaptorServoWrite(t *testing.T) {
 	a := initTestAdaptor()
-	assert.Nil(t, a.ServoWrite("1", 50))
+	assert.NoError(t, a.ServoWrite("1", 50))
 }
 
 func TestAdaptorServoWriteBadPin(t *testing.T) {
@@ -155,7 +155,7 @@ func TestAdaptorServoWriteBadPin(t *testing.T) {
 
 func TestAdaptorPwmWrite(t *testing.T) {
 	a := initTestAdaptor()
-	assert.Nil(t, a.PwmWrite("1", 50))
+	assert.NoError(t, a.PwmWrite("1", 50))
 }
 
 func TestAdaptorPwmWriteBadPin(t *testing.T) {
@@ -165,7 +165,7 @@ func TestAdaptorPwmWriteBadPin(t *testing.T) {
 
 func TestAdaptorDigitalWrite(t *testing.T) {
 	a := initTestAdaptor()
-	assert.Nil(t, a.DigitalWrite("1", 1))
+	assert.NoError(t, a.DigitalWrite("1", 1))
 }
 
 func TestAdaptorDigitalWriteBadPin(t *testing.T) {
@@ -176,11 +176,11 @@ func TestAdaptorDigitalWriteBadPin(t *testing.T) {
 func TestAdaptorDigitalRead(t *testing.T) {
 	a := initTestAdaptor()
 	val, err := a.DigitalRead("1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, val)
 
 	val, err = a.DigitalRead("0")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, val)
 }
 
@@ -194,10 +194,10 @@ func TestAdaptorAnalogRead(t *testing.T) {
 	a := initTestAdaptor()
 	val, err := a.AnalogRead("1")
 	assert.Equal(t, 133, val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	val, err = a.AnalogRead("0")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, val)
 }
 
@@ -210,7 +210,7 @@ func TestAdaptorAnalogReadBadPin(t *testing.T) {
 func TestServoConfig(t *testing.T) {
 	a := initTestAdaptor()
 	err := a.ServoConfig("9", 0, 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// test atoi error
 	err = a.ServoConfig("a", 0, 0)

--- a/platforms/firmata/firmata_i2c_test.go
+++ b/platforms/firmata/firmata_i2c_test.go
@@ -72,7 +72,7 @@ func initTestTestAdaptorWithI2cConnection() (i2c.Connection, *i2cMockFirmataBoar
 
 func TestClose(t *testing.T) {
 	i2c, _ := initTestTestAdaptorWithI2cConnection()
-	assert.Nil(t, i2c.Close())
+	assert.NoError(t, i2c.Close())
 }
 
 func TestRead(t *testing.T) {
@@ -82,7 +82,7 @@ func TestRead(t *testing.T) {
 	buf := []byte{0}
 	// act
 	countRead, err := con.Read(buf)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, countRead)
 	assert.Equal(t, 1, brd.numBytesToRead)
 	assert.Equal(t, brd.i2cDataForRead, buf)
@@ -96,7 +96,7 @@ func TestReadByte(t *testing.T) {
 	// act
 	val, err := con.ReadByte()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, brd.numBytesToRead)
 	assert.Equal(t, brd.i2cDataForRead[0], val)
 	assert.Equal(t, 0, len(brd.i2cWritten))
@@ -110,7 +110,7 @@ func TestReadByteData(t *testing.T) {
 	// act
 	val, err := con.ReadByteData(reg)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, brd.numBytesToRead)
 	assert.Equal(t, brd.i2cDataForRead[0], val)
 	assert.Equal(t, 1, len(brd.i2cWritten))
@@ -127,7 +127,7 @@ func TestReadWordData(t *testing.T) {
 	// act
 	val, err := con.ReadWordData(reg)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, brd.numBytesToRead)
 	assert.Equal(t, uint16(lsb)|uint16(msb)<<8, val)
 	assert.Equal(t, 1, len(brd.i2cWritten))
@@ -143,7 +143,7 @@ func TestReadBlockData(t *testing.T) {
 	// act
 	err := con.ReadBlockData(reg, buf)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 5, brd.numBytesToRead)
 	assert.Equal(t, brd.i2cDataForRead, buf)
 	assert.Equal(t, 1, len(brd.i2cWritten))
@@ -158,7 +158,7 @@ func TestWrite(t *testing.T) {
 	// act
 	written, err := con.Write(want)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, wantLen, written)
 	assert.Equal(t, want, brd.i2cWritten)
 }
@@ -171,7 +171,7 @@ func TestWrite20bytes(t *testing.T) {
 	// act
 	written, err := con.Write(want)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, wantLen, written)
 	assert.Equal(t, want, brd.i2cWritten)
 }
@@ -183,7 +183,7 @@ func TestWriteByte(t *testing.T) {
 	// act
 	err := con.WriteByte(want)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(brd.i2cWritten))
 	assert.Equal(t, want, brd.i2cWritten[0])
 }
@@ -196,7 +196,7 @@ func TestWriteByteData(t *testing.T) {
 	// act
 	err := con.WriteByteData(reg, val)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, len(brd.i2cWritten))
 	assert.Equal(t, reg, brd.i2cWritten[0])
 	assert.Equal(t, val, brd.i2cWritten[1])
@@ -210,7 +210,7 @@ func TestWriteWordData(t *testing.T) {
 	// act
 	err := con.WriteWordData(reg, val)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 3, len(brd.i2cWritten))
 	assert.Equal(t, reg, brd.i2cWritten[0])
 	assert.Equal(t, uint8(val&0x00FF), brd.i2cWritten[1])
@@ -229,7 +229,7 @@ func TestWriteBlockData(t *testing.T) {
 	// act
 	err := con.WriteBlockData(reg, val)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 33, len(brd.i2cWritten))
 	assert.Equal(t, reg, brd.i2cWritten[0])
 	assert.Equal(t, val[0:32], brd.i2cWritten[1:])

--- a/platforms/intel-iot/curie/imu_driver_test.go
+++ b/platforms/intel-iot/curie/imu_driver_test.go
@@ -91,12 +91,12 @@ func initTestIMUDriver() *IMUDriver {
 
 func TestIMUDriverStart(t *testing.T) {
 	d := initTestIMUDriver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestIMUDriverHalt(t *testing.T) {
 	d := initTestIMUDriver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestIMUDriverDefaultName(t *testing.T) {
@@ -118,7 +118,7 @@ func TestIMUDriverConnection(t *testing.T) {
 func TestIMUDriverReadAccelerometer(t *testing.T) {
 	d := initTestIMUDriver()
 	_ = d.Start()
-	assert.Nil(t, d.ReadAccelerometer())
+	assert.NoError(t, d.ReadAccelerometer())
 }
 
 func TestIMUDriverReadAccelerometerData(t *testing.T) {
@@ -126,14 +126,14 @@ func TestIMUDriverReadAccelerometerData(t *testing.T) {
 	assert.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseAccelerometerData([]byte{0xF0, 0x11, 0x00, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, &AccelerometerData{X: 1920, Y: 1920, Z: 1920}, result)
 }
 
 func TestIMUDriverReadGyroscope(t *testing.T) {
 	d := initTestIMUDriver()
 	_ = d.Start()
-	assert.Nil(t, d.ReadGyroscope())
+	assert.NoError(t, d.ReadGyroscope())
 }
 
 func TestIMUDriverReadGyroscopeData(t *testing.T) {
@@ -141,14 +141,14 @@ func TestIMUDriverReadGyroscopeData(t *testing.T) {
 	assert.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseGyroscopeData([]byte{0xF0, 0x11, 0x01, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, &GyroscopeData{X: 1920, Y: 1920, Z: 1920}, result)
 }
 
 func TestIMUDriverReadTemperature(t *testing.T) {
 	d := initTestIMUDriver()
 	_ = d.Start()
-	assert.Nil(t, d.ReadTemperature())
+	assert.NoError(t, d.ReadTemperature())
 }
 
 func TestIMUDriverReadTemperatureData(t *testing.T) {
@@ -156,14 +156,14 @@ func TestIMUDriverReadTemperatureData(t *testing.T) {
 	assert.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseTemperatureData([]byte{0xF0, 0x11, 0x02, 0x00, 0x02, 0x03, 0x04, 0xf7})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, float32(31.546875), result)
 }
 
 func TestIMUDriverEnableShockDetection(t *testing.T) {
 	d := initTestIMUDriver()
 	_ = d.Start()
-	assert.Nil(t, d.EnableShockDetection(true))
+	assert.NoError(t, d.EnableShockDetection(true))
 }
 
 func TestIMUDriverShockDetectData(t *testing.T) {
@@ -171,14 +171,14 @@ func TestIMUDriverShockDetectData(t *testing.T) {
 	assert.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseShockData([]byte{0xF0, 0x11, 0x03, 0x00, 0x02, 0xf7})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, &ShockData{Axis: 0, Direction: 2}, result)
 }
 
 func TestIMUDriverEnableStepCounter(t *testing.T) {
 	d := initTestIMUDriver()
 	_ = d.Start()
-	assert.Nil(t, d.EnableStepCounter(true))
+	assert.NoError(t, d.EnableStepCounter(true))
 }
 
 func TestIMUDriverStepCountData(t *testing.T) {
@@ -186,14 +186,14 @@ func TestIMUDriverStepCountData(t *testing.T) {
 	assert.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseStepData([]byte{0xF0, 0x11, 0x04, 0x00, 0x02, 0xf7})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, int16(256), result)
 }
 
 func TestIMUDriverEnableTapDetection(t *testing.T) {
 	d := initTestIMUDriver()
 	_ = d.Start()
-	assert.Nil(t, d.EnableTapDetection(true))
+	assert.NoError(t, d.EnableTapDetection(true))
 }
 
 func TestIMUDriverTapDetectData(t *testing.T) {
@@ -201,14 +201,14 @@ func TestIMUDriverTapDetectData(t *testing.T) {
 	assert.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseTapData([]byte{0xF0, 0x11, 0x05, 0x00, 0x02, 0xf7})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, &TapData{Axis: 0, Direction: 2}, result)
 }
 
 func TestIMUDriverEnableReadMotion(t *testing.T) {
 	d := initTestIMUDriver()
 	_ = d.Start()
-	assert.Nil(t, d.ReadMotion())
+	assert.NoError(t, d.ReadMotion())
 }
 
 func TestIMUDriverReadMotionData(t *testing.T) {
@@ -216,7 +216,7 @@ func TestIMUDriverReadMotionData(t *testing.T) {
 	assert.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseMotionData([]byte{0xF0, 0x11, 0x06, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, &MotionData{AX: 1920, AY: 1920, AZ: 1920, GX: 1920, GY: 1920, GZ: 1920}, result)
 }
 
@@ -224,11 +224,11 @@ func TestIMUDriverHandleEvents(t *testing.T) {
 	d := initTestIMUDriver()
 	_ = d.Start()
 
-	assert.Nil(t, d.handleEvent([]byte{0xF0, 0x11, 0x00, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7}))
-	assert.Nil(t, d.handleEvent([]byte{0xF0, 0x11, 0x01, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7}))
-	assert.Nil(t, d.handleEvent([]byte{0xF0, 0x11, 0x02, 0x00, 0x02, 0x03, 0x04, 0xf7}))
-	assert.Nil(t, d.handleEvent([]byte{0xF0, 0x11, 0x03, 0x00, 0x02, 0xf7}))
-	assert.Nil(t, d.handleEvent([]byte{0xF0, 0x11, 0x04, 0x00, 0x02, 0xf7}))
-	assert.Nil(t, d.handleEvent([]byte{0xF0, 0x11, 0x05, 0x00, 0x02, 0xf7}))
-	assert.Nil(t, d.handleEvent([]byte{0xF0, 0x11, 0x06, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7}))
+	assert.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x00, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7}))
+	assert.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x01, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7}))
+	assert.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x02, 0x00, 0x02, 0x03, 0x04, 0xf7}))
+	assert.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x03, 0x00, 0x02, 0xf7}))
+	assert.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x04, 0x00, 0x02, 0xf7}))
+	assert.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x05, 0x00, 0x02, 0xf7}))
+	assert.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x06, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7}))
 }

--- a/platforms/intel-iot/edison/edison_adaptor_test.go
+++ b/platforms/intel-iot/edison/edison_adaptor_test.go
@@ -235,7 +235,7 @@ func TestConnect(t *testing.T) {
 
 	assert.Equal(t, 6, a.DefaultI2cBus())
 	assert.Equal(t, "arduino", a.board)
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 }
 
 func TestArduinoSetupFail263(t *testing.T) {
@@ -272,7 +272,7 @@ func TestArduinoSetupFail131(t *testing.T) {
 
 func TestArduinoI2CSetupFailTristate(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
-	assert.Nil(t, a.arduinoSetup())
+	assert.NoError(t, a.arduinoSetup())
 
 	fs.WithWriteError = true
 	err := a.arduinoI2CSetup()
@@ -282,7 +282,7 @@ func TestArduinoI2CSetupFailTristate(t *testing.T) {
 func TestArduinoI2CSetupFail14(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 
-	assert.Nil(t, a.arduinoSetup())
+	assert.NoError(t, a.arduinoSetup())
 	delete(fs.Files, "/sys/class/gpio/gpio14/direction")
 
 	err := a.arduinoI2CSetup()
@@ -292,7 +292,7 @@ func TestArduinoI2CSetupFail14(t *testing.T) {
 func TestArduinoI2CSetupUnexportFail(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 
-	assert.Nil(t, a.arduinoSetup())
+	assert.NoError(t, a.arduinoSetup())
 	delete(fs.Files, "/sys/class/gpio/unexport")
 
 	err := a.arduinoI2CSetup()
@@ -302,7 +302,7 @@ func TestArduinoI2CSetupUnexportFail(t *testing.T) {
 func TestArduinoI2CSetupFail236(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 
-	assert.Nil(t, a.arduinoSetup())
+	assert.NoError(t, a.arduinoSetup())
 	delete(fs.Files, "/sys/class/gpio/gpio236/direction")
 
 	err := a.arduinoI2CSetup()
@@ -312,7 +312,7 @@ func TestArduinoI2CSetupFail236(t *testing.T) {
 func TestArduinoI2CSetupFail28(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 
-	assert.Nil(t, a.arduinoSetup())
+	assert.NoError(t, a.arduinoSetup())
 	delete(fs.Files, "/sys/kernel/debug/gpio_debug/gpio28/current_pinmux")
 
 	err := a.arduinoI2CSetup()
@@ -338,7 +338,7 @@ func TestConnectArduinoWriteError(t *testing.T) {
 func TestConnectSparkfun(t *testing.T) {
 	a, _ := initTestAdaptorWithMockedFilesystem("sparkfun")
 
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 	assert.Equal(t, 1, a.DefaultI2cBus())
 	assert.Equal(t, "sparkfun", a.board)
 }
@@ -346,7 +346,7 @@ func TestConnectSparkfun(t *testing.T) {
 func TestConnectMiniboard(t *testing.T) {
 	a, _ := initTestAdaptorWithMockedFilesystem("miniboard")
 
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 	assert.Equal(t, 1, a.DefaultI2cBus())
 	assert.Equal(t, "miniboard", a.board)
 }
@@ -365,10 +365,10 @@ func TestFinalize(t *testing.T) {
 	_ = a.PwmWrite("5", 100)
 
 	_, _ = a.GetI2cConnection(0xff, 6)
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 
 	// assert that finalize after finalize is working
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 
 	// assert that re-connect is working
 	_ = a.Connect()
@@ -400,7 +400,7 @@ func TestDigitalIO(t *testing.T) {
 
 	_ = a.DigitalWrite("2", 0)
 	i, err := a.DigitalRead("2")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, i)
 }
 
@@ -468,7 +468,7 @@ func TestPwm(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 
 	err := a.PwmWrite("5", 100)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "1960", fs.Files["/sys/class/pwm/pwmchip0/pwm1/duty_cycle"].Contents)
 
 	err = a.PwmWrite("7", 100)
@@ -480,7 +480,7 @@ func TestPwmExportError(t *testing.T) {
 	fs := a.sys.UseMockFilesystem(pwmMockPathsMux13Arduino)
 	delete(fs.Files, "/sys/class/pwm/pwmchip0/export")
 	err := a.Connect()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = a.PwmWrite("5", 100)
 	assert.Contains(t, err.Error(), "/sys/class/pwm/pwmchip0/export: no such file")
@@ -541,17 +541,17 @@ func TestI2cWorkflow(t *testing.T) {
 	a.sys.UseMockSyscall()
 
 	con, err := a.GetI2cConnection(0xff, 6)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	_, err = con.Write([]byte{0x00, 0x01})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	data := []byte{42, 42}
 	_, err = con.Read(data)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte{0x00, 0x01}, data)
 
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestI2cFinalizeWithErrors(t *testing.T) {
@@ -559,11 +559,11 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a := NewAdaptor()
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem(pwmMockPathsMux13ArduinoI2c)
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 	con, err := a.GetI2cConnection(0xff, 6)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	_, err = con.Write([]byte{0x0A})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/intel-iot/joule/joule_adaptor_test.go
+++ b/platforms/intel-iot/joule/joule_adaptor_test.go
@@ -111,13 +111,13 @@ func TestFinalize(t *testing.T) {
 	_ = a.DigitalWrite("J12_1", 1)
 	_ = a.PwmWrite("J12_26", 100)
 
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 
 	// assert finalize after finalize is working
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 
 	// assert re-connect is working
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 }
 
 func TestDigitalIO(t *testing.T) {
@@ -129,7 +129,7 @@ func TestDigitalIO(t *testing.T) {
 	_ = a.DigitalWrite("J12_1", 0)
 
 	i, err := a.DigitalRead("J12_1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, i)
 
 	_, err = a.DigitalRead("P9_99")
@@ -140,7 +140,7 @@ func TestPwm(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem()
 
 	err := a.PwmWrite("J12_26", 100)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "3921568", fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents)
 
 	err = a.PwmWrite("4", 100)
@@ -176,11 +176,11 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a := NewAdaptor()
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-2"})
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 	con, err := a.GetI2cConnection(0xff, 2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	_, err = con.Write([]byte{0xbf})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/jetson/jetson_adaptor_test.go
+++ b/platforms/jetson/jetson_adaptor_test.go
@@ -59,7 +59,7 @@ func TestFinalize(t *testing.T) {
 	_ = a.DigitalWrite("3", 1)
 
 	_, _ = a.GetI2cConnection(0xff, 0)
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestPWMPinsConnect(t *testing.T) {
@@ -70,7 +70,7 @@ func TestPWMPinsConnect(t *testing.T) {
 	assert.ErrorContains(t, err, "not connected")
 
 	err = a.Connect()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotEqual(t, (map[string]gobot.PWMPinner)(nil), a.pwmPins)
 	assert.Equal(t, 0, len(a.pwmPins))
 }
@@ -86,13 +86,13 @@ func TestPWMPinsReConnect(t *testing.T) {
 	}
 	a, _ := initTestAdaptorWithMockedFilesystem(mockPaths)
 	assert.Equal(t, 0, len(a.pwmPins))
-	assert.Nil(t, a.PwmWrite("33", 1))
+	assert.NoError(t, a.PwmWrite("33", 1))
 	assert.Equal(t, 1, len(a.pwmPins))
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 	// act
 	err := a.Connect()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, len(a.pwmPins))
 }
 
@@ -108,17 +108,17 @@ func TestDigitalIO(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem(mockPaths)
 
 	err := a.DigitalWrite("7", 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "1", fs.Files["/sys/class/gpio/gpio216/value"].Contents)
 
 	err = a.DigitalWrite("13", 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	i, err := a.DigitalRead("13")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, i)
 
 	assert.ErrorContains(t, a.DigitalWrite("notexist", 1), "'notexist' is not a valid id for a digital pin")
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestDigitalPinConcurrency(t *testing.T) {
@@ -163,11 +163,11 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a := NewAdaptor()
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-1"})
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 	con, err := a.GetI2cConnection(0xff, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	_, err = con.Write([]byte{0xbf})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/jetson/pwm_pin_test.go
+++ b/platforms/jetson/pwm_pin_test.go
@@ -37,15 +37,15 @@ func TestPwmPin(t *testing.T) {
 	require.Equal(t, "", fs.Files[periodPath].Contents)
 	require.Equal(t, "", fs.Files[dutyCyclePath].Contents)
 
-	assert.Nil(t, pin.Export())
+	assert.NoError(t, pin.Export())
 	assert.Equal(t, "3", fs.Files[exportPath].Contents)
 
-	assert.Nil(t, pin.SetEnabled(true))
+	assert.NoError(t, pin.SetEnabled(true))
 	assert.Equal(t, "1", fs.Files[enablePath].Contents)
 
 	val, _ := pin.Polarity()
 	assert.True(t, val)
-	assert.Nil(t, pin.SetPolarity(false))
+	assert.NoError(t, pin.SetPolarity(false))
 	val, _ = pin.Polarity()
 	assert.True(t, val)
 
@@ -54,7 +54,7 @@ func TestPwmPin(t *testing.T) {
 	assert.ErrorContains(t, pin.SetDutyCycle(10000), "Jetson PWM pin period not set")
 	assert.Equal(t, "", fs.Files[dutyCyclePath].Contents)
 
-	assert.Nil(t, pin.SetPeriod(20000000))
+	assert.NoError(t, pin.SetPeriod(20000000))
 	// TODO: see PR #990 assert.Equal(t, "20000000", fs.Files[periodPath].Contents)
 	period, _ := pin.Period()
 	assert.Equal(t, uint32(20000000), period)
@@ -64,7 +64,7 @@ func TestPwmPin(t *testing.T) {
 	dc, _ := pin.DutyCycle()
 	assert.Equal(t, uint32(0), dc)
 
-	assert.Nil(t, pin.SetDutyCycle(10000))
+	assert.NoError(t, pin.SetDutyCycle(10000))
 	assert.Equal(t, "10000", fs.Files[dutyCyclePath].Contents)
 	dc, _ = pin.DutyCycle()
 	assert.Equal(t, uint32(10000), dc)
@@ -74,6 +74,6 @@ func TestPwmPin(t *testing.T) {
 	assert.Equal(t, "10000", fs.Files[dutyCyclePath].Contents)
 	assert.Equal(t, uint32(10000), dc)
 
-	assert.Nil(t, pin.Unexport())
+	assert.NoError(t, pin.Unexport())
 	assert.Equal(t, "3", fs.Files[unexportPath].Contents)
 }

--- a/platforms/joystick/joystick_adaptor_test.go
+++ b/platforms/joystick/joystick_adaptor_test.go
@@ -29,7 +29,7 @@ func TestJoystickAdaptorName(t *testing.T) {
 
 func TestAdaptorConnect(t *testing.T) {
 	a := initTestAdaptor()
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 
 	a = NewAdaptor("6")
 	err := a.Connect()
@@ -39,5 +39,5 @@ func TestAdaptorConnect(t *testing.T) {
 func TestAdaptorFinalize(t *testing.T) {
 	a := initTestAdaptor()
 	_ = a.Connect()
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }

--- a/platforms/joystick/joystick_driver_test.go
+++ b/platforms/joystick/joystick_driver_test.go
@@ -36,7 +36,7 @@ func TestJoystickDriverName(t *testing.T) {
 func TestDriverStart(t *testing.T) {
 	d, _ := initTestDriver("./configs/dualshock3.json")
 	d.interval = 1 * time.Millisecond
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 	time.Sleep(2 * time.Millisecond)
 }
 
@@ -45,7 +45,7 @@ func TestDriverHalt(t *testing.T) {
 	go func() {
 		<-d.halt
 	}()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestDriverHandleEventDS3(t *testing.T) {

--- a/platforms/keyboard/keyboard_driver_test.go
+++ b/platforms/keyboard/keyboard_driver_test.go
@@ -35,10 +35,10 @@ func TestKeyboardDriverName(t *testing.T) {
 
 func TestKeyboardDriverStart(t *testing.T) {
 	d := initTestKeyboardDriver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestKeyboardDriverHalt(t *testing.T) {
 	d := initTestKeyboardDriver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }

--- a/platforms/leap/leap_motion_adaptor_test.go
+++ b/platforms/leap/leap_motion_adaptor_test.go
@@ -32,7 +32,7 @@ func TestLeapMotionAdaptorName(t *testing.T) {
 
 func TestLeapMotionAdaptorConnect(t *testing.T) {
 	a := initTestLeapMotionAdaptor()
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 
 	a.connect = func(port string) (io.ReadWriteCloser, error) {
 		return nil, errors.New("connection error")
@@ -42,5 +42,5 @@ func TestLeapMotionAdaptorConnect(t *testing.T) {
 
 func TestLeapMotionAdaptorFinalize(t *testing.T) {
 	a := initTestLeapMotionAdaptor()
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }

--- a/platforms/leap/leap_motion_driver_test.go
+++ b/platforms/leap/leap_motion_driver_test.go
@@ -69,7 +69,7 @@ func TestLeapMotionDriverName(t *testing.T) {
 
 func TestLeapMotionDriverStart(t *testing.T) {
 	d, _ := initTestLeapMotionDriver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 
 	d2, rwc := initTestLeapMotionDriver()
 	e := errors.New("write error")
@@ -79,7 +79,7 @@ func TestLeapMotionDriverStart(t *testing.T) {
 
 func TestLeapMotionDriverHalt(t *testing.T) {
 	d, _ := initTestLeapMotionDriver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestLeapMotionDriverParser(t *testing.T) {

--- a/platforms/mavlink/mavlink_adaptor_test.go
+++ b/platforms/mavlink/mavlink_adaptor_test.go
@@ -66,7 +66,7 @@ func TestMavlinkAdaptorName(t *testing.T) {
 
 func TestMavlinkAdaptorConnect(t *testing.T) {
 	a := initTestMavlinkAdaptor()
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 
 	a.connect = func(port string) (io.ReadWriteCloser, error) { return nil, errors.New("connect error") }
 	assert.ErrorContains(t, a.Connect(), "connect error")
@@ -74,7 +74,7 @@ func TestMavlinkAdaptorConnect(t *testing.T) {
 
 func TestMavlinkAdaptorFinalize(t *testing.T) {
 	a := initTestMavlinkAdaptor()
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 
 	testAdaptorClose = func() error {
 		return errors.New("close error")

--- a/platforms/mavlink/mavlink_driver_test.go
+++ b/platforms/mavlink/mavlink_driver_test.go
@@ -59,11 +59,11 @@ func TestMavlinkDriverStart(t *testing.T) {
 		err <- data.(error)
 	})
 
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 
 	select {
 	case p := <-packet:
-		assert.Nil(t, d.SendPacket(p))
+		assert.NoError(t, d.SendPacket(p))
 
 	case <-time.After(100 * time.Millisecond):
 		t.Errorf("packet was not emitted")
@@ -82,5 +82,5 @@ func TestMavlinkDriverStart(t *testing.T) {
 
 func TestMavlinkDriverHalt(t *testing.T) {
 	d := initTestMavlinkDriver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }

--- a/platforms/mavlink/mavlink_udp_adaptor_test.go
+++ b/platforms/mavlink/mavlink_udp_adaptor_test.go
@@ -65,8 +65,8 @@ func TestMavlinkUDPAdaptorName(t *testing.T) {
 
 func TestMavlinkUDPAdaptorConnectAndFinalize(t *testing.T) {
 	a := initTestMavlinkUDPAdaptor()
-	assert.Nil(t, a.Connect())
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Connect())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestMavlinkUDPAdaptorWrite(t *testing.T) {
@@ -82,7 +82,7 @@ func TestMavlinkUDPAdaptorWrite(t *testing.T) {
 
 	i, err := a.Write([]byte{0x01, 0x02, 0x03})
 	assert.Equal(t, 3, i)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestMavlinkReadMAVLinkReadDefaultPacket(t *testing.T) {

--- a/platforms/microbit/accelerometer_driver_test.go
+++ b/platforms/microbit/accelerometer_driver_test.go
@@ -25,8 +25,8 @@ func TestAccelerometerDriver(t *testing.T) {
 
 func TestAccelerometerDriverStartAndHalt(t *testing.T) {
 	d := initTestAccelerometerDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Halt())
 }
 
 func TestAccelerometerDriverReadData(t *testing.T) {

--- a/platforms/microbit/button_driver_test.go
+++ b/platforms/microbit/button_driver_test.go
@@ -25,8 +25,8 @@ func TestButtonDriver(t *testing.T) {
 
 func TestButtonDriverStartAndHalt(t *testing.T) {
 	d := initTestButtonDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Halt())
 }
 
 func TestButtonDriverReadData(t *testing.T) {

--- a/platforms/microbit/io_pin_driver_test.go
+++ b/platforms/microbit/io_pin_driver_test.go
@@ -39,8 +39,8 @@ func TestIOPinDriverStartAndHalt(t *testing.T) {
 	a.TestReadCharacteristic(func(cUUID string) ([]byte, error) {
 		return []byte{0, 1, 1, 0}, nil
 	})
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Halt())
 }
 
 func TestIOPinDriverStartError(t *testing.T) {
@@ -82,7 +82,7 @@ func TestIOPinDriverDigitalWrite(t *testing.T) {
 	d := NewIOPinDriver(a)
 
 	// TODO: a better test
-	assert.Nil(t, d.DigitalWrite("0", 1))
+	assert.NoError(t, d.DigitalWrite("0", 1))
 }
 
 func TestIOPinDriverDigitalWriteInvalidPin(t *testing.T) {
@@ -139,7 +139,7 @@ func TestIOPinDriverDigitalWriteAnalogRead(t *testing.T) {
 		return []byte{0, 0, 1, 128, 2, 1}, nil
 	})
 
-	assert.Nil(t, d.DigitalWrite("1", 0))
+	assert.NoError(t, d.DigitalWrite("1", 0))
 
 	val, _ := d.AnalogRead("1")
 	assert.Equal(t, 128, val)
@@ -155,5 +155,5 @@ func TestIOPinDriverAnalogReadDigitalWrite(t *testing.T) {
 	val, _ := d.AnalogRead("1")
 	assert.Equal(t, 128, val)
 
-	assert.Nil(t, d.DigitalWrite("1", 0))
+	assert.NoError(t, d.DigitalWrite("1", 0))
 }

--- a/platforms/microbit/led_driver_test.go
+++ b/platforms/microbit/led_driver_test.go
@@ -24,32 +24,32 @@ func TestLEDDriver(t *testing.T) {
 
 func TestLEDDriverStartAndHalt(t *testing.T) {
 	d := initTestLEDDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Halt())
 }
 
 func TestLEDDriverWriteMatrix(t *testing.T) {
 	d := initTestLEDDriver()
 	_ = d.Start()
-	assert.Nil(t, d.WriteMatrix([]byte{0x01, 0x02}))
+	assert.NoError(t, d.WriteMatrix([]byte{0x01, 0x02}))
 }
 
 func TestLEDDriverWriteText(t *testing.T) {
 	d := initTestLEDDriver()
 	_ = d.Start()
-	assert.Nil(t, d.WriteText("Hello"))
+	assert.NoError(t, d.WriteText("Hello"))
 }
 
 func TestLEDDriverCommands(t *testing.T) {
 	d := initTestLEDDriver()
 	_ = d.Start()
-	assert.Nil(t, d.Blank())
-	assert.Nil(t, d.Solid())
-	assert.Nil(t, d.UpRightArrow())
-	assert.Nil(t, d.UpLeftArrow())
-	assert.Nil(t, d.DownRightArrow())
-	assert.Nil(t, d.DownLeftArrow())
-	assert.Nil(t, d.Dimond())
-	assert.Nil(t, d.Smile())
-	assert.Nil(t, d.Wink())
+	assert.NoError(t, d.Blank())
+	assert.NoError(t, d.Solid())
+	assert.NoError(t, d.UpRightArrow())
+	assert.NoError(t, d.UpLeftArrow())
+	assert.NoError(t, d.DownRightArrow())
+	assert.NoError(t, d.DownLeftArrow())
+	assert.NoError(t, d.Dimond())
+	assert.NoError(t, d.Smile())
+	assert.NoError(t, d.Wink())
 }

--- a/platforms/microbit/magnetometer_driver_test.go
+++ b/platforms/microbit/magnetometer_driver_test.go
@@ -25,8 +25,8 @@ func TestMagnetometerDriver(t *testing.T) {
 
 func TestMagnetometerDriverStartAndHalt(t *testing.T) {
 	d := initTestMagnetometerDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Halt())
 }
 
 func TestMagnetometerDriverReadData(t *testing.T) {

--- a/platforms/microbit/temperature_driver_test.go
+++ b/platforms/microbit/temperature_driver_test.go
@@ -25,8 +25,8 @@ func TestTemperatureDriver(t *testing.T) {
 
 func TestTemperatureDriverStartAndHalt(t *testing.T) {
 	d := initTestTemperatureDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Halt())
 }
 
 func TestTemperatureDriverReadData(t *testing.T) {

--- a/platforms/mqtt/mqtt_adaptor_test.go
+++ b/platforms/mqtt/mqtt_adaptor_test.go
@@ -90,7 +90,7 @@ func TestMqttAdaptorConnectWithAuthError(t *testing.T) {
 
 func TestMqttAdaptorFinalize(t *testing.T) {
 	a := initTestMqttAdaptor()
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestMqttAdaptorCannotPublishUnlessConnected(t *testing.T) {

--- a/platforms/mqtt/mqtt_driver_test.go
+++ b/platforms/mqtt/mqtt_driver_test.go
@@ -16,8 +16,8 @@ func TestMqttDriver(t *testing.T) {
 	assert.True(t, strings.HasPrefix(d.Name(), "MQTT"))
 	assert.True(t, strings.HasPrefix(d.Connection().Name(), "MQTT"))
 
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Halt())
 }
 
 func TestMqttDriverName(t *testing.T) {

--- a/platforms/nanopi/nanopi_adaptor_test.go
+++ b/platforms/nanopi/nanopi_adaptor_test.go
@@ -93,7 +93,7 @@ func TestDigitalIO(t *testing.T) {
 	assert.Equal(t, 1, i)
 
 	assert.ErrorContains(t, a.DigitalWrite("99", 1), "'99' is not a valid id for a digital pin")
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestInvalidPWMPin(t *testing.T) {
@@ -118,7 +118,7 @@ func TestPwmWrite(t *testing.T) {
 	preparePwmFs(fs)
 
 	err := a.PwmWrite("PWM", 100)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "0", fs.Files[pwmExportPath].Contents)
 	assert.Equal(t, "1", fs.Files[pwmEnablePath].Contents)
@@ -127,15 +127,15 @@ func TestPwmWrite(t *testing.T) {
 	assert.Equal(t, "normal", fs.Files[pwmPolarityPath].Contents)
 
 	err = a.ServoWrite("PWM", 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "500000", fs.Files[pwmDutyCyclePath].Contents)
 
 	err = a.ServoWrite("PWM", 180)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "2000000", fs.Files[pwmDutyCyclePath].Contents)
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestSetPeriod(t *testing.T) {
@@ -147,7 +147,7 @@ func TestSetPeriod(t *testing.T) {
 	// act
 	err := a.SetPeriod("PWM", newPeriod)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "0", fs.Files[pwmExportPath].Contents)
 	assert.Equal(t, "1", fs.Files[pwmEnablePath].Contents)
 	assert.Equal(t, fmt.Sprintf("%d", newPeriod), fs.Files[pwmPeriodPath].Contents)
@@ -156,7 +156,7 @@ func TestSetPeriod(t *testing.T) {
 
 	// arrange test for automatic adjustment of duty cycle to lower value
 	err = a.PwmWrite("PWM", 127) // 127 is a little bit smaller than 50% of period
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("%d", 1270000), fs.Files[pwmDutyCyclePath].Contents)
 	newPeriod = newPeriod / 10
 
@@ -164,7 +164,7 @@ func TestSetPeriod(t *testing.T) {
 	err = a.SetPeriod("PWM", newPeriod)
 
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("%d", 127000), fs.Files[pwmDutyCyclePath].Contents)
 
 	// arrange test for automatic adjustment of duty cycle to higher value
@@ -174,14 +174,14 @@ func TestSetPeriod(t *testing.T) {
 	err = a.SetPeriod("PWM", newPeriod)
 
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("%d", 2540000), fs.Files[pwmDutyCyclePath].Contents)
 }
 
 func TestFinalizeErrorAfterGPIO(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem(gpioMockPaths)
 
-	assert.Nil(t, a.DigitalWrite("7", 1))
+	assert.NoError(t, a.DigitalWrite("7", 1))
 
 	fs.WithWriteError = true
 
@@ -193,7 +193,7 @@ func TestFinalizeErrorAfterPWM(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem(pwmMockPaths)
 	preparePwmFs(fs)
 
-	assert.Nil(t, a.PwmWrite("PWM", 1))
+	assert.NoError(t, a.PwmWrite("PWM", 1))
 
 	fs.WithWriteError = true
 
@@ -221,11 +221,11 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a := NewNeoAdaptor()
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-1"})
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 	con, err := a.GetI2cConnection(0xff, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	_, err = con.Write([]byte{0xbf})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/nats/nats_adaptor_test.go
+++ b/platforms/nats/nats_adaptor_test.go
@@ -74,7 +74,7 @@ func TestNatsAdapterSetsRootCAs(t *testing.T) {
 	_ = a.Connect()
 	o := a.client.Opts
 	casPool, err := o.RootCAsCB()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, casPool)
 	assert.True(t, o.Secure)
 }
@@ -84,7 +84,7 @@ func TestNatsAdapterSetsClientCerts(t *testing.T) {
 	assert.Equal(t, "tls://localhost:4242", a.Host)
 	_ = a.Connect()
 	cert, err := a.client.Opts.TLSCertCB()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, cert)
 	assert.NotNil(t, cert.Leaf)
 	assert.True(t, a.client.Opts.Secure)
@@ -95,7 +95,7 @@ func TestNatsAdapterSetsClientCertsWithUserInfo(t *testing.T) {
 	assert.Equal(t, "tls://localhost:4242", a.Host)
 	_ = a.Connect()
 	cert, err := a.client.Opts.TLSCertCB()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, cert)
 	assert.NotNil(t, cert.Leaf)
 	assert.True(t, a.client.Opts.Secure)
@@ -153,7 +153,7 @@ func TestNatsAdaptorFailedConnect(t *testing.T) {
 
 func TestNatsAdaptorFinalize(t *testing.T) {
 	a := NewAdaptor("localhost:9999", 79999)
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestNatsAdaptorCannotPublishUnlessConnected(t *testing.T) {

--- a/platforms/nats/nats_driver_test.go
+++ b/platforms/nats/nats_driver_test.go
@@ -17,8 +17,8 @@ func TestNatsDriver(t *testing.T) {
 	assert.True(t, strings.HasPrefix(d.Connection().Name(), "NATS"))
 	assert.NotNil(t, d.adaptor())
 
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Halt())
 }
 
 func TestNatsDriverName(t *testing.T) {

--- a/platforms/neurosky/neurosky_adaptor_test.go
+++ b/platforms/neurosky/neurosky_adaptor_test.go
@@ -69,7 +69,7 @@ func TestNeuroskyAdaptorName(t *testing.T) {
 
 func TestNeuroskyAdaptorConnect(t *testing.T) {
 	a := initTestNeuroskyAdaptor()
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 
 	a.connect = func(n *Adaptor) (io.ReadWriteCloser, error) {
 		return nil, errors.New("connection error")
@@ -84,7 +84,7 @@ func TestNeuroskyAdaptorFinalize(t *testing.T) {
 		return rwc, nil
 	}
 	_ = a.Connect()
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 
 	rwc.CloseError(errors.New("close error"))
 	_ = a.Connect()

--- a/platforms/neurosky/neurosky_driver_test.go
+++ b/platforms/neurosky/neurosky_driver_test.go
@@ -52,7 +52,7 @@ func TestNeuroskyDriverStart(t *testing.T) {
 		sem <- true
 	})
 
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 
 	time.Sleep(50 * time.Millisecond)
 	rwc.ReadError(e)
@@ -69,7 +69,7 @@ func TestNeuroskyDriverStart(t *testing.T) {
 
 func TestNeuroskyDriverHalt(t *testing.T) {
 	d := initTestNeuroskyDriver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestNeuroskyDriverParse(t *testing.T) {

--- a/platforms/opencv/camera_driver_test.go
+++ b/platforms/opencv/camera_driver_test.go
@@ -36,7 +36,7 @@ func TestCameraDriverName(t *testing.T) {
 func TestCameraDriverStart(t *testing.T) {
 	sem := make(chan bool)
 	d := initTestCameraDriver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 	d.On(d.Event("frame"), func(data interface{}) {
 		sem <- true
 	})
@@ -47,7 +47,7 @@ func TestCameraDriverStart(t *testing.T) {
 	}
 
 	d = NewCameraDriver("")
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 
 	d = NewCameraDriver(true)
 	assert.NotNil(t, d.Start())
@@ -55,5 +55,5 @@ func TestCameraDriverStart(t *testing.T) {
 
 func TestCameraDriverHalt(t *testing.T) {
 	d := initTestCameraDriver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }

--- a/platforms/opencv/window_driver_test.go
+++ b/platforms/opencv/window_driver_test.go
@@ -33,12 +33,12 @@ func TestWindowDriverName(t *testing.T) {
 
 func TestWindowDriverStart(t *testing.T) {
 	d := initTestWindowDriver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestWindowDriverHalt(t *testing.T) {
 	d := initTestWindowDriver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestWindowDriverShowImage(t *testing.T) {

--- a/platforms/parrot/ardrone/ardrone_adaptor_test.go
+++ b/platforms/parrot/ardrone/ardrone_adaptor_test.go
@@ -29,7 +29,7 @@ func TestArdroneAdaptor(t *testing.T) {
 
 func TestArdroneAdaptorConnect(t *testing.T) {
 	a := initTestArdroneAdaptor()
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 
 	a.connect = func(a *Adaptor) (drone, error) {
 		return nil, errors.New("connection error")
@@ -46,5 +46,5 @@ func TestArdroneAdaptorName(t *testing.T) {
 
 func TestArdroneAdaptorFinalize(t *testing.T) {
 	a := initTestArdroneAdaptor()
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }

--- a/platforms/parrot/ardrone/ardrone_driver_test.go
+++ b/platforms/parrot/ardrone/ardrone_driver_test.go
@@ -34,12 +34,12 @@ func TestArdroneDriverName(t *testing.T) {
 
 func TestArdroneDriverStart(t *testing.T) {
 	d := initTestArdroneDriver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestArdroneDriverHalt(t *testing.T) {
 	d := initTestArdroneDriver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestArdroneDriverTakeOff(t *testing.T) {

--- a/platforms/parrot/bebop/bebop_adaptor_test.go
+++ b/platforms/parrot/bebop/bebop_adaptor_test.go
@@ -29,7 +29,7 @@ func TestBebopAdaptorName(t *testing.T) {
 
 func TestBebopAdaptorConnect(t *testing.T) {
 	a := initTestBebopAdaptor()
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 
 	a.connect = func(a *Adaptor) error {
 		return errors.New("connection error")
@@ -40,5 +40,5 @@ func TestBebopAdaptorConnect(t *testing.T) {
 func TestBebopAdaptorFinalize(t *testing.T) {
 	a := initTestBebopAdaptor()
 	_ = a.Connect()
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }

--- a/platforms/parrot/minidrone/minidrone_driver_test.go
+++ b/platforms/parrot/minidrone/minidrone_driver_test.go
@@ -24,133 +24,133 @@ func TestMinidroneDriver(t *testing.T) {
 
 func TestMinidroneDriverStartAndHalt(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Halt())
 }
 
 func TestMinidroneTakeoff(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.TakeOff())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.TakeOff())
 }
 
 func TestMinidroneEmergency(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Emergency())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Emergency())
 }
 
 func TestMinidroneTakePicture(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.TakePicture())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.TakePicture())
 }
 
 func TestMinidroneUp(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Up(25))
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Up(25))
 }
 
 func TestMinidroneUpTooFar(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Up(125))
-	assert.Nil(t, d.Up(-50))
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Up(125))
+	assert.NoError(t, d.Up(-50))
 }
 
 func TestMinidroneDown(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Down(25))
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Down(25))
 }
 
 func TestMinidroneForward(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Forward(25))
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Forward(25))
 }
 
 func TestMinidroneBackward(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Backward(25))
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Backward(25))
 }
 
 func TestMinidroneRight(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Right(25))
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Right(25))
 }
 
 func TestMinidroneLeft(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Left(25))
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Left(25))
 }
 
 func TestMinidroneClockwise(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Clockwise(25))
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Clockwise(25))
 }
 
 func TestMinidroneCounterClockwise(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.CounterClockwise(25))
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.CounterClockwise(25))
 }
 
 func TestMinidroneStop(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Stop())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Stop())
 }
 
 func TestMinidroneStartStopRecording(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.StartRecording())
-	assert.Nil(t, d.StopRecording())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.StartRecording())
+	assert.NoError(t, d.StopRecording())
 }
 
 func TestMinidroneHullProtectionOutdoor(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.HullProtection(true))
-	assert.Nil(t, d.Outdoor(true))
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.HullProtection(true))
+	assert.NoError(t, d.Outdoor(true))
 }
 
 func TestMinidroneHullFlips(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.FrontFlip())
-	assert.Nil(t, d.BackFlip())
-	assert.Nil(t, d.RightFlip())
-	assert.Nil(t, d.LeftFlip())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.FrontFlip())
+	assert.NoError(t, d.BackFlip())
+	assert.NoError(t, d.RightFlip())
+	assert.NoError(t, d.LeftFlip())
 }
 
 func TestMinidroneLightControl(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.LightControl(0, LightBlinked, 25))
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.LightControl(0, LightBlinked, 25))
 }
 
 func TestMinidroneClawControl(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.ClawControl(0, ClawOpen))
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.ClawControl(0, ClawOpen))
 }
 
 func TestMinidroneGunControl(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.GunControl(0))
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.GunControl(0))
 }
 
 func TestMinidroneProcessFlightData(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 
 	d.processFlightStatus([]byte{0x00, 0x00, 0x00})
 	d.processFlightStatus([]byte{0x00, 0x00, 0x00, 0x00, 0x00})
@@ -166,5 +166,5 @@ func TestMinidroneProcessFlightData(t *testing.T) {
 	d.processFlightStatus([]byte{0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x05})
 	d.processFlightStatus([]byte{0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x06})
 
-	assert.Nil(t, d.Stop())
+	assert.NoError(t, d.Stop())
 }

--- a/platforms/particle/adaptor_test.go
+++ b/platforms/particle/adaptor_test.go
@@ -88,13 +88,13 @@ func TestNewAdaptor(t *testing.T) {
 
 func TestAdaptorConnect(t *testing.T) {
 	a := initTestAdaptor()
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 }
 
 func TestAdaptorFinalize(t *testing.T) {
 	a := initTestAdaptor()
 	_ = a.Connect()
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestAdaptorAnalogRead(t *testing.T) {
@@ -403,5 +403,5 @@ func TestAdaptorEventStream(t *testing.T) {
 	}
 
 	_, err = a.EventStream("devices", "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/platforms/pebble/pebble_adaptor_test.go
+++ b/platforms/pebble/pebble_adaptor_test.go
@@ -20,10 +20,10 @@ func TestAdaptor(t *testing.T) {
 
 func TestAdaptorConnect(t *testing.T) {
 	a := initTestAdaptor()
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 }
 
 func TestAdaptorFinalize(t *testing.T) {
 	a := initTestAdaptor()
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }

--- a/platforms/pebble/pebble_driver_test.go
+++ b/platforms/pebble/pebble_driver_test.go
@@ -16,12 +16,12 @@ func initTestDriver() *Driver {
 
 func TestDriverStart(t *testing.T) {
 	d := initTestDriver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestDriverHalt(t *testing.T) {
 	d := initTestDriver()
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestDriver(t *testing.T) {

--- a/platforms/raspi/pwm_pin_test.go
+++ b/platforms/raspi/pwm_pin_test.go
@@ -17,13 +17,13 @@ func TestPwmPin(t *testing.T) {
 
 	pin := NewPWMPin(a, path, "1")
 
-	assert.Nil(t, pin.Export())
-	assert.Nil(t, pin.SetEnabled(true))
+	assert.NoError(t, pin.Export())
+	assert.NoError(t, pin.SetEnabled(true))
 
 	val, _ := pin.Polarity()
 	assert.True(t, val)
 
-	assert.Nil(t, pin.SetPolarity(false))
+	assert.NoError(t, pin.SetPolarity(false))
 
 	val, _ = pin.Polarity()
 	assert.True(t, val)
@@ -32,7 +32,7 @@ func TestPwmPin(t *testing.T) {
 	assert.ErrorContains(t, err, "Raspi PWM pin period not set")
 	assert.ErrorContains(t, pin.SetDutyCycle(10000), "Raspi PWM pin period not set")
 
-	assert.Nil(t, pin.SetPeriod(20000000))
+	assert.NoError(t, pin.SetPeriod(20000000))
 	period, _ := pin.Period()
 	assert.Equal(t, uint32(20000000), period)
 	assert.ErrorContains(t, pin.SetPeriod(10000000), "Cannot set the period of individual PWM pins on Raspi")
@@ -40,7 +40,7 @@ func TestPwmPin(t *testing.T) {
 	dc, _ := pin.DutyCycle()
 	assert.Equal(t, uint32(0), dc)
 
-	assert.Nil(t, pin.SetDutyCycle(10000))
+	assert.NoError(t, pin.SetDutyCycle(10000))
 
 	dc, _ = pin.DutyCycle()
 	assert.Equal(t, uint32(10000), dc)
@@ -49,5 +49,5 @@ func TestPwmPin(t *testing.T) {
 	dc, _ = pin.DutyCycle()
 	assert.Equal(t, uint32(10000), dc)
 
-	assert.Nil(t, pin.Unexport())
+	assert.NoError(t, pin.Unexport())
 }

--- a/platforms/raspi/raspi_adaptor_test.go
+++ b/platforms/raspi/raspi_adaptor_test.go
@@ -103,7 +103,7 @@ func TestFinalize(t *testing.T) {
 	_ = a.PwmWrite("7", 255)
 
 	_, _ = a.GetI2cConnection(0xff, 0)
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestDigitalPWM(t *testing.T) {
@@ -111,17 +111,17 @@ func TestDigitalPWM(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem(mockedPaths)
 	a.PiBlasterPeriod = 20000000
 
-	assert.Nil(t, a.PwmWrite("7", 4))
+	assert.NoError(t, a.PwmWrite("7", 4))
 
 	pin, _ := a.PWMPin("7")
 	period, _ := pin.Period()
 	assert.Equal(t, uint32(20000000), period)
 
-	assert.Nil(t, a.PwmWrite("7", 255))
+	assert.NoError(t, a.PwmWrite("7", 255))
 
 	assert.Equal(t, "4=1", strings.Split(fs.Files["/dev/pi-blaster"].Contents, "\n")[0])
 
-	assert.Nil(t, a.ServoWrite("11", 90))
+	assert.NoError(t, a.ServoWrite("11", 90))
 
 	assert.Equal(t, "17=0.5", strings.Split(fs.Files["/dev/pi-blaster"].Contents, "\n")[0])
 
@@ -132,7 +132,7 @@ func TestDigitalPWM(t *testing.T) {
 	period, _ = pin.Period()
 	assert.Equal(t, uint32(20000000), period)
 
-	assert.Nil(t, pin.SetDutyCycle(1.5*1000*1000))
+	assert.NoError(t, pin.SetDutyCycle(1.5*1000*1000))
 
 	assert.Equal(t, "18=0.075", strings.Split(fs.Files["/dev/pi-blaster"].Contents, "\n")[0])
 }
@@ -149,19 +149,19 @@ func TestDigitalIO(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem(mockedPaths)
 
 	err := a.DigitalWrite("7", 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "1", fs.Files["/sys/class/gpio/gpio4/value"].Contents)
 
 	a.revision = "2"
 	err = a.DigitalWrite("13", 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	i, err := a.DigitalRead("13")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, i)
 
 	assert.ErrorContains(t, a.DigitalWrite("notexist", 1), "Not a valid pin")
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestDigitalPinConcurrency(t *testing.T) {
@@ -197,18 +197,18 @@ func TestPWMPin(t *testing.T) {
 
 	a.revision = "3"
 	firstSysPin, err := a.PWMPin("35")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(a.pwmPins))
 
 	secondSysPin, err := a.PWMPin("35")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(a.pwmPins))
 	assert.Equal(t, secondSysPin, firstSysPin)
 
 	otherSysPin, err := a.PWMPin("36")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, len(a.pwmPins))
 	assert.NotEqual(t, otherSysPin, firstSysPin)
 }
@@ -222,17 +222,17 @@ func TestPWMPinsReConnect(t *testing.T) {
 	}
 
 	_, err := a.PWMPin("35")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(a.pwmPins))
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 	// act
 	err = a.Connect()
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, len(a.pwmPins))
 	_, _ = a.PWMPin("35")
 	_, err = a.PWMPin("36")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, len(a.pwmPins))
 }
 
@@ -262,11 +262,11 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a := NewAdaptor()
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-1"})
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 	con, err := a.GetI2cConnection(0xff, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	_, err = con.Write([]byte{0xbf})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/sphero/bb8/bb8_driver_test.go
+++ b/platforms/sphero/bb8/bb8_driver_test.go
@@ -24,6 +24,6 @@ func TestBB8Driver(t *testing.T) {
 
 func TestBB8DriverStartAndHalt(t *testing.T) {
 	d := initTestBB8Driver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Halt())
 }

--- a/platforms/sphero/ollie/ollie_driver_test.go
+++ b/platforms/sphero/ollie/ollie_driver_test.go
@@ -26,8 +26,8 @@ func TestOllieDriver(t *testing.T) {
 
 func TestOllieDriverStartAndHalt(t *testing.T) {
 	d := initTestOllieDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Halt())
 }
 
 func TestLocatorData(t *testing.T) {

--- a/platforms/sphero/sphero_adaptor_test.go
+++ b/platforms/sphero/sphero_adaptor_test.go
@@ -82,7 +82,7 @@ func TestSpheroAdaptorReconnect(t *testing.T) {
 func TestSpheroAdaptorFinalize(t *testing.T) {
 	a, rwc := initTestSpheroAdaptor()
 	_ = a.Connect()
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 
 	rwc.testAdaptorClose = func() error {
 		return errors.New("close error")
@@ -94,7 +94,7 @@ func TestSpheroAdaptorFinalize(t *testing.T) {
 
 func TestSpheroAdaptorConnect(t *testing.T) {
 	a, _ := initTestSpheroAdaptor()
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 
 	a.connect = func(string) (io.ReadWriteCloser, error) {
 		return nil, errors.New("connect error")

--- a/platforms/sphero/sphero_driver_test.go
+++ b/platforms/sphero/sphero_driver_test.go
@@ -84,13 +84,13 @@ func TestSpheroDriver(t *testing.T) {
 
 func TestSpheroDriverStart(t *testing.T) {
 	d := initTestSpheroDriver()
-	assert.Nil(t, d.Start())
+	assert.NoError(t, d.Start())
 }
 
 func TestSpheroDriverHalt(t *testing.T) {
 	d := initTestSpheroDriver()
 	d.adaptor().connected = true
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Halt())
 }
 
 func TestSpheroDriverSetDataStreaming(t *testing.T) {

--- a/platforms/sphero/sprkplus/sprkplus_driver_test.go
+++ b/platforms/sphero/sprkplus/sprkplus_driver_test.go
@@ -24,6 +24,6 @@ func TestSPRKPlusDriver(t *testing.T) {
 
 func TestSPRKPlusDriverStartAndHalt(t *testing.T) {
 	d := initTestSPRKPlusDriver()
-	assert.Nil(t, d.Start())
-	assert.Nil(t, d.Halt())
+	assert.NoError(t, d.Start())
+	assert.NoError(t, d.Halt())
 }

--- a/platforms/tinkerboard/adaptor_test.go
+++ b/platforms/tinkerboard/adaptor_test.go
@@ -93,7 +93,7 @@ func TestDigitalIO(t *testing.T) {
 	assert.Equal(t, 1, i)
 
 	assert.ErrorContains(t, a.DigitalWrite("99", 1), "'99' is not a valid id for a digital pin")
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestInvalidPWMPin(t *testing.T) {
@@ -118,7 +118,7 @@ func TestPwmWrite(t *testing.T) {
 	preparePwmFs(fs)
 
 	err := a.PwmWrite("33", 100)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "0", fs.Files[pwmExportPath].Contents)
 	assert.Equal(t, "1", fs.Files[pwmEnablePath].Contents)
@@ -127,15 +127,15 @@ func TestPwmWrite(t *testing.T) {
 	assert.Equal(t, "normal", fs.Files[pwmPolarityPath].Contents)
 
 	err = a.ServoWrite("33", 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "500000", fs.Files[pwmDutyCyclePath].Contents)
 
 	err = a.ServoWrite("33", 180)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "2000000", fs.Files[pwmDutyCyclePath].Contents)
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestSetPeriod(t *testing.T) {
@@ -147,7 +147,7 @@ func TestSetPeriod(t *testing.T) {
 	// act
 	err := a.SetPeriod("33", newPeriod)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "0", fs.Files[pwmExportPath].Contents)
 	assert.Equal(t, "1", fs.Files[pwmEnablePath].Contents)
 	assert.Equal(t, fmt.Sprintf("%d", newPeriod), fs.Files[pwmPeriodPath].Contents)
@@ -156,7 +156,7 @@ func TestSetPeriod(t *testing.T) {
 
 	// arrange test for automatic adjustment of duty cycle to lower value
 	err = a.PwmWrite("33", 127) // 127 is a little bit smaller than 50% of period
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("%d", 1270000), fs.Files[pwmDutyCyclePath].Contents)
 	newPeriod = newPeriod / 10
 
@@ -164,7 +164,7 @@ func TestSetPeriod(t *testing.T) {
 	err = a.SetPeriod("33", newPeriod)
 
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("%d", 127000), fs.Files[pwmDutyCyclePath].Contents)
 
 	// arrange test for automatic adjustment of duty cycle to higher value
@@ -174,14 +174,14 @@ func TestSetPeriod(t *testing.T) {
 	err = a.SetPeriod("33", newPeriod)
 
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("%d", 2540000), fs.Files[pwmDutyCyclePath].Contents)
 }
 
 func TestFinalizeErrorAfterGPIO(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem(gpioMockPaths)
 
-	assert.Nil(t, a.DigitalWrite("7", 1))
+	assert.NoError(t, a.DigitalWrite("7", 1))
 
 	fs.WithWriteError = true
 
@@ -193,7 +193,7 @@ func TestFinalizeErrorAfterPWM(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem(pwmMockPaths)
 	preparePwmFs(fs)
 
-	assert.Nil(t, a.PwmWrite("33", 1))
+	assert.NoError(t, a.PwmWrite("33", 1))
 
 	fs.WithWriteError = true
 
@@ -221,11 +221,11 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a := NewAdaptor()
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-4"})
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 	con, err := a.GetI2cConnection(0xff, 4)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	_, err = con.Write([]byte{0xbf})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/upboard/up2/adaptor_test.go
+++ b/platforms/upboard/up2/adaptor_test.go
@@ -78,7 +78,7 @@ func TestDigitalIO(t *testing.T) {
 	)
 
 	assert.ErrorContains(t, a.DigitalWrite("99", 1), "'99' is not a valid id for a digital pin")
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestPWM(t *testing.T) {
@@ -87,7 +87,7 @@ func TestPWM(t *testing.T) {
 	fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents = "0"
 
 	err := a.PwmWrite("32", 100)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "0", fs.Files["/sys/class/pwm/pwmchip0/export"].Contents)
 	assert.Equal(t, "1", fs.Files["/sys/class/pwm/pwmchip0/pwm0/enable"].Contents)
@@ -96,24 +96,24 @@ func TestPWM(t *testing.T) {
 	assert.Equal(t, "normal", fs.Files["/sys/class/pwm/pwmchip0/pwm0/polarity"].Contents)
 
 	err = a.ServoWrite("32", 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "500000", fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents)
 	assert.Equal(t, "10000000", fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents)
 
 	err = a.ServoWrite("32", 180)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "2000000", fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents)
 	assert.Equal(t, "10000000", fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents)
 
-	assert.Nil(t, a.Finalize())
+	assert.NoError(t, a.Finalize())
 }
 
 func TestFinalizeErrorAfterGPIO(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem(gpioMockPaths)
 
-	assert.Nil(t, a.DigitalWrite("7", 1))
+	assert.NoError(t, a.DigitalWrite("7", 1))
 
 	fs.WithWriteError = true
 
@@ -126,7 +126,7 @@ func TestFinalizeErrorAfterPWM(t *testing.T) {
 	fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents = "0"
 	fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents = "0"
 
-	assert.Nil(t, a.PwmWrite("32", 1))
+	assert.NoError(t, a.PwmWrite("32", 1))
 
 	fs.WithWriteError = true
 
@@ -184,11 +184,11 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a := NewAdaptor()
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-5"})
-	assert.Nil(t, a.Connect())
+	assert.NoError(t, a.Connect())
 	con, err := a.GetI2cConnection(0xff, 5)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	_, err = con.Write([]byte{0xbf})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/robot_test.go
+++ b/robot_test.go
@@ -39,8 +39,8 @@ func TestRobotDevicesToJSON(t *testing.T) {
 
 func TestRobotStart(t *testing.T) {
 	r := newTestRobot("Robot99")
-	assert.Nil(t, r.Start())
-	assert.Nil(t, r.Stop())
+	assert.NoError(t, r.Start())
+	assert.NoError(t, r.Stop())
 	assert.False(t, r.Running())
 }
 
@@ -55,13 +55,13 @@ func TestRobotStartAutoRun(t *testing.T) {
 	)
 
 	go func() {
-		assert.Nil(t, r.Start())
+		assert.NoError(t, r.Start())
 	}()
 
 	time.Sleep(10 * time.Millisecond)
 	assert.True(t, r.Running())
 
 	// stop it
-	assert.Nil(t, r.Stop())
+	assert.NoError(t, r.Stop())
 	assert.False(t, r.Running())
 }

--- a/system/digitalpin_gpiod_test.go
+++ b/system/digitalpin_gpiod_test.go
@@ -259,7 +259,7 @@ func TestWrite(t *testing.T) {
 					assert.Contains(t, err.Error(), want)
 				}
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}
 			assert.Equal(t, tc.want, lm.lastVal)
 		})
@@ -294,7 +294,7 @@ func TestRead(t *testing.T) {
 					assert.Contains(t, err.Error(), want)
 				}
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}
 			assert.Equal(t, got, tc.simVal)
 		})

--- a/system/digitalpin_sysfs_test.go
+++ b/system/digitalpin_sysfs_test.go
@@ -36,20 +36,20 @@ func TestDigitalPin(t *testing.T) {
 	assert.Nil(t, pin.valFile)
 
 	err := pin.Unexport()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "10", fs.Files["/sys/class/gpio/unexport"].Contents)
 
 	err = pin.Export()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "10", fs.Files["/sys/class/gpio/export"].Contents)
 	assert.NotNil(t, pin.valFile)
 
 	err = pin.Write(1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "1", fs.Files["/sys/class/gpio/gpio10/value"].Contents)
 
 	err = pin.ApplyOptions(WithPinDirectionInput())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "in", fs.Files["/sys/class/gpio/gpio10/direction"].Contents)
 
 	data, _ := pin.Read()
@@ -68,7 +68,7 @@ func TestDigitalPin(t *testing.T) {
 	}
 
 	err = pin.Unexport()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	writeFile = func(File, []byte) (int, error) {
 		return 0, &os.PathError{Err: errors.New("write error")}
@@ -87,7 +87,7 @@ func TestDigitalPin(t *testing.T) {
 		return 0, nil
 	}
 	err = pin.Export()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// assert write error on export
 	writeFile = func(File, []byte) (int, error) {

--- a/system/fs_mock_test.go
+++ b/system/fs_mock_test.go
@@ -14,10 +14,10 @@ func TestMockFilesystemOpen(t *testing.T) {
 	assert.False(t, f1.Opened)
 	f2, err := fs.openFile("foo", 0, 0o666)
 	assert.Equal(t, f2, f1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = f2.Sync()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	_, err = fs.openFile("bar", 0, 0o666)
 	assert.ErrorContains(t, err, " : bar: no such file")
@@ -31,11 +31,11 @@ func TestMockFilesystemStat(t *testing.T) {
 	fs := newMockFilesystem([]string{"foo", "bar/baz"})
 
 	fileStat, err := fs.stat("foo")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, fileStat.IsDir())
 
 	dirStat, err := fs.stat("bar")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, dirStat.IsDir())
 
 	_, err = fs.stat("plonk")
@@ -61,7 +61,7 @@ func TestMockFilesystemFind(t *testing.T) {
 			// act
 			dirs, err := fs.find(tt.baseDir, tt.pattern)
 			// assert
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			sort.Strings(dirs)
 			assert.Equal(t, tt.want, dirs)
 		})
@@ -73,7 +73,7 @@ func TestMockFilesystemWrite(t *testing.T) {
 	f1 := fs.Files["bar"]
 
 	f2, err := fs.openFile("bar", 0, 0o666)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Never been read or written.
 	assert.True(t, f1.Seq <= 0)
 
@@ -89,7 +89,7 @@ func TestMockFilesystemRead(t *testing.T) {
 	f1.Contents = "Yip"
 
 	f2, err := fs.openFile("bar", 0, 0o666)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Never been read or written.
 	assert.True(t, f1.Seq <= 0)
 

--- a/system/fs_test.go
+++ b/system/fs_test.go
@@ -10,13 +10,13 @@ import (
 func TestFilesystemOpen(t *testing.T) {
 	fs := &nativeFilesystem{}
 	file, err := fs.openFile(os.DevNull, os.O_RDONLY, 0o666)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	var _ File = file
 }
 
 func TestFilesystemStat(t *testing.T) {
 	fs := &nativeFilesystem{}
 	fileInfo, err := fs.stat(os.DevNull)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, fileInfo)
 }

--- a/system/i2c_device_test.go
+++ b/system/i2c_device_test.go
@@ -83,7 +83,7 @@ func TestNewI2cDevice(t *testing.T) {
 				assert.Equal(t, (*i2cDevice)(nil), d)
 			} else {
 				var _ gobot.I2cSystemDevicer = d
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}
 		})
 	}
@@ -93,7 +93,7 @@ func TestClose(t *testing.T) {
 	// arrange
 	d, _ := initTestI2cDeviceWithMockedSys()
 	// act & assert
-	assert.Nil(t, d.Close())
+	assert.NoError(t, d.Close())
 }
 
 func TestWriteRead(t *testing.T) {
@@ -105,8 +105,8 @@ func TestWriteRead(t *testing.T) {
 	wn, werr := d.Write(1, wbuf)
 	rn, rerr := d.Read(1, rbuf)
 	// assert
-	assert.Nil(t, werr)
-	assert.Nil(t, rerr)
+	assert.NoError(t, werr)
+	assert.NoError(t, rerr)
 	assert.Equal(t, len(wbuf), wn)
 	assert.Equal(t, len(wbuf), rn) // will read only the written values
 	assert.Equal(t, rbuf[:len(wbuf)], wbuf)
@@ -144,7 +144,7 @@ func TestReadByte(t *testing.T) {
 			if tc.wantErr != "" {
 				assert.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, want, got)
 				assert.Equal(t, d.file, msc.lastFile)
 				assert.Equal(t, uintptr(I2C_SMBUS), msc.lastSignal)
@@ -191,7 +191,7 @@ func TestReadByteData(t *testing.T) {
 			if tc.wantErr != "" {
 				assert.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, want, got)
 				assert.Equal(t, d.file, msc.lastFile)
 				assert.Equal(t, uintptr(I2C_SMBUS), msc.lastSignal)
@@ -241,7 +241,7 @@ func TestReadWordData(t *testing.T) {
 			if tc.wantErr != "" {
 				assert.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, want, got)
 				assert.Equal(t, d.file, msc.lastFile)
 				assert.Equal(t, uintptr(I2C_SMBUS), msc.lastSignal)
@@ -299,7 +299,7 @@ func TestReadBlockData(t *testing.T) {
 			if tc.wantErr != "" {
 				assert.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, msc.dataSlice, buf)
 				assert.Equal(t, d.file, msc.lastFile)
 				assert.Equal(t, uintptr(I2C_SMBUS), msc.lastSignal)
@@ -343,7 +343,7 @@ func TestWriteByte(t *testing.T) {
 			if tc.wantErr != "" {
 				assert.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, d.file, msc.lastFile)
 				assert.Equal(t, uintptr(I2C_SMBUS), msc.lastSignal)
 				assert.Equal(t, byte(I2C_SMBUS_WRITE), msc.smbus.readWrite)
@@ -388,7 +388,7 @@ func TestWriteByteData(t *testing.T) {
 			if tc.wantErr != "" {
 				assert.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, d.file, msc.lastFile)
 				assert.Equal(t, uintptr(I2C_SMBUS), msc.lastSignal)
 				assert.Equal(t, byte(I2C_SMBUS_WRITE), msc.smbus.readWrite)
@@ -437,7 +437,7 @@ func TestWriteWordData(t *testing.T) {
 			if tc.wantErr != "" {
 				assert.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, d.file, msc.lastFile)
 				assert.Equal(t, uintptr(I2C_SMBUS), msc.lastSignal)
 				assert.Equal(t, byte(I2C_SMBUS_WRITE), msc.smbus.readWrite)
@@ -494,7 +494,7 @@ func TestWriteBlockData(t *testing.T) {
 			if tc.wantErr != "" {
 				assert.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, d.file, msc.lastFile)
 				assert.Equal(t, uintptr(I2C_SMBUS), msc.lastSignal)
 				assert.Equal(t, uint8(len(data)+1), msc.sliceSize) // including size element
@@ -523,7 +523,7 @@ func Test_setAddress(t *testing.T) {
 	// act
 	err := d.setAddress(0xff)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uintptr(0xff), msc.devAddress)
 }
 
@@ -567,7 +567,7 @@ func Test_queryFunctionality(t *testing.T) {
 			if tc.wantErr != "" {
 				assert.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}
 			if tc.wantFile {
 				assert.NotNil(t, d.file)

--- a/system/pwmpin_sysfs_test.go
+++ b/system/pwmpin_sysfs_test.go
@@ -35,25 +35,25 @@ func TestPwmPin(t *testing.T) {
 	assert.Equal(t, "10", pin.pin)
 
 	err := pin.Unexport()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "10", fs.Files["/sys/class/pwm/pwmchip0/unexport"].Contents)
 
 	err = pin.Export()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "10", fs.Files["/sys/class/pwm/pwmchip0/export"].Contents)
 
-	assert.Nil(t, pin.SetPolarity(false))
+	assert.NoError(t, pin.SetPolarity(false))
 	assert.Equal(t, inverted, fs.Files["/sys/class/pwm/pwmchip0/pwm10/polarity"].Contents)
 	pol, _ := pin.Polarity()
 	assert.False(t, pol)
-	assert.Nil(t, pin.SetPolarity(true))
+	assert.NoError(t, pin.SetPolarity(true))
 	assert.Equal(t, normal, fs.Files["/sys/class/pwm/pwmchip0/pwm10/polarity"].Contents)
 	pol, _ = pin.Polarity()
 	assert.True(t, pol)
 
 	assert.NotEqual(t, "1", fs.Files["/sys/class/pwm/pwmchip0/pwm10/enable"].Contents)
 	err = pin.SetEnabled(true)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "1", fs.Files["/sys/class/pwm/pwmchip0/pwm10/enable"].Contents)
 	err = pin.SetPolarity(true)
 	assert.ErrorContains(t, err, "Cannot set PWM polarity when enabled")
@@ -61,13 +61,13 @@ func TestPwmPin(t *testing.T) {
 	fs.Files["/sys/class/pwm/pwmchip0/pwm10/period"].Contents = "6"
 	data, _ := pin.Period()
 	assert.Equal(t, uint32(6), data)
-	assert.Nil(t, pin.SetPeriod(100000))
+	assert.NoError(t, pin.SetPeriod(100000))
 	data, _ = pin.Period()
 	assert.Equal(t, uint32(100000), data)
 
 	assert.NotEqual(t, "1", fs.Files["/sys/class/pwm/pwmchip0/pwm10/duty_cycle"].Contents)
 	err = pin.SetDutyCycle(100)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "100", fs.Files["/sys/class/pwm/pwmchip0/pwm10/duty_cycle"].Contents)
 	data, _ = pin.DutyCycle()
 	assert.Equal(t, uint32(100), data)
@@ -88,7 +88,7 @@ func TestPwmPinAlreadyExported(t *testing.T) {
 	}
 
 	// no error indicates that the pin was already exported
-	assert.Nil(t, pin.Export())
+	assert.NoError(t, pin.Export())
 }
 
 func TestPwmPinExportError(t *testing.T) {

--- a/system/system_test.go
+++ b/system/system_test.go
@@ -34,7 +34,7 @@ func TestNewAccesser_NewSpiDevice(t *testing.T) {
 	// act
 	con, err := a.NewSpiDevice(busNum, chipNum, mode, bits, maxSpeed)
 	// assert
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, con)
 	assert.Equal(t, busNum, spi.busNum)
 	assert.Equal(t, chipNum, spi.chipNum)


### PR DESCRIPTION
## Solved issues and/or description of the change

test for no error has the advantage of print out an existing error by default

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code (no productive code affected)