### PR TITLE
i2c(core): fix problems with usage of uintptr

### DIFF
--- a/drivers/i2c/i2c_connection_test.go
+++ b/drivers/i2c/i2c_connection_test.go
@@ -14,18 +14,20 @@ import (
 
 const dev = "/dev/i2c-1"
 
-func getSyscallFuncImpl(errorMask byte) func(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err system.SyscallErrno) {
+func getSyscallFuncImpl(
+	errorMask byte,
+) func(trap, a1, a2 uintptr, a3 unsafe.Pointer) (r1, r2 uintptr, err system.SyscallErrno) {
 	// bit 0: error on function query
 	// bit 1: error on set address
 	// bit 2: error on command
-	return func(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err system.SyscallErrno) {
+	return func(trap, a1, a2 uintptr, a3 unsafe.Pointer) (r1, r2 uintptr, err system.SyscallErrno) {
 		// function query
 		if (trap == system.Syscall_SYS_IOCTL) && (a2 == system.I2C_FUNCS) {
 			if errorMask&0x01 == 0x01 {
 				return 0, 0, 1
 			}
 
-			var funcPtr *uint64 = (*uint64)(unsafe.Pointer(a3))
+			var funcPtr *uint64 = (*uint64)(a3)
 			*funcPtr = system.I2C_FUNC_SMBUS_READ_BYTE | system.I2C_FUNC_SMBUS_READ_BYTE_DATA |
 				system.I2C_FUNC_SMBUS_READ_WORD_DATA |
 				system.I2C_FUNC_SMBUS_WRITE_BYTE | system.I2C_FUNC_SMBUS_WRITE_BYTE_DATA |

--- a/system/syscall.go
+++ b/system/syscall.go
@@ -21,8 +21,30 @@ const (
 type nativeSyscall struct{}
 
 // Syscall calls the native unix.Syscall, implements the SystemCaller interface
-func (sys *nativeSyscall) syscall(trap uintptr, f File, signal uintptr, payload unsafe.Pointer) (r1, r2 uintptr, err SyscallErrno) {
-	r1, r2, errNo := unix.Syscall(trap, f.Fd(), signal, uintptr(payload))
+// Note: It would be possible to transfer the address as an unsafe.Pointer to e.g. a byte, uint16 or integer variable.
+// The unpack process here would be as follows:
+// * convert the payload back to the pointer: addrPtr := (*byte)(payload)
+// * call with the content converted to uintptr: r1, r2, errNo = unix.Syscall(trap, f.Fd(), signal, uintptr(*addrPtr))
+// This has the main disadvantage, that if someone change the type of the address at caller side, the compiler will not
+// detect this problem and this unpack procedure would cause unpredictable results.
+// So the decision was taken to give the address here as a separate parameter, although it is not used in every call.
+// Note also, that the size of the address variable at Kernel side is u16, therefore uint16 is used here.
+func (sys *nativeSyscall) syscall(
+	trap uintptr,
+	f File,
+	signal uintptr,
+	payload unsafe.Pointer,
+	address uint16,
+) (r1, r2 uintptr, err SyscallErrno) {
+	var errNo unix.Errno
+	if signal == I2C_SLAVE {
+		// this is the setup for the address, it just needs to be converted to an uintptr,
+		// the given payload is not used in this case, see the comment on the function
+		r1, r2, errNo = unix.Syscall(trap, f.Fd(), signal, uintptr(address))
+	} else {
+		r1, r2, errNo = unix.Syscall(trap, f.Fd(), signal, uintptr(payload))
+	}
+
 	return r1, r2, SyscallErrno(errNo)
 }
 

--- a/system/system.go
+++ b/system/system.go
@@ -31,8 +31,15 @@ type filesystem interface {
 
 // systemCaller represents unexposed Syscall interface to allow the switch between native and mocked implementation
 // Prevent unsafe call, since go 1.15, see "Pattern 4" in: https://go101.org/article/unsafe.html
+// For go vet false positives, see: https://github.com/golang/go/issues/41205
 type systemCaller interface {
-	syscall(trap uintptr, f File, signal uintptr, payload unsafe.Pointer) (r1, r2 uintptr, err SyscallErrno)
+	syscall(
+		trap uintptr,
+		f File,
+		signal uintptr,
+		payload unsafe.Pointer,
+		address uint16,
+	) (r1, r2 uintptr, err SyscallErrno)
 }
 
 // digitalPinAccesser represents unexposed interface to allow the switch between different implementations and


### PR DESCRIPTION
## Solved issues and/or description of the change

null reference exception in i2c core drivers when test with `test -race`, caused by GC - fixed by using an additional parameter for address instead of try to reuse the payload parameter and use a unsafe.Pointer instead of uintptr for the last parameter in test mocks for syscall

this partially fix https://github.com/hybridgroup/gobot/issues/1017

## Manual test

- OS and Version (Win/Mac/Linux): Linux
- Adaptor(s) and/or driver(s): tinkerboard with PCA9533 and ADS1115

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code