### PR TITLE
gpio: fix data race in PIRMotionDriver

### DIFF
--- a/drivers/gpio/button_driver.go
+++ b/drivers/gpio/button_driver.go
@@ -75,7 +75,7 @@ func (b *ButtonDriver) SetDefaultState(s int) {
 //	Push int - On button push
 //	Release int - On button release
 //	Error error - On button error
-func (b *ButtonDriver) initialize() (err error) {
+func (b *ButtonDriver) initialize() error {
 	state := b.defaultState
 	go func() {
 		for {
@@ -93,10 +93,10 @@ func (b *ButtonDriver) initialize() (err error) {
 			}
 		}
 	}()
-	return
+	return nil
 }
 
-func (b *ButtonDriver) shutdown() (err error) {
+func (b *ButtonDriver) shutdown() error {
 	b.halt <- true
 	return nil
 }

--- a/drivers/gpio/button_driver_test.go
+++ b/drivers/gpio/button_driver_test.go
@@ -1,7 +1,7 @@
 package gpio
 
 import (
-	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -58,7 +58,7 @@ func TestButtonStart(t *testing.T) {
 		select {
 		case val = <-nextVal:
 			if val < 0 {
-				err = errors.New("digital read error")
+				err = fmt.Errorf("digital read error")
 			}
 			return val, err
 		default:
@@ -73,9 +73,11 @@ func TestButtonStart(t *testing.T) {
 	})
 
 	// act
-	assert.NoError(t, d.Start())
+	err := d.Start()
 
 	// assert & rearrange
+	assert.NoError(t, err)
+
 	select {
 	case <-sem:
 	case <-time.After(buttonTestDelay * time.Millisecond):

--- a/drivers/gpio/pir_motion_driver_test.go
+++ b/drivers/gpio/pir_motion_driver_test.go
@@ -1,8 +1,9 @@
 package gpio
 
 import (
-	"errors"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,42 +15,67 @@ var _ gobot.Driver = (*PIRMotionDriver)(nil)
 
 const motionTestDelay = 150
 
-func initTestPIRMotionDriver() *PIRMotionDriver {
-	return NewPIRMotionDriver(newGpioTestAdaptor(), "1")
+func initTestPIRMotionDriverWithStubbedAdaptor() (*PIRMotionDriver, *gpioTestAdaptor) {
+	a := newGpioTestAdaptor()
+	d := NewPIRMotionDriver(a, "1")
+	return d, a
 }
 
-func TestPIRMotionDriverHalt(t *testing.T) {
-	d := initTestPIRMotionDriver()
-	go func() {
-		<-d.halt
-	}()
-	assert.NoError(t, d.Halt())
-}
-
-func TestPIRMotionDriver(t *testing.T) {
-	d := NewPIRMotionDriver(newGpioTestAdaptor(), "1")
-	assert.NotNil(t, d.Connection())
-
+func TestNewPIRMotionDriver(t *testing.T) {
+	// arrange
+	a := newGpioTestAdaptor()
+	// act
+	d := NewPIRMotionDriver(a, "1")
+	// assert
+	assert.IsType(t, &PIRMotionDriver{}, d)
+	assert.True(t, strings.HasPrefix(d.name, "PIRMotion"))
+	assert.Equal(t, a, d.connection)
+	assert.NotNil(t, d.afterStart)
+	assert.NotNil(t, d.beforeHalt)
+	assert.NotNil(t, d.Commander)
+	assert.NotNil(t, d.mutex)
+	assert.NotNil(t, d.Eventer)
+	assert.Equal(t, "1", d.pin)
+	assert.Equal(t, false, d.active)
+	assert.Equal(t, 10*time.Millisecond, d.interval)
+	assert.NotNil(t, d.halt)
+	// act & assert other interval
 	d = NewPIRMotionDriver(newGpioTestAdaptor(), "1", 30*time.Second)
 	assert.Equal(t, 30*time.Second, d.interval)
 }
 
-func TestPIRMotionDriverStart(t *testing.T) {
+func TestPIRMotionStart(t *testing.T) {
+	// arrange
 	sem := make(chan bool)
+	nextVal := make(chan int, 1)
 	a := newGpioTestAdaptor()
 	d := NewPIRMotionDriver(a, "1")
 
-	assert.NoError(t, d.Start())
+	a.digitalReadFunc = func(string) (int, error) {
+		val := 1
+		var err error
+		select {
+		case val = <-nextVal:
+			if val < 0 {
+				err = fmt.Errorf("digital read error")
+			}
+			return val, err
+		default:
+			return val, err
+		}
+	}
 
 	_ = d.Once(MotionDetected, func(data interface{}) {
-		assert.True(t, d.Active)
+		assert.True(t, d.active)
+		nextVal <- 0
 		sem <- true
 	})
 
-	a.digitalReadFunc = func(string) (val int, err error) {
-		val = 1
-		return
-	}
+	// act
+	err := d.Start()
+
+	// assert & rearrange
+	assert.NoError(t, err)
 
 	select {
 	case <-sem:
@@ -58,14 +84,10 @@ func TestPIRMotionDriverStart(t *testing.T) {
 	}
 
 	_ = d.Once(MotionStopped, func(data interface{}) {
-		assert.False(t, d.Active)
+		assert.False(t, d.active)
+		nextVal <- -1
 		sem <- true
 	})
-
-	a.digitalReadFunc = func(string) (val int, err error) {
-		val = 0
-		return
-	}
 
 	select {
 	case <-sem:
@@ -77,25 +99,76 @@ func TestPIRMotionDriverStart(t *testing.T) {
 		sem <- true
 	})
 
-	a.digitalReadFunc = func(string) (val int, err error) {
-		err = errors.New("digital read error")
-		return
-	}
-
 	select {
 	case <-sem:
 	case <-time.After(motionTestDelay * time.Millisecond):
 		t.Errorf("PIRMotionDriver Event \"Error\" was not published")
 	}
+
+	_ = d.Once(MotionDetected, func(data interface{}) {
+		sem <- true
+	})
+
+	d.halt <- true
+	nextVal <- 1
+
+	select {
+	case <-sem:
+		t.Errorf("PIRMotion Event \"MotionDetected\" should not published")
+	case <-time.After(motionTestDelay * time.Millisecond):
+	}
 }
 
-func TestPIRDriverDefaultName(t *testing.T) {
-	d := initTestPIRMotionDriver()
-	assert.True(t, strings.HasPrefix(d.Name(), "PIR"))
+func TestPIRMotionHalt(t *testing.T) {
+	// arrange
+	d, _ := initTestPIRMotionDriverWithStubbedAdaptor()
+	const timeout = 10 * time.Microsecond
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		select {
+		case <-d.halt: // wait until halt was set to the channel
+		case <-time.After(timeout): // otherwise run into the timeout
+			t.Errorf("halt was not received within %s", timeout)
+		}
+	}()
+	// act & assert
+	assert.NoError(t, d.Halt())
+	wg.Wait() // wait until the go function was really finished
 }
 
-func TestPIRDriverSetName(t *testing.T) {
-	d := initTestPIRMotionDriver()
-	d.SetName("mybot")
-	assert.Equal(t, "mybot", d.Name())
+func TestPIRMotionPin(t *testing.T) {
+	tests := map[string]struct {
+		want string
+	}{
+		"10": {want: "10"},
+		"36": {want: "36"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			d := PIRMotionDriver{pin: name}
+			// act & assert
+			assert.Equal(t, tc.want, d.Pin())
+		})
+	}
+}
+
+func TestPIRMotionActive(t *testing.T) {
+	tests := map[string]struct {
+		want bool
+	}{
+		"active_true":  {want: true},
+		"active_false": {want: false},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			d := PIRMotionDriver{Driver: NewDriver(nil, "PIRMotion")} // just for mutex
+			d.active = tc.want
+			// act & assert
+			assert.Equal(t, tc.want, d.Active())
+		})
+	}
 }


### PR DESCRIPTION
## Solved issues and/or description of the change

data race in PIRMotionDriver found by go test -race - fixed by rework of driver and its tests

this partially fix https://github.com/hybridgroup/gobot/issues/1017

## Manual test

none

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code