### PR TITLE
jetson(PWM): fix set period

### DIFF
--- a/platforms/jetson/pwm_pin.go
+++ b/platforms/jetson/pwm_pin.go
@@ -89,7 +89,7 @@ func (p *PWMPin) SetPeriod(period uint32) error {
 	if period < minimumPeriod {
 		return errors.New("Cannot set the period more then minimum")
 	}
-	if err := p.writeFile(fmt.Sprintf("pwm%s/period", p.fn), fmt.Sprintf("%v", p.period)); err != nil {
+	if err := p.writeFile(fmt.Sprintf("pwm%s/period", p.fn), fmt.Sprintf("%v", period)); err != nil {
 		return err
 	}
 	p.period = period

--- a/platforms/jetson/pwm_pin_test.go
+++ b/platforms/jetson/pwm_pin_test.go
@@ -55,11 +55,11 @@ func TestPwmPin(t *testing.T) {
 	assert.Equal(t, "", fs.Files[dutyCyclePath].Contents)
 
 	assert.NoError(t, pin.SetPeriod(20000000))
-	// TODO: see PR #990 assert.Equal(t, "20000000", fs.Files[periodPath].Contents)
+	assert.Equal(t, "20000000", fs.Files[periodPath].Contents)
 	period, _ := pin.Period()
 	assert.Equal(t, uint32(20000000), period)
 	assert.ErrorContains(t, pin.SetPeriod(10000000), "Cannot set the period of individual PWM pins on Jetson")
-	// TODO: see PR #990 assert.Equal(t, "20000000", fs.Files[periodPath].Contents)
+	assert.Equal(t, "20000000", fs.Files[periodPath].Contents)
 
 	dc, _ := pin.DutyCycle()
 	assert.Equal(t, uint32(0), dc)


### PR DESCRIPTION
## Solved issues and/or description of the change

SetPeriod() uses the value from the backing field and therefor not change the real value - changed to usage of the given parameter

in addition activate related tests

obsoletes the #990 , the honor go to @Jwen98

## Manual test

none

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code