### PR TITLE
doc(test): use -race for tests by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run:
           name: Core and drivers tests
           command:  |
-            go test -v -coverprofile=coverage.txt -covermode=atomic . ./drivers/...
+            go test -race -v -coverprofile=coverage.txt -covermode=atomic . ./drivers/...
       - run:
           name: Code coverage
           command: |
@@ -41,7 +41,7 @@ jobs:
           # digispark needs libusb, opencv needs opencv
           name: Platform tests (except digispark and opencv)
           command: |
-            go test -v $(go list ./platforms/... | grep -v platforms/digispark | grep -v platforms/opencv)
+            go test -race -v $(go list ./platforms/... | grep -v platforms/digispark | grep -v platforms/opencv)
   
   "check_examples":
     docker:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@
 
 - [ ] The PR's target branch is 'hybridgroup:dev'
 - [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes (e.g. by run `make test`)
+- [ ] New and existing unit tests pass locally with my changes (e.g. by run `make test_race`)
 - [ ] No linter errors exist locally (e.g. by run `make fmt_check`)
 - [ ] I have performed a self-review of my own code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Descriptions for each of these will eventually be provided below.
 * Take care to maintain the existing coding style.
 * `golangci-lint` your code, see [instruction for local installation](https://golangci-lint.run/usage/install/#local-installation)
 * `gofumpt` your code (the go version will be automatically obtained from go.mod), see [instructions](https://github.com/mvdan/gofumpt/blob/master/README.md)
-* Add unit tests for any new or changed functionality.
+* Add unit tests for any new or changed functionality and run tests with `-race` flag activated.
 * All pull requests should be "fast forward"
   * If there are commits after yours use “git rebase -i <new_head_branch>”
   * If you have local changes you may need to use “git stash”
@@ -69,14 +69,10 @@ The basics are as follows:
     All import paths should now work fine assuming that you've got the
     proper branch checked out.
 
-3. Get all the needed gobot's dependencies each of them at their needed version. Gobot uses
-   [dep (Dependency management for Go)](https://golang.github.io/dep/) to manage the project's dependencies. To get all
-   the correct dependencies:
+3. Get all dependencies:
 
-   * Install dep tool. Follow the dep [installation](https://golang.github.io/dep/docs/installation.html) instructions in
-     case you don't have it already installed.
    * `cd $GOPATH/src/gobot.io/x/gobot`
-   * `dep ensure` will fetch  all the dependencies at their needed version.
+   * `go mod tidy` will fetch  all the dependencies at their needed version.
 
 ## Landing Pull Requests
 

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,13 @@ EXAMPLES := $(EXAMPLES_NO_GOCV)
 # opencv platform currently skipped to prevent install of preconditions
 including_except := $(shell go list ./... | grep -v platforms/opencv)
 
+# Run tests on nearly all directories without test cache, with race detection
+test_race:
+	go test -failfast -count=1 -v -race $(including_except)
+
 # Run tests on nearly all directories without test cache
 test:
-	go test -failfast -count=1 -v $(including_except)
-
-# Run tests with race detection
-test_race:
-	go test -race $(including_except)
+	go test -failfast -count=1 $(including_except)
 
 # Test, generate and show coverage in browser
 test_cover:


### PR DESCRIPTION
## Solved issues and/or description of the change

after fix all data race detections, the -race flag is used by default in the CI tests

this partially fix #1017 

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test`)
- [x] I have performed a self-review of my own code