### PR TITLE
test(lint): switch to 1.55.2 and adjust linter issues

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,7 +24,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.54.2
+          version: v1.55.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: v2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,8 @@
 # note: GolangCI-Lint also searches for config files in all directories from the directory of the first analyzed path up to the root.
 run:
+  build-tags:
+    - utils
+
   # Timeout for analysis, e.g. 30s, 5m.
   # gobot is very expensive, on a machine with heavy load it takes some minutes
   # for first run or after empty the cache by 'golangci-lint cache clean'
@@ -31,10 +34,10 @@ run:
 linters:
   # currently active linters:
   #
-  #INFO [lintersdb] Active 42 linters: [asasalint asciicheck bidichk contextcheck decorder depguard dupword durationcheck errcheck exportloopref
-  # gocheckcompilerdirectives gofmt gofumpt goimports gomoddirectives gomodguard goprintffuncname gosec gosimple govet grouper ineffassign makezero mirror
-  # misspell musttag nilerr nilnil nolintlint nosprintfhostport prealloc reassign revive staticcheck tagalign tenv testableexamples tparallel unconvert unparam
-  # unused wastedassign]
+  #INFO [lintersdb] Active 49 linters: [asasalint asciicheck bidichk contextcheck decorder depguard dupword durationcheck errcheck exportloopref
+  # gocheckcompilerdirectives gochecknoinits gochecksumtype gofmt gofumpt goimports gomoddirectives gomodguard goprintffuncname gosec gosimple govet grouper
+  # inamedparam ineffassign makezero mirror misspell musttag nilerr nilnil nolintlint nosprintfhostport perfsprint prealloc protogetter reassign revive
+  # sloglint staticcheck tagalign tenv testableexamples testifylint tparallel unconvert unparam unused wastedassign]
 
   enable-all: true
 

--- a/adaptor.go
+++ b/adaptor.go
@@ -8,7 +8,7 @@ import (
 // DigitalPinOptioner is the interface to provide the possibility to change pin behavior for the next usage
 type DigitalPinOptioner interface {
 	// SetLabel change the pins label
-	SetLabel(string) (changed bool)
+	SetLabel(label string) (changed bool)
 	// SetDirectionOutput sets the pins direction to output with the given initial value
 	SetDirectionOutput(initialState int) (changed bool)
 	// SetDirectionInput sets the pins direction to input
@@ -38,7 +38,7 @@ type DigitalPinOptioner interface {
 // DigitalPinOptionApplier is the interface to apply options to change pin behavior immediately
 type DigitalPinOptionApplier interface {
 	// ApplyOptions apply all given options to the pin immediately
-	ApplyOptions(...func(DigitalPinOptioner) bool) error
+	ApplyOptions(options ...func(DigitalPinOptioner) bool) error
 }
 
 // DigitalPinner is the interface for system gpio interactions
@@ -50,7 +50,7 @@ type DigitalPinner interface {
 	// Read reads the current value of the pin
 	Read() (int, error)
 	// Write writes to the pin
-	Write(int) error
+	Write(val int) error
 	// DigitalPinOptionApplier is the interface to change pin behavior immediately
 	DigitalPinOptionApplier
 }
@@ -78,7 +78,7 @@ type PWMPinner interface {
 	// Enabled returns the enabled state of the PWM pin
 	Enabled() (bool, error)
 	// SetEnabled enables/disables the PWM pin
-	SetEnabled(bool) error
+	SetEnabled(val bool) error
 	// Polarity returns true if the polarity of the PWM pin is normal, otherwise false
 	Polarity() (bool, error)
 	// SetPolarity sets the polarity of the PWM pin to normal if called with true and to inverted if called with false
@@ -86,11 +86,11 @@ type PWMPinner interface {
 	// Period returns the current PWM period in nanoseconds for pin
 	Period() (uint32, error)
 	// SetPeriod sets the current PWM period in nanoseconds for pin
-	SetPeriod(uint32) error
+	SetPeriod(period uint32) error
 	// DutyCycle returns the duty cycle in nanoseconds for the PWM pin
 	DutyCycle() (uint32, error)
 	// SetDutyCycle writes the duty cycle in nanoseconds to the PWM pin
-	SetDutyCycle(uint32) error
+	SetDutyCycle(dutyCyle uint32) error
 }
 
 // PWMPinnerProvider is the interface that an Adaptor should implement to allow
@@ -210,7 +210,7 @@ type Adaptor interface {
 	// Name returns the label for the Adaptor
 	Name() string
 	// SetName sets the label for the Adaptor
-	SetName(string)
+	SetName(name string)
 	// Connect initiates the Adaptor
 	Connect() error
 	// Finalize terminates the Adaptor

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -80,8 +80,8 @@ func TestIndex(t *testing.T) {
 
 	a.ServeHTTP(response, request)
 
-	assert.Equal(t, response.Code, http.StatusMovedPermanently)
-	assert.Equal(t, response.Header()["Location"][0], "/index.html")
+	assert.Equal(t, http.StatusMovedPermanently, response.Code)
+	assert.Equal(t, "/index.html", response.Header()["Location"][0])
 }
 
 func TestMcp(t *testing.T) {
@@ -144,7 +144,7 @@ func TestRobots(t *testing.T) {
 
 	var body map[string]interface{}
 	_ = json.NewDecoder(response.Body).Decode(&body)
-	assert.Equal(t, 3, len(body["robots"].([]interface{})))
+	assert.Len(t, body["robots"].([]interface{}), 3)
 }
 
 func TestRobot(t *testing.T) {
@@ -177,7 +177,7 @@ func TestRobotDevices(t *testing.T) {
 
 	var body map[string]interface{}
 	_ = json.NewDecoder(response.Body).Decode(&body)
-	assert.Equal(t, 3, len(body["devices"].([]interface{})))
+	assert.Len(t, body["devices"].([]interface{}), 3)
 
 	// unknown robot
 	request, _ = http.NewRequest("GET", "/api/robots/UnknownRobot1/devices", nil)
@@ -283,7 +283,7 @@ func TestRobotDeviceCommands(t *testing.T) {
 
 	var body map[string]interface{}
 	_ = json.NewDecoder(response.Body).Decode(&body)
-	assert.Equal(t, 2, len(body["commands"].([]interface{})))
+	assert.Len(t, body["commands"].([]interface{}), 2)
 
 	// unknown device
 	request, _ = http.NewRequest("GET",
@@ -345,7 +345,7 @@ func TestRobotConnections(t *testing.T) {
 
 	var body map[string]interface{}
 	_ = json.NewDecoder(response.Body).Decode(&body)
-	assert.Equal(t, 3, len(body["connections"].([]interface{})))
+	assert.Len(t, body["connections"].([]interface{}), 3)
 
 	// unknown robot
 	request, _ = http.NewRequest("GET", "/api/robots/UnknownRobot1/connections", nil)

--- a/commander.go
+++ b/commander.go
@@ -8,7 +8,7 @@ type commander struct {
 // which exposes API commands.
 type Commander interface {
 	// Command returns a command given a name. Returns nil if the command is not found.
-	Command(string) (command func(map[string]interface{}) interface{})
+	Command(name string) (command func(map[string]interface{}) interface{})
 	// Commands returns a map of commands.
 	Commands() (commands map[string]func(map[string]interface{}) interface{})
 	// AddCommand adds a command given a name.

--- a/commander_test.go
+++ b/commander_test.go
@@ -14,7 +14,7 @@ func TestCommander(t *testing.T) {
 	})
 
 	// act && assert
-	assert.Equal(t, 1, len(c.Commands()))
+	assert.Len(t, c.Commands(), 1)
 	assert.NotNil(t, c.Command("test"))
 	assert.Nil(t, c.Command("booyeah"))
 }

--- a/drivers/aio/analog_actuator_driver_test.go
+++ b/drivers/aio/analog_actuator_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAnalogActuatorDriver(t *testing.T) {
@@ -15,16 +16,16 @@ func TestAnalogActuatorDriver(t *testing.T) {
 	assert.Equal(t, "47", d.Pin())
 
 	err := d.RawWrite(100)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(a.written))
+	require.NoError(t, err)
+	assert.Len(t, a.written, 1)
 	assert.Equal(t, 100, a.written[0])
 
 	err = d.Write(247.0)
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(a.written))
+	require.NoError(t, err)
+	assert.Len(t, a.written, 2)
 	assert.Equal(t, 247, a.written[1])
 	assert.Equal(t, 247, d.RawValue())
-	assert.Equal(t, 247.0, d.Value())
+	assert.InDelta(t, 247.0, d.Value(), 0.0)
 }
 
 func TestAnalogActuatorDriverWithScaler(t *testing.T) {
@@ -35,12 +36,12 @@ func TestAnalogActuatorDriverWithScaler(t *testing.T) {
 
 	err := d.Command("RawWrite")(map[string]interface{}{"val": "100"})
 	assert.Nil(t, err)
-	assert.Equal(t, 1, len(a.written))
+	assert.Len(t, a.written, 1)
 	assert.Equal(t, 100, a.written[0])
 
 	err = d.Command("Write")(map[string]interface{}{"val": "247.0"})
 	assert.Nil(t, err)
-	assert.Equal(t, 2, len(a.written))
+	assert.Len(t, a.written, 2)
 	assert.Equal(t, 100, a.written[1])
 }
 
@@ -76,8 +77,8 @@ func TestAnalogActuatorDriverLinearScaler(t *testing.T) {
 			// act
 			err := d.Write(tt.input)
 			// assert
-			assert.NoError(t, err)
-			assert.Equal(t, 1, len(a.written))
+			require.NoError(t, err)
+			assert.Len(t, a.written, 1)
 			assert.Equal(t, tt.want, a.written[0])
 		})
 	}
@@ -85,12 +86,12 @@ func TestAnalogActuatorDriverLinearScaler(t *testing.T) {
 
 func TestAnalogActuatorDriverStart(t *testing.T) {
 	d := NewAnalogActuatorDriver(newAioTestAdaptor(), "1")
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestAnalogActuatorDriverHalt(t *testing.T) {
 	d := NewAnalogActuatorDriver(newAioTestAdaptor(), "1")
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestAnalogActuatorDriverDefaultName(t *testing.T) {

--- a/drivers/aio/analog_sensor_driver_test.go
+++ b/drivers/aio/analog_sensor_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -37,7 +38,7 @@ func TestAnalogSensorDriver(t *testing.T) {
 	assert.Nil(t, ret["err"])
 
 	ret = d.Command("Read")(nil).(map[string]interface{})
-	assert.Equal(t, 247.0, ret["val"].(float64))
+	assert.InDelta(t, 247.0, ret["val"].(float64), 0.0)
 	assert.Nil(t, ret["err"])
 
 	// refresh value on read
@@ -47,11 +48,11 @@ func TestAnalogSensorDriver(t *testing.T) {
 		val = 150
 		return
 	}
-	assert.Equal(t, 0.0, d.Value())
+	assert.InDelta(t, 0.0, d.Value(), 0.0)
 	val, err := d.Read()
-	assert.NoError(t, err)
-	assert.Equal(t, 150.0, val)
-	assert.Equal(t, 150.0, d.Value())
+	require.NoError(t, err)
+	assert.InDelta(t, 150.0, val, 0.0)
+	assert.InDelta(t, 150.0, d.Value(), 0.0)
 	assert.Equal(t, 150, d.RawValue())
 }
 
@@ -85,8 +86,8 @@ func TestAnalogSensorDriverWithLinearScaler(t *testing.T) {
 			// act
 			got, err := d.Read()
 			// assert
-			assert.NoError(t, err)
-			assert.Equal(t, tt.want, got)
+			require.NoError(t, err)
+			assert.InDelta(t, tt.want, got, 0.0)
 		})
 	}
 }
@@ -104,7 +105,7 @@ func TestAnalogSensorDriverStart(t *testing.T) {
 	})
 
 	_ = d.Once(d.Event(Value), func(data interface{}) {
-		assert.Equal(t, 10000.0, data.(float64))
+		assert.InDelta(t, 10000.0, data.(float64), 0.0)
 		sem <- true
 	})
 
@@ -114,7 +115,7 @@ func TestAnalogSensorDriverStart(t *testing.T) {
 		return
 	}
 
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 
 	select {
 	case <-sem:
@@ -170,7 +171,7 @@ func TestAnalogSensorDriverHalt(t *testing.T) {
 		<-d.halt
 		close(done)
 	}()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 	select {
 	case <-done:
 	case <-time.After(100 * time.Millisecond):

--- a/drivers/aio/grove_drivers_test.go
+++ b/drivers/aio/grove_drivers_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -89,7 +90,7 @@ func TestDriverPublishesError(t *testing.T) {
 			return
 		}
 
-		assert.NoError(t, driver.Start())
+		require.NoError(t, driver.Start())
 
 		// expect error
 		_ = driver.Once(driver.Event(Error), func(data interface{}) {

--- a/drivers/aio/grove_temperature_sensor_driver_test.go
+++ b/drivers/aio/grove_temperature_sensor_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -47,8 +48,8 @@ func TestGroveTemperatureSensorDriverScaling(t *testing.T) {
 			// act
 			got, err := d.Read()
 			// assert
-			assert.NoError(t, err)
-			assert.Equal(t, tt.want, got)
+			require.NoError(t, err)
+			assert.InDelta(t, tt.want, got, 0.0)
 		})
 	}
 }
@@ -66,7 +67,7 @@ func TestGroveTempSensorPublishesTemperatureInCelsius(t *testing.T) {
 		assert.Equal(t, "31.62", fmt.Sprintf("%.2f", data.(float64)))
 		sem <- true
 	})
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 
 	select {
 	case <-sem:
@@ -74,7 +75,7 @@ func TestGroveTempSensorPublishesTemperatureInCelsius(t *testing.T) {
 		t.Errorf("Grove Temperature Sensor Event \"Data\" was not published")
 	}
 
-	assert.Equal(t, 31.61532462352477, d.Temperature())
+	assert.InDelta(t, 31.61532462352477, d.Temperature(), 0.0)
 }
 
 func TestGroveTempDriverDefaultName(t *testing.T) {

--- a/drivers/aio/temperature_sensor_driver_test.go
+++ b/drivers/aio/temperature_sensor_driver_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTemperatureSensorDriver(t *testing.T) {
@@ -48,8 +49,8 @@ func TestTemperatureSensorDriverNtcScaling(t *testing.T) {
 			// act
 			got, err := d.Read()
 			// assert
-			assert.NoError(t, err)
-			assert.Equal(t, tt.want, got)
+			require.NoError(t, err)
+			assert.InDelta(t, tt.want, got, 0.0)
 		})
 	}
 }
@@ -83,8 +84,8 @@ func TestTemperatureSensorDriverLinearScaling(t *testing.T) {
 			// act
 			got, err := d.Read()
 			// assert
-			assert.NoError(t, err)
-			assert.Equal(t, tt.want, got)
+			require.NoError(t, err)
+			assert.InDelta(t, tt.want, got, 0.0)
 		})
 	}
 }
@@ -104,7 +105,7 @@ func TestTempSensorPublishesTemperatureInCelsius(t *testing.T) {
 		assert.Equal(t, "31.62", fmt.Sprintf("%.2f", data.(float64)))
 		sem <- true
 	})
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 
 	select {
 	case <-sem:
@@ -112,7 +113,7 @@ func TestTempSensorPublishesTemperatureInCelsius(t *testing.T) {
 		t.Errorf(" Temperature Sensor Event \"Data\" was not published")
 	}
 
-	assert.Equal(t, 31.61532462352477, d.Value())
+	assert.InDelta(t, 31.61532462352477, d.Value(), 0.0)
 }
 
 func TestTempSensorPublishesError(t *testing.T) {
@@ -126,7 +127,7 @@ func TestTempSensorPublishesError(t *testing.T) {
 		return
 	}
 
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 
 	// expect error
 	_ = d.Once(d.Event(Error), func(data interface{}) {
@@ -148,7 +149,7 @@ func TestTempSensorHalt(t *testing.T) {
 		<-d.halt
 		close(done)
 	}()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 	select {
 	case <-done:
 	case <-time.After(100 * time.Millisecond):

--- a/drivers/common/mfrc522/mfrc522_pcd_test.go
+++ b/drivers/common/mfrc522/mfrc522_pcd_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type busConnMock struct {
@@ -63,7 +64,7 @@ func TestInitialize(t *testing.T) {
 	// act
 	err := d.Initialize(c)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, c, d.connection)
 	assert.Equal(t, wantSoftReset, c.written[:3])
 	assert.Equal(t, wantInit, c.written[3:21])
@@ -80,7 +81,7 @@ func Test_getVersion(t *testing.T) {
 	// act
 	got, err := d.getVersion()
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, want, got)
 	assert.Equal(t, wantWritten, c.written)
 }
@@ -120,7 +121,7 @@ func Test_switchAntenna(t *testing.T) {
 			// act
 			err := d.switchAntenna(tc.target)
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.wantWritten, c.written)
 		})
 	}
@@ -134,7 +135,7 @@ func Test_stopCrypto1(t *testing.T) {
 	// act
 	err := d.stopCrypto1()
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, wantWritten, c.written)
 }
 
@@ -158,7 +159,7 @@ func Test_communicateWithPICC(t *testing.T) {
 	// transceive, all 8 bits, no CRC
 	err := d.communicateWithPICC(0x0C, dataToFifo, backData, 0x00, false)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, writtenPrepare, c.written[:8])
 	assert.Equal(t, writtenWriteFifo, c.written[8:12])
 	assert.Equal(t, writtenTransceive, c.written[12:16])
@@ -181,7 +182,7 @@ func Test_calculateCRC(t *testing.T) {
 	// act
 	err := d.calculateCRC(dataToFifo, gotCrcBack)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, writtenPrepare, c.written[:6])
 	assert.Equal(t, writtenFifo, c.written[6:10])
 	assert.Equal(t, writtenCalc, c.written[10:15])
@@ -197,7 +198,7 @@ func Test_writeFifo(t *testing.T) {
 	// act
 	err := d.writeFifo(dataToFifo)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, wantWritten, c.written)
 }
 
@@ -210,7 +211,7 @@ func Test_readFifo(t *testing.T) {
 	// act
 	_, err := d.readFifo(backData)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, wantWritten, c.written)
 	assert.Equal(t, c.simFifo, backData)
 }

--- a/drivers/gpio/aip1640_driver_test.go
+++ b/drivers/gpio/aip1640_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -32,12 +33,12 @@ func TestAIP1640Driver(t *testing.T) {
 
 func TestAIP1640DriverStart(t *testing.T) {
 	d := initTestAIP1640Driver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestAIP1640DriverHalt(t *testing.T) {
 	d := initTestAIP1640Driver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestAIP1640DriverDefaultName(t *testing.T) {
@@ -55,39 +56,39 @@ func TestAIP1640DriveDrawPixel(t *testing.T) {
 	d := initTestAIP1640Driver()
 	d.DrawPixel(2, 3, true)
 	d.DrawPixel(0, 3, true)
-	assert.Equal(t, d.buffer[7-3], uint8(5))
+	assert.Equal(t, uint8(5), d.buffer[7-3])
 }
 
 func TestAIP1640DriverDrawRow(t *testing.T) {
 	d := initTestAIP1640Driver()
 	d.DrawRow(4, 0x3C)
-	assert.Equal(t, d.buffer[7-4], uint8(0x3C))
+	assert.Equal(t, uint8(0x3C), d.buffer[7-4])
 }
 
 func TestAIP1640DriverDrawMatrix(t *testing.T) {
 	d := initTestAIP1640Driver()
 	drawing := [8]byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF}
 	d.DrawMatrix(drawing)
-	assert.Equal(t, d.buffer, [8]byte{0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01})
+	assert.Equal(t, [8]byte{0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01}, d.buffer)
 }
 
 func TestAIP1640DriverClear(t *testing.T) {
 	d := initTestAIP1640Driver()
 	drawing := [8]byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF}
 	d.DrawMatrix(drawing)
-	assert.Equal(t, d.buffer, [8]byte{0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01})
+	assert.Equal(t, [8]byte{0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01}, d.buffer)
 	d.Clear()
-	assert.Equal(t, d.buffer, [8]byte{})
+	assert.Equal(t, [8]byte{}, d.buffer)
 }
 
 func TestAIP1640DriverSetIntensity(t *testing.T) {
 	d := initTestAIP1640Driver()
 	d.SetIntensity(3)
-	assert.Equal(t, d.intensity, uint8(3))
+	assert.Equal(t, uint8(3), d.intensity)
 }
 
 func TestAIP1640DriverSetIntensityHigherThan7(t *testing.T) {
 	d := initTestAIP1640Driver()
 	d.SetIntensity(19)
-	assert.Equal(t, d.intensity, uint8(7))
+	assert.Equal(t, uint8(7), d.intensity)
 }

--- a/drivers/gpio/button_driver_test.go
+++ b/drivers/gpio/button_driver_test.go
@@ -37,7 +37,7 @@ func TestNewButtonDriver(t *testing.T) {
 	assert.NotNil(t, d.mutex)
 	assert.NotNil(t, d.Eventer)
 	assert.Equal(t, "1", d.pin)
-	assert.Equal(t, false, d.active)
+	assert.False(t, d.active)
 	assert.Equal(t, 0, d.defaultState)
 	assert.Equal(t, 10*time.Millisecond, d.interval)
 	assert.NotNil(t, d.halt)
@@ -76,7 +76,7 @@ func TestButtonStart(t *testing.T) {
 	err := d.Start()
 
 	// assert & rearrange
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	select {
 	case <-sem:
@@ -146,7 +146,7 @@ func TestButtonSetDefaultState(t *testing.T) {
 
 	// assert & rearrange
 	require.Equal(t, 1, d.defaultState)
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 
 	select {
 	case <-sem:
@@ -182,7 +182,7 @@ func TestButtonHalt(t *testing.T) {
 		}
 	}()
 	// act & assert
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 	wg.Wait() // wait until the go function was really finished
 }
 

--- a/drivers/gpio/buzzer_driver_test.go
+++ b/drivers/gpio/buzzer_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -28,12 +29,12 @@ func TestBuzzerDriverSetName(t *testing.T) {
 
 func TestBuzzerDriverStart(t *testing.T) {
 	d := initTestBuzzerDriver(newGpioTestAdaptor())
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestBuzzerDriverHalt(t *testing.T) {
 	d := initTestBuzzerDriver(newGpioTestAdaptor())
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestBuzzerDriverToggle(t *testing.T) {
@@ -47,7 +48,7 @@ func TestBuzzerDriverToggle(t *testing.T) {
 
 func TestBuzzerDriverTone(t *testing.T) {
 	d := initTestBuzzerDriver(newGpioTestAdaptor())
-	assert.NoError(t, d.Tone(100, 0.01))
+	require.NoError(t, d.Tone(100, 0.01))
 }
 
 func TestBuzzerDriverOnError(t *testing.T) {
@@ -57,7 +58,7 @@ func TestBuzzerDriverOnError(t *testing.T) {
 		return errors.New("write error")
 	}
 
-	assert.ErrorContains(t, d.On(), "write error")
+	require.ErrorContains(t, d.On(), "write error")
 }
 
 func TestBuzzerDriverOffError(t *testing.T) {
@@ -67,7 +68,7 @@ func TestBuzzerDriverOffError(t *testing.T) {
 		return errors.New("write error")
 	}
 
-	assert.ErrorContains(t, d.Off(), "write error")
+	require.ErrorContains(t, d.Off(), "write error")
 }
 
 func TestBuzzerDriverToneError(t *testing.T) {
@@ -77,5 +78,5 @@ func TestBuzzerDriverToneError(t *testing.T) {
 		return errors.New("write error")
 	}
 
-	assert.ErrorContains(t, d.Tone(100, 0.01), "write error")
+	require.ErrorContains(t, d.Tone(100, 0.01), "write error")
 }

--- a/drivers/gpio/direct_pin_driver_test.go
+++ b/drivers/gpio/direct_pin_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -43,120 +44,120 @@ func TestDirectPinDriver(t *testing.T) {
 	assert.Nil(t, ret["err"])
 
 	err = d.Command("DigitalWrite")(map[string]interface{}{"level": "1"})
-	assert.ErrorContains(t, err.(error), "write error")
+	require.ErrorContains(t, err.(error), "write error")
 
 	err = d.Command("PwmWrite")(map[string]interface{}{"level": "1"})
-	assert.ErrorContains(t, err.(error), "write error")
+	require.ErrorContains(t, err.(error), "write error")
 
 	err = d.Command("ServoWrite")(map[string]interface{}{"level": "1"})
-	assert.ErrorContains(t, err.(error), "write error")
+	require.ErrorContains(t, err.(error), "write error")
 }
 
 func TestDirectPinDriverStart(t *testing.T) {
 	d := initTestDirectPinDriver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestDirectPinDriverHalt(t *testing.T) {
 	d := initTestDirectPinDriver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestDirectPinDriverOff(t *testing.T) {
 	d := initTestDirectPinDriver()
-	assert.NotNil(t, d.Off())
+	require.Error(t, d.Off())
 
 	a := newGpioTestAdaptor()
 	d = NewDirectPinDriver(a, "1")
-	assert.NoError(t, d.Off())
+	require.NoError(t, d.Off())
 }
 
 func TestDirectPinDriverOffNotSupported(t *testing.T) {
 	a := &gpioTestBareAdaptor{}
 	d := NewDirectPinDriver(a, "1")
-	assert.ErrorContains(t, d.Off(), "DigitalWrite is not supported by this platform")
+	require.ErrorContains(t, d.Off(), "DigitalWrite is not supported by this platform")
 }
 
 func TestDirectPinDriverOn(t *testing.T) {
 	a := newGpioTestAdaptor()
 	d := NewDirectPinDriver(a, "1")
-	assert.NoError(t, d.On())
+	require.NoError(t, d.On())
 }
 
 func TestDirectPinDriverOnError(t *testing.T) {
 	d := initTestDirectPinDriver()
-	assert.NotNil(t, d.On())
+	require.Error(t, d.On())
 }
 
 func TestDirectPinDriverOnNotSupported(t *testing.T) {
 	a := &gpioTestBareAdaptor{}
 	d := NewDirectPinDriver(a, "1")
-	assert.ErrorContains(t, d.On(), "DigitalWrite is not supported by this platform")
+	require.ErrorContains(t, d.On(), "DigitalWrite is not supported by this platform")
 }
 
 func TestDirectPinDriverDigitalWrite(t *testing.T) {
 	adaptor := newGpioTestAdaptor()
 	d := NewDirectPinDriver(adaptor, "1")
-	assert.NoError(t, d.DigitalWrite(1))
+	require.NoError(t, d.DigitalWrite(1))
 }
 
 func TestDirectPinDriverDigitalWriteNotSupported(t *testing.T) {
 	a := &gpioTestBareAdaptor{}
 	d := NewDirectPinDriver(a, "1")
-	assert.ErrorContains(t, d.DigitalWrite(1), "DigitalWrite is not supported by this platform")
+	require.ErrorContains(t, d.DigitalWrite(1), "DigitalWrite is not supported by this platform")
 }
 
 func TestDirectPinDriverDigitalWriteError(t *testing.T) {
 	d := initTestDirectPinDriver()
-	assert.NotNil(t, d.DigitalWrite(1))
+	require.Error(t, d.DigitalWrite(1))
 }
 
 func TestDirectPinDriverDigitalRead(t *testing.T) {
 	d := initTestDirectPinDriver()
 	ret, err := d.DigitalRead()
 	assert.Equal(t, 1, ret)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDirectPinDriverDigitalReadNotSupported(t *testing.T) {
 	a := &gpioTestBareAdaptor{}
 	d := NewDirectPinDriver(a, "1")
 	_, e := d.DigitalRead()
-	assert.ErrorContains(t, e, "DigitalRead is not supported by this platform")
+	require.ErrorContains(t, e, "DigitalRead is not supported by this platform")
 }
 
 func TestDirectPinDriverPwmWrite(t *testing.T) {
 	a := newGpioTestAdaptor()
 	d := NewDirectPinDriver(a, "1")
-	assert.NoError(t, d.PwmWrite(1))
+	require.NoError(t, d.PwmWrite(1))
 }
 
 func TestDirectPinDriverPwmWriteNotSupported(t *testing.T) {
 	a := &gpioTestBareAdaptor{}
 	d := NewDirectPinDriver(a, "1")
-	assert.ErrorContains(t, d.PwmWrite(1), "PwmWrite is not supported by this platform")
+	require.ErrorContains(t, d.PwmWrite(1), "PwmWrite is not supported by this platform")
 }
 
 func TestDirectPinDriverPwmWriteError(t *testing.T) {
 	d := initTestDirectPinDriver()
-	assert.NotNil(t, d.PwmWrite(1))
+	require.Error(t, d.PwmWrite(1))
 }
 
 func TestDirectPinDriverServoWrite(t *testing.T) {
 	a := newGpioTestAdaptor()
 	d := NewDirectPinDriver(a, "1")
-	assert.NoError(t, d.ServoWrite(1))
+	require.NoError(t, d.ServoWrite(1))
 }
 
 func TestDirectPinDriverServoWriteNotSupported(t *testing.T) {
 	a := &gpioTestBareAdaptor{}
 	d := NewDirectPinDriver(a, "1")
-	assert.ErrorContains(t, d.ServoWrite(1), "ServoWrite is not supported by this platform")
+	require.ErrorContains(t, d.ServoWrite(1), "ServoWrite is not supported by this platform")
 }
 
 func TestDirectPinDriverServoWriteError(t *testing.T) {
 	d := initTestDirectPinDriver()
-	assert.NotNil(t, d.ServoWrite(1))
+	require.Error(t, d.ServoWrite(1))
 }
 
 func TestDirectPinDriverDefaultName(t *testing.T) {

--- a/drivers/gpio/easy_driver_test.go
+++ b/drivers/gpio/easy_driver_test.go
@@ -29,20 +29,20 @@ func TestNewEasyDriver(t *testing.T) {
 	assert.IsType(t, &EasyDriver{}, d)
 	assert.True(t, strings.HasPrefix(d.name, "EasyDriver"))
 	assert.Equal(t, a, d.connection)
-	assert.NoError(t, d.afterStart())
-	assert.NoError(t, d.beforeHalt())
+	require.NoError(t, d.afterStart())
+	require.NoError(t, d.beforeHalt())
 	assert.NotNil(t, d.Commander)
 	assert.NotNil(t, d.mutex)
 	assert.Equal(t, "1", d.stepPin)
 	assert.Equal(t, "2", d.dirPin)
 	assert.Equal(t, "3", d.enPin)
 	assert.Equal(t, "4", d.sleepPin)
-	assert.Equal(t, float32(anglePerStep), d.anglePerStep)
+	assert.InDelta(t, float32(anglePerStep), d.anglePerStep, 0.0)
 	assert.Equal(t, uint(14), d.speedRpm)
 	assert.Equal(t, "forward", d.direction)
 	assert.Equal(t, 0, d.stepNum)
-	assert.Equal(t, false, d.disabled)
-	assert.Equal(t, false, d.sleeping)
+	assert.False(t, d.disabled)
+	assert.False(t, d.sleeping)
 	assert.Nil(t, d.stopAsynchRunFunc)
 }
 
@@ -95,7 +95,7 @@ func TestEasyDriverMoveDeg_IsMoving(t *testing.T) {
 				// for cleanup dangling channels
 				if d.stopAsynchRunFunc != nil {
 					err := d.stopAsynchRunFunc(true)
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				}
 			}()
 			// arrange: different behavior
@@ -110,12 +110,12 @@ func TestEasyDriverMoveDeg_IsMoving(t *testing.T) {
 			err := d.MoveDeg(tc.inputDeg)
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tc.wantSteps, d.stepNum)
-			assert.Equal(t, tc.wantWrites, len(a.written))
+			assert.Len(t, a.written, tc.wantWrites)
 			assert.Equal(t, tc.wantMoving, d.IsMoving())
 		})
 	}
@@ -168,9 +168,9 @@ func TestEasyDriverRun_IsMoving(t *testing.T) {
 			err := d.Run()
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tc.wantMoving, d.IsMoving())
 		})
@@ -185,7 +185,7 @@ func TestEasyDriverStop_IsMoving(t *testing.T) {
 	// act
 	err := d.Stop()
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, d.IsMoving())
 }
 
@@ -197,7 +197,7 @@ func TestEasyDriverHalt_IsMoving(t *testing.T) {
 	// act
 	err := d.Halt()
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, d.IsMoving())
 }
 
@@ -259,9 +259,9 @@ func TestEasyDriverSetDirection(t *testing.T) {
 			err := d.SetDirection(tc.input)
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tc.dirPin, a.written[0].pin)
 				assert.Equal(t, tc.wantWritten, a.written[0].val)
 			}
@@ -356,9 +356,9 @@ func TestEasyDriverSetSpeed(t *testing.T) {
 			err := d.SetSpeed(tc.input)
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tc.want, d.speedRpm)
 		})
@@ -515,11 +515,11 @@ func TestEasyDriverEnable_IsEnabled(t *testing.T) {
 			// act
 			err := d.Enable()
 			// assert
-			assert.Equal(t, tc.wantWrites, len(a.written))
+			assert.Len(t, a.written, tc.wantWrites)
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tc.enPin, a.written[0].pin)
 				assert.Equal(t, byte(0), a.written[0].val) // enable pin is active low
 			}
@@ -596,9 +596,9 @@ func TestEasyDriverDisable_IsEnabled(t *testing.T) {
 			err := d.Disable()
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, byte(1), writtenValue) // enable pin is active low
 			}
 			assert.Equal(t, tc.wantEnabled, d.IsEnabled())
@@ -676,9 +676,9 @@ func TestEasyDriverSleep_IsSleeping(t *testing.T) {
 			err := d.Sleep()
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, byte(0), writtenValue) // sleep pin is active low
 			}
 			assert.Equal(t, tc.wantSleep, d.IsSleeping())
@@ -745,9 +745,9 @@ func TestEasyDriverWake_IsSleeping(t *testing.T) {
 			err := d.Wake()
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, byte(1), writtenValue) // sleep pin is active low
 			}
 			assert.Equal(t, tc.wantSleep, d.IsSleeping())

--- a/drivers/gpio/gpio_driver.go
+++ b/drivers/gpio/gpio_driver.go
@@ -47,22 +47,22 @@ const (
 
 // PwmWriter interface represents an Adaptor which has Pwm capabilities
 type PwmWriter interface {
-	PwmWrite(string, byte) (err error)
+	PwmWrite(pin string, val byte) (err error)
 }
 
 // ServoWriter interface represents an Adaptor which has Servo capabilities
 type ServoWriter interface {
-	ServoWrite(string, byte) (err error)
+	ServoWrite(pin string, val byte) (err error)
 }
 
 // DigitalWriter interface represents an Adaptor which has DigitalWrite capabilities
 type DigitalWriter interface {
-	DigitalWrite(string, byte) (err error)
+	DigitalWrite(pin string, val byte) (err error)
 }
 
 // DigitalReader interface represents an Adaptor which has DigitalRead capabilities
 type DigitalReader interface {
-	DigitalRead(string) (val int, err error)
+	DigitalRead(pin string) (val int, err error)
 }
 
 // Driver implements the interface gobot.Driver.

--- a/drivers/gpio/gpio_driver_test.go
+++ b/drivers/gpio/gpio_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -30,8 +31,8 @@ func TestNewDriver(t *testing.T) {
 	assert.IsType(t, &Driver{}, d)
 	assert.Contains(t, d.name, "GPIO_BASIC")
 	assert.Equal(t, a, d.connection)
-	assert.NoError(t, d.afterStart())
-	assert.NoError(t, d.beforeHalt())
+	require.NoError(t, d.afterStart())
+	require.NoError(t, d.beforeHalt())
 	assert.NotNil(t, d.Commander)
 	assert.NotNil(t, d.mutex)
 }
@@ -56,20 +57,20 @@ func TestStart(t *testing.T) {
 	// arrange
 	d := initTestDriver()
 	// act, assert
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 	// arrange after start function
 	d.afterStart = func() error { return fmt.Errorf("after start error") }
 	// act, assert
-	assert.ErrorContains(t, d.Start(), "after start error")
+	require.ErrorContains(t, d.Start(), "after start error")
 }
 
 func TestHalt(t *testing.T) {
 	// arrange
 	d := initTestDriver()
 	// act, assert
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 	// arrange after start function
 	d.beforeHalt = func() error { return fmt.Errorf("before halt error") }
 	// act, assert
-	assert.ErrorContains(t, d.Halt(), "before halt error")
+	require.ErrorContains(t, d.Halt(), "before halt error")
 }

--- a/drivers/gpio/grove_drivers_test.go
+++ b/drivers/gpio/grove_drivers_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -91,7 +92,7 @@ func TestDriverPublishesError(t *testing.T) {
 		}
 		testAdaptor.digitalReadFunc = returnErr
 
-		assert.NoError(t, driver.Start())
+		require.NoError(t, driver.Start())
 
 		// expect error
 		_ = driver.Once(driver.Event(Error), func(data interface{}) {

--- a/drivers/gpio/hcsr04_driver_test.go
+++ b/drivers/gpio/hcsr04_driver_test.go
@@ -39,13 +39,13 @@ func TestNewHCSR04Driver(t *testing.T) {
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.name, "HCSR04"))
 	assert.Equal(t, a, d.connection)
-	assert.NoError(t, d.afterStart())
-	assert.NoError(t, d.beforeHalt())
+	require.NoError(t, d.afterStart())
+	require.NoError(t, d.beforeHalt())
 	assert.NotNil(t, d.Commander)
 	assert.NotNil(t, d.mutex)
 	assert.Equal(t, triggerPinID, d.triggerPinID)
 	assert.Equal(t, echoPinID, d.echoPinID)
-	assert.Equal(t, false, d.useEdgePolling)
+	assert.False(t, d.useEdgePolling)
 	assert.Equal(t, tpin, d.triggerPin)
 	assert.Equal(t, epin, d.echoPin)
 }
@@ -115,11 +115,11 @@ func TestHCSR04MeasureDistance(t *testing.T) {
 			// assert
 			assert.Equal(t, tc.wantCallsWrite, numCallsWrite)
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
 				require.NoError(t, err)
 			}
-			assert.Equal(t, tc.wantVal, got)
+			assert.InDelta(t, tc.wantVal, got, 0.0)
 		})
 	}
 }
@@ -151,7 +151,7 @@ func TestHCSR04Distance(t *testing.T) {
 			// act
 			got := d.Distance()
 			// assert
-			assert.Equal(t, tc.wantVal, got)
+			assert.InDelta(t, tc.wantVal, got, 0.0)
 		})
 	}
 }
@@ -197,7 +197,7 @@ func TestHCSR04StartDistanceMonitor(t *testing.T) {
 			time.Sleep(1 * time.Millisecond) // < 160 ms
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
 				require.NoError(t, err)
 				assert.NotNil(t, d.distanceMonitorStopChan)
@@ -240,7 +240,7 @@ func TestHCSR04StopDistanceMonitor(t *testing.T) {
 			time.Sleep(1 * time.Millisecond) // < 160 ms
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
 				require.NoError(t, err)
 				assert.Nil(t, d.distanceMonitorStopChan)

--- a/drivers/gpio/hd44780_driver_test.go
+++ b/drivers/gpio/hd44780_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"gobot.io/x/gobot/v2"
 )
@@ -61,7 +62,7 @@ func TestHD44780Driver(t *testing.T) {
 
 func TestHD44780DriverHalt(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestHD44780DriverDefaultName(t *testing.T) {
@@ -77,7 +78,7 @@ func TestHD44780DriverSetName(t *testing.T) {
 
 func TestHD44780DriverStart(t *testing.T) {
 	d, _ := initTestHD44780Driver4BitModeWithStubbedAdaptor()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestHD44780DriverStartError(t *testing.T) {
@@ -93,7 +94,7 @@ func TestHD44780DriverStartError(t *testing.T) {
 		D7: "",
 	}
 	d = NewHD44780Driver(a, 2, 16, HD44780_4BITMODE, "13", "15", pins)
-	assert.ErrorContains(t, d.Start(), "Initialization error")
+	require.ErrorContains(t, d.Start(), "Initialization error")
 
 	pins = HD44780DataPin{
 		D0: "31",
@@ -106,7 +107,7 @@ func TestHD44780DriverStartError(t *testing.T) {
 		D7: "",
 	}
 	d = NewHD44780Driver(a, 2, 16, HD44780_8BITMODE, "13", "15", pins)
-	assert.ErrorContains(t, d.Start(), "Initialization error")
+	require.ErrorContains(t, d.Start(), "Initialization error")
 }
 
 func TestHD44780DriverWrite(t *testing.T) {
@@ -114,11 +115,11 @@ func TestHD44780DriverWrite(t *testing.T) {
 
 	d, _ = initTestHD44780Driver4BitModeWithStubbedAdaptor()
 	_ = d.Start()
-	assert.NoError(t, d.Write("hello gobot"))
+	require.NoError(t, d.Write("hello gobot"))
 
 	d, _ = initTestHD44780Driver8BitModeWithStubbedAdaptor()
 	_ = d.Start()
-	assert.NoError(t, d.Write("hello gobot"))
+	require.NoError(t, d.Write("hello gobot"))
 }
 
 func TestHD44780DriverWriteError(t *testing.T) {
@@ -130,108 +131,108 @@ func TestHD44780DriverWriteError(t *testing.T) {
 		return errors.New("write error")
 	}
 	_ = d.Start()
-	assert.ErrorContains(t, d.Write("hello gobot"), "write error")
+	require.ErrorContains(t, d.Write("hello gobot"), "write error")
 
 	d, a = initTestHD44780Driver8BitModeWithStubbedAdaptor()
 	a.digitalWriteFunc = func(string, byte) (err error) {
 		return errors.New("write error")
 	}
 	_ = d.Start()
-	assert.ErrorContains(t, d.Write("hello gobot"), "write error")
+	require.ErrorContains(t, d.Write("hello gobot"), "write error")
 }
 
 func TestHD44780DriverClear(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.NoError(t, d.Clear())
+	require.NoError(t, d.Clear())
 }
 
 func TestHD44780DriverHome(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.NoError(t, d.Home())
+	require.NoError(t, d.Home())
 }
 
 func TestHD44780DriverSetCursor(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.NoError(t, d.SetCursor(0, 3))
+	require.NoError(t, d.SetCursor(0, 3))
 }
 
 func TestHD44780DriverSetCursorInvalid(t *testing.T) {
 	d := initTestHD44780Driver()
 
-	assert.ErrorContains(t, d.SetCursor(-1, 3), "Invalid position value (-1, 3), range (1, 15)")
-	assert.ErrorContains(t, d.SetCursor(2, 3), "Invalid position value (2, 3), range (1, 15)")
-	assert.ErrorContains(t, d.SetCursor(0, -1), "Invalid position value (0, -1), range (1, 15)")
-	assert.ErrorContains(t, d.SetCursor(0, 16), "Invalid position value (0, 16), range (1, 15)")
+	require.ErrorContains(t, d.SetCursor(-1, 3), "Invalid position value (-1, 3), range (1, 15)")
+	require.ErrorContains(t, d.SetCursor(2, 3), "Invalid position value (2, 3), range (1, 15)")
+	require.ErrorContains(t, d.SetCursor(0, -1), "Invalid position value (0, -1), range (1, 15)")
+	require.ErrorContains(t, d.SetCursor(0, 16), "Invalid position value (0, 16), range (1, 15)")
 }
 
 func TestHD44780DriverDisplayOn(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.NoError(t, d.Display(true))
+	require.NoError(t, d.Display(true))
 }
 
 func TestHD44780DriverDisplayOff(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.NoError(t, d.Display(false))
+	require.NoError(t, d.Display(false))
 }
 
 func TestHD44780DriverCursorOn(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.NoError(t, d.Cursor(true))
+	require.NoError(t, d.Cursor(true))
 }
 
 func TestHD44780DriverCursorOff(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.NoError(t, d.Cursor(false))
+	require.NoError(t, d.Cursor(false))
 }
 
 func TestHD44780DriverBlinkOn(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.NoError(t, d.Blink(true))
+	require.NoError(t, d.Blink(true))
 }
 
 func TestHD44780DriverBlinkOff(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.NoError(t, d.Blink(false))
+	require.NoError(t, d.Blink(false))
 }
 
 func TestHD44780DriverScrollLeft(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.NoError(t, d.ScrollLeft())
+	require.NoError(t, d.ScrollLeft())
 }
 
 func TestHD44780DriverScrollRight(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.NoError(t, d.ScrollRight())
+	require.NoError(t, d.ScrollRight())
 }
 
 func TestHD44780DriverLeftToRight(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.NoError(t, d.LeftToRight())
+	require.NoError(t, d.LeftToRight())
 }
 
 func TestHD44780DriverRightToLeft(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.NoError(t, d.RightToLeft())
+	require.NoError(t, d.RightToLeft())
 }
 
 func TestHD44780DriverSendCommand(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.NoError(t, d.SendCommand(0x33))
+	require.NoError(t, d.SendCommand(0x33))
 }
 
 func TestHD44780DriverWriteChar(t *testing.T) {
 	d := initTestHD44780Driver()
-	assert.NoError(t, d.WriteChar(0x41))
+	require.NoError(t, d.WriteChar(0x41))
 }
 
 func TestHD44780DriverCreateChar(t *testing.T) {
 	d := initTestHD44780Driver()
 	charMap := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
-	assert.NoError(t, d.CreateChar(0, charMap))
+	require.NoError(t, d.CreateChar(0, charMap))
 }
 
 func TestHD44780DriverCreateCharError(t *testing.T) {
 	d := initTestHD44780Driver()
 	charMap := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
-	assert.ErrorContains(t, d.CreateChar(8, charMap), "can't set a custom character at a position greater than 7")
+	require.ErrorContains(t, d.CreateChar(8, charMap), "can't set a custom character at a position greater than 7")
 }

--- a/drivers/gpio/led_driver_test.go
+++ b/drivers/gpio/led_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -38,26 +39,26 @@ func TestLedDriver(t *testing.T) {
 	}
 
 	err = d.Command("Toggle")(nil)
-	assert.ErrorContains(t, err.(error), "write error")
+	require.ErrorContains(t, err.(error), "write error")
 
 	err = d.Command("On")(nil)
-	assert.ErrorContains(t, err.(error), "write error")
+	require.ErrorContains(t, err.(error), "write error")
 
 	err = d.Command("Off")(nil)
-	assert.ErrorContains(t, err.(error), "write error")
+	require.ErrorContains(t, err.(error), "write error")
 
 	err = d.Command("Brightness")(map[string]interface{}{"level": 100.0})
-	assert.ErrorContains(t, err.(error), "pwm error")
+	require.ErrorContains(t, err.(error), "pwm error")
 }
 
 func TestLedDriverStart(t *testing.T) {
 	d := initTestLedDriver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestLedDriverHalt(t *testing.T) {
 	d := initTestLedDriver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestLedDriverToggle(t *testing.T) {
@@ -76,7 +77,7 @@ func TestLedDriverBrightness(t *testing.T) {
 		err = errors.New("pwm error")
 		return
 	}
-	assert.ErrorContains(t, d.Brightness(150), "pwm error")
+	require.ErrorContains(t, d.Brightness(150), "pwm error")
 }
 
 func TestLEDDriverDefaultName(t *testing.T) {

--- a/drivers/gpio/max7219_driver_test.go
+++ b/drivers/gpio/max7219_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -32,12 +33,12 @@ func TestMAX7219Driver(t *testing.T) {
 
 func TestMAX7219DriverStart(t *testing.T) {
 	d := initTestMAX7219Driver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestMAX7219DriverHalt(t *testing.T) {
 	d := initTestMAX7219Driver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestMAX7219DriverDefaultName(t *testing.T) {

--- a/drivers/gpio/motor_driver_test.go
+++ b/drivers/gpio/motor_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -21,12 +22,12 @@ func TestMotorDriver(t *testing.T) {
 
 func TestMotorDriverStart(t *testing.T) {
 	d := initTestMotorDriver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestMotorDriverHalt(t *testing.T) {
 	d := initTestMotorDriver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestMotorDriverIsOn(t *testing.T) {

--- a/drivers/gpio/pir_motion_driver_test.go
+++ b/drivers/gpio/pir_motion_driver_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -36,7 +37,7 @@ func TestNewPIRMotionDriver(t *testing.T) {
 	assert.NotNil(t, d.mutex)
 	assert.NotNil(t, d.Eventer)
 	assert.Equal(t, "1", d.pin)
-	assert.Equal(t, false, d.active)
+	assert.False(t, d.active)
 	assert.Equal(t, 10*time.Millisecond, d.interval)
 	assert.NotNil(t, d.halt)
 	// act & assert other interval
@@ -75,7 +76,7 @@ func TestPIRMotionStart(t *testing.T) {
 	err := d.Start()
 
 	// assert & rearrange
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	select {
 	case <-sem:
@@ -134,7 +135,7 @@ func TestPIRMotionHalt(t *testing.T) {
 		}
 	}()
 	// act & assert
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 	wg.Wait() // wait until the go function was really finished
 }
 

--- a/drivers/gpio/relay_driver_test.go
+++ b/drivers/gpio/relay_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -38,12 +39,12 @@ func TestRelayDriverSetName(t *testing.T) {
 
 func TestRelayDriverStart(t *testing.T) {
 	d, _ := initTestRelayDriver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestRelayDriverHalt(t *testing.T) {
 	d, _ := initTestRelayDriver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestRelayDriverToggle(t *testing.T) {

--- a/drivers/gpio/rgb_led_driver_test.go
+++ b/drivers/gpio/rgb_led_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -42,26 +43,26 @@ func TestRgbLedDriver(t *testing.T) {
 	}
 
 	err = d.Command("Toggle")(nil)
-	assert.ErrorContains(t, err.(error), "pwm error")
+	require.ErrorContains(t, err.(error), "pwm error")
 
 	err = d.Command("On")(nil)
-	assert.ErrorContains(t, err.(error), "pwm error")
+	require.ErrorContains(t, err.(error), "pwm error")
 
 	err = d.Command("Off")(nil)
-	assert.ErrorContains(t, err.(error), "pwm error")
+	require.ErrorContains(t, err.(error), "pwm error")
 
 	err = d.Command("SetRGB")(map[string]interface{}{"r": 0xff, "g": 0xff, "b": 0xff})
-	assert.ErrorContains(t, err.(error), "pwm error")
+	require.ErrorContains(t, err.(error), "pwm error")
 }
 
 func TestRgbLedDriverStart(t *testing.T) {
 	d := initTestRgbLedDriver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestRgbLedDriverHalt(t *testing.T) {
 	d := initTestRgbLedDriver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestRgbLedDriverToggle(t *testing.T) {
@@ -76,14 +77,14 @@ func TestRgbLedDriverToggle(t *testing.T) {
 func TestRgbLedDriverSetLevel(t *testing.T) {
 	a := newGpioTestAdaptor()
 	d := NewRgbLedDriver(a, "1", "2", "3")
-	assert.NoError(t, d.SetLevel("1", 150))
+	require.NoError(t, d.SetLevel("1", 150))
 
 	d = NewRgbLedDriver(a, "1", "2", "3")
 	a.pwmWriteFunc = func(string, byte) (err error) {
 		err = errors.New("pwm error")
 		return
 	}
-	assert.ErrorContains(t, d.SetLevel("1", 150), "pwm error")
+	require.ErrorContains(t, d.SetLevel("1", 150), "pwm error")
 }
 
 func TestRgbLedDriverDefaultName(t *testing.T) {

--- a/drivers/gpio/servo_driver_test.go
+++ b/drivers/gpio/servo_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -29,26 +30,26 @@ func TestServoDriver(t *testing.T) {
 	}
 
 	err = d.Command("Min")(nil)
-	assert.ErrorContains(t, err.(error), "pwm error")
+	require.ErrorContains(t, err.(error), "pwm error")
 
 	err = d.Command("Center")(nil)
-	assert.ErrorContains(t, err.(error), "pwm error")
+	require.ErrorContains(t, err.(error), "pwm error")
 
 	err = d.Command("Max")(nil)
-	assert.ErrorContains(t, err.(error), "pwm error")
+	require.ErrorContains(t, err.(error), "pwm error")
 
 	err = d.Command("Move")(map[string]interface{}{"angle": 100.0})
-	assert.ErrorContains(t, err.(error), "pwm error")
+	require.ErrorContains(t, err.(error), "pwm error")
 }
 
 func TestServoDriverStart(t *testing.T) {
 	d := initTestServoDriver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestServoDriverHalt(t *testing.T) {
 	d := initTestServoDriver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestServoDriverMove(t *testing.T) {

--- a/drivers/gpio/stepper_driver_test.go
+++ b/drivers/gpio/stepper_driver_test.go
@@ -30,13 +30,13 @@ func TestNewStepperDriver(t *testing.T) {
 	assert.IsType(t, &StepperDriver{}, d)
 	assert.True(t, strings.HasPrefix(d.name, "Stepper"))
 	assert.Equal(t, a, d.connection)
-	assert.NoError(t, d.afterStart())
-	assert.NoError(t, d.beforeHalt())
+	require.NoError(t, d.afterStart())
+	require.NoError(t, d.beforeHalt())
 	assert.NotNil(t, d.Commander)
 	assert.NotNil(t, d.mutex)
 	assert.Equal(t, "forward", d.direction)
 	assert.Equal(t, StepperModes.DualPhaseStepping, d.phase)
-	assert.Equal(t, float32(stepsPerRev), d.stepsPerRev)
+	assert.InDelta(t, float32(stepsPerRev), d.stepsPerRev, 0.0)
 	assert.Equal(t, 0, d.stepNum)
 	assert.Nil(t, d.stopAsynchRunFunc)
 }
@@ -126,7 +126,7 @@ func TestStepperMove_IsMoving(t *testing.T) {
 				// for cleanup dangling channels
 				if d.stopAsynchRunFunc != nil {
 					err := d.stopAsynchRunFunc(true)
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				}
 			}()
 			// arrange: different behavior
@@ -141,12 +141,12 @@ func TestStepperMove_IsMoving(t *testing.T) {
 			err := d.Move(tc.inputSteps)
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tc.wantSteps, d.stepNum)
-			assert.Equal(t, tc.wantWrites, len(a.written))
+			assert.Len(t, a.written, tc.wantWrites)
 			assert.Equal(t, tc.wantMoving, d.IsMoving())
 		})
 	}
@@ -182,7 +182,7 @@ func TestStepperRun_IsMoving(t *testing.T) {
 				// for cleanup dangling channels
 				if d.stopAsynchRunFunc != nil {
 					err := d.stopAsynchRunFunc(true)
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				}
 			}()
 			// arrange: different behavior
@@ -216,9 +216,9 @@ func TestStepperRun_IsMoving(t *testing.T) {
 			err := d.Run()
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tc.wantMoving, d.IsMoving())
 			if writeChan != nil {
@@ -231,9 +231,9 @@ func TestStepperRun_IsMoving(t *testing.T) {
 					d.stopAsynchRunFunc = nil
 				}
 				if tc.simulateWriteErr {
-					assert.Error(t, asynchErr)
+					require.Error(t, asynchErr)
 				} else {
-					assert.NoError(t, asynchErr)
+					require.NoError(t, asynchErr)
 				}
 			}
 		})
@@ -265,9 +265,9 @@ func TestStepperStop_IsMoving(t *testing.T) {
 			err := d.Stop()
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.False(t, d.IsMoving())
 		})
@@ -296,7 +296,7 @@ func TestStepperHalt_IsMoving(t *testing.T) {
 			// act
 			err := d.Halt()
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.False(t, d.IsMoving())
 		})
 	}
@@ -331,9 +331,9 @@ func TestStepperSetDirection(t *testing.T) {
 			err := d.SetDirection(tc.input)
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tc.wantVal, d.direction)
 		})
@@ -419,9 +419,9 @@ func TestStepperSetSpeed(t *testing.T) {
 			err := d.SetSpeed(tc.input)
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tc.want, d.speedRpm)
 		})

--- a/drivers/gpio/tm1638_driver_test.go
+++ b/drivers/gpio/tm1638_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -32,12 +33,12 @@ func TestTM1638Driver(t *testing.T) {
 
 func TestTM1638DriverStart(t *testing.T) {
 	d := initTestTM1638Driver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestTM1638DriverHalt(t *testing.T) {
 	d := initTestTM1638Driver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestTM1638DriverDefaultName(t *testing.T) {
@@ -54,19 +55,19 @@ func TestTM1638DriverSetName(t *testing.T) {
 func TestTM1638DriverFromStringToByteArray(t *testing.T) {
 	d := initTestTM1638Driver()
 	data := d.fromStringToByteArray("Hello World")
-	assert.Equal(t, data, []byte{0x76, 0x7B, 0x30, 0x30, 0x5C, 0x00, 0x1D, 0x5C, 0x50, 0x30, 0x5E})
+	assert.Equal(t, []byte{0x76, 0x7B, 0x30, 0x30, 0x5C, 0x00, 0x1D, 0x5C, 0x50, 0x30, 0x5E}, data)
 }
 
 func TestTM1638DriverAddFonts(t *testing.T) {
 	d := initTestTM1638Driver()
 	d.AddFonts(map[string]byte{"µ": 0x1C, "ß": 0x7F})
 	data := d.fromStringToByteArray("µß")
-	assert.Equal(t, data, []byte{0x1C, 0x7F})
+	assert.Equal(t, []byte{0x1C, 0x7F}, data)
 }
 
 func TestTM1638DriverClearFonts(t *testing.T) {
 	d := initTestTM1638Driver()
 	d.ClearFonts()
 	data := d.fromStringToByteArray("Hello World")
-	assert.Equal(t, data, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
+	assert.Equal(t, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, data)
 }

--- a/drivers/i2c/adafruit1109_driver_test.go
+++ b/drivers/i2c/adafruit1109_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -49,12 +50,12 @@ func TestNewAdafruit1109Driver(t *testing.T) {
 
 func TestAdafruit1109Connect(t *testing.T) {
 	d, _ := initTestAdafruit1109WithStubbedAdaptor()
-	assert.NoError(t, d.Connect())
+	require.NoError(t, d.Connect())
 }
 
 func TestAdafruit1109Finalize(t *testing.T) {
 	d, _ := initTestAdafruit1109WithStubbedAdaptor()
-	assert.NoError(t, d.Finalize())
+	require.NoError(t, d.Finalize())
 }
 
 func TestAdafruit1109SetName(t *testing.T) {
@@ -65,7 +66,7 @@ func TestAdafruit1109SetName(t *testing.T) {
 
 func TestAdafruit1109Start(t *testing.T) {
 	d, _ := initTestAdafruit1109WithStubbedAdaptor()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestAdafruit1109StartWriteErr(t *testing.T) {
@@ -73,7 +74,7 @@ func TestAdafruit1109StartWriteErr(t *testing.T) {
 	adaptor.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
-	assert.ErrorContains(t, d.Start(), "write error")
+	require.ErrorContains(t, d.Start(), "write error")
 }
 
 func TestAdafruit1109StartReadErr(t *testing.T) {
@@ -81,13 +82,13 @@ func TestAdafruit1109StartReadErr(t *testing.T) {
 	adaptor.i2cReadImpl = func([]byte) (int, error) {
 		return 0, errors.New("read error")
 	}
-	assert.ErrorContains(t, d.Start(), "MCP write-read: MCP write-ReadByteData(reg=0): read error")
+	require.ErrorContains(t, d.Start(), "MCP write-read: MCP write-ReadByteData(reg=0): read error")
 }
 
 func TestAdafruit1109Halt(t *testing.T) {
 	d, _ := initTestAdafruit1109WithStubbedAdaptor()
 	_ = d.Start()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestAdafruit1109DigitalRead(t *testing.T) {
@@ -128,9 +129,9 @@ func TestAdafruit1109DigitalRead(t *testing.T) {
 			// act
 			got, err := d.DigitalRead(name)
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, 1, numCallsRead)
-			assert.Equal(t, 1, len(a.written))
+			assert.Len(t, a.written, 1)
 			assert.Equal(t, tc.wantReg, a.written[0])
 			assert.Equal(t, 1, got)
 		})
@@ -160,7 +161,7 @@ func TestAdafruit1109SelectButton(t *testing.T) {
 			// act
 			got, err := d.SelectButton()
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, 1, numCallsRead)
 			assert.Equal(t, tc.want, got)
 		})
@@ -190,7 +191,7 @@ func TestAdafruit1109UpButton(t *testing.T) {
 			// act
 			got, err := d.UpButton()
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, 1, numCallsRead)
 			assert.Equal(t, tc.want, got)
 		})
@@ -220,7 +221,7 @@ func TestAdafruit1109DownButton(t *testing.T) {
 			// act
 			got, err := d.DownButton()
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, 1, numCallsRead)
 			assert.Equal(t, tc.want, got)
 		})
@@ -250,7 +251,7 @@ func TestAdafruit1109LeftButton(t *testing.T) {
 			// act
 			got, err := d.LeftButton()
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, 1, numCallsRead)
 			assert.Equal(t, tc.want, got)
 		})
@@ -280,7 +281,7 @@ func TestAdafruit1109RightButton(t *testing.T) {
 			// act
 			got, err := d.RightButton()
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, 1, numCallsRead)
 			assert.Equal(t, tc.want, got)
 		})

--- a/drivers/i2c/adafruit2327_driver_test.go
+++ b/drivers/i2c/adafruit2327_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -47,8 +48,8 @@ func TestAdafruit2327SetServoMotorFreq(t *testing.T) {
 	// act
 	err := d.SetServoMotorFreq(freq)
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 9, len(a.written)) // detailed test, see "TestPCA9685SetPWMFreq"
+	require.NoError(t, err)
+	assert.Len(t, a.written, 9) // detailed test, see "TestPCA9685SetPWMFreq"
 }
 
 func TestAdafruit2327SetServoMotorFreqError(t *testing.T) {
@@ -59,7 +60,7 @@ func TestAdafruit2327SetServoMotorFreqError(t *testing.T) {
 	}
 	const freq = 60.0
 	// act & assert
-	assert.ErrorContains(t, d.SetServoMotorFreq(freq), "write error")
+	require.ErrorContains(t, d.SetServoMotorFreq(freq), "write error")
 }
 
 func TestAdafruit2327SetServoMotorPulse(t *testing.T) {
@@ -74,8 +75,8 @@ func TestAdafruit2327SetServoMotorPulse(t *testing.T) {
 	// act
 	err := d.SetServoMotorPulse(channel, on, off)
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 8, len(a.written)) // detailed test, see "TestPCA9685SetPWM"
+	require.NoError(t, err)
+	assert.Len(t, a.written, 8) // detailed test, see "TestPCA9685SetPWM"
 }
 
 func TestAdafruit2327SetServoMotorPulseError(t *testing.T) {
@@ -90,5 +91,5 @@ func TestAdafruit2327SetServoMotorPulseError(t *testing.T) {
 		off     int32 = 4321
 	)
 	// act & assert
-	assert.ErrorContains(t, d.SetServoMotorPulse(channel, on, off), "write error")
+	require.ErrorContains(t, d.SetServoMotorPulse(channel, on, off), "write error")
 }

--- a/drivers/i2c/adafruit2348_driver_test.go
+++ b/drivers/i2c/adafruit2348_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -52,8 +53,8 @@ func TestAdafruit2348SetDCMotorSpeed(t *testing.T) {
 	// act
 	err := d.SetDCMotorSpeed(dcMotor, speed)
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 8, len(a.written)) // detailed test, see "TestPCA9685SetPWM"
+	require.NoError(t, err)
+	assert.Len(t, a.written, 8) // detailed test, see "TestPCA9685SetPWM"
 }
 
 func TestAdafruit2348SetDCMotorSpeedError(t *testing.T) {
@@ -63,7 +64,7 @@ func TestAdafruit2348SetDCMotorSpeedError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	// act & assert
-	assert.ErrorContains(t, d.SetDCMotorSpeed(1, 255), "write error")
+	require.ErrorContains(t, d.SetDCMotorSpeed(1, 255), "write error")
 }
 
 func TestAdafruit2348RunDCMotor(t *testing.T) {
@@ -71,9 +72,9 @@ func TestAdafruit2348RunDCMotor(t *testing.T) {
 	d, _ := initTestAdafruit2348WithStubbedAdaptor()
 	const dcMotor = 1
 	// act & assert
-	assert.NoError(t, d.RunDCMotor(dcMotor, Adafruit2348Forward))
-	assert.NoError(t, d.RunDCMotor(dcMotor, Adafruit2348Backward))
-	assert.NoError(t, d.RunDCMotor(dcMotor, Adafruit2348Release))
+	require.NoError(t, d.RunDCMotor(dcMotor, Adafruit2348Forward))
+	require.NoError(t, d.RunDCMotor(dcMotor, Adafruit2348Backward))
+	require.NoError(t, d.RunDCMotor(dcMotor, Adafruit2348Release))
 }
 
 func TestAdafruit2348RunDCMotorError(t *testing.T) {
@@ -84,9 +85,9 @@ func TestAdafruit2348RunDCMotorError(t *testing.T) {
 	}
 	const dcMotor = 1
 	// act & assert
-	assert.ErrorContains(t, d.RunDCMotor(dcMotor, Adafruit2348Forward), "write error")
-	assert.ErrorContains(t, d.RunDCMotor(dcMotor, Adafruit2348Backward), "write error")
-	assert.ErrorContains(t, d.RunDCMotor(dcMotor, Adafruit2348Release), "write error")
+	require.ErrorContains(t, d.RunDCMotor(dcMotor, Adafruit2348Forward), "write error")
+	require.ErrorContains(t, d.RunDCMotor(dcMotor, Adafruit2348Backward), "write error")
+	require.ErrorContains(t, d.RunDCMotor(dcMotor, Adafruit2348Release), "write error")
 }
 
 func TestAdafruit2348SetStepperMotorSpeed(t *testing.T) {
@@ -97,8 +98,8 @@ func TestAdafruit2348SetStepperMotorSpeed(t *testing.T) {
 		rpm          = 30
 	)
 	// act & assert
-	assert.NoError(t, d.SetStepperMotorSpeed(stepperMotor, rpm))
-	assert.Equal(t, 0.01, d.stepperMotors[stepperMotor].secPerStep) // 60/(revSteps*rpm), revSteps=200
+	require.NoError(t, d.SetStepperMotorSpeed(stepperMotor, rpm))
+	assert.InDelta(t, 0.01, d.stepperMotors[stepperMotor].secPerStep, 0.0) // 60/(revSteps*rpm), revSteps=200
 }
 
 func TestAdafruit2348StepperSingleStep(t *testing.T) {
@@ -113,7 +114,7 @@ func TestAdafruit2348StepperSingleStep(t *testing.T) {
 	// act
 	err := d.Step(stepperMotor, steps, back, single)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestAdafruit2348StepperDoubleStep(t *testing.T) {
@@ -128,7 +129,7 @@ func TestAdafruit2348StepperDoubleStep(t *testing.T) {
 	// act
 	err := d.Step(stepperMotor, steps, back, double)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestAdafruit2348StepperInterleaveStep(t *testing.T) {
@@ -143,7 +144,7 @@ func TestAdafruit2348StepperInterleaveStep(t *testing.T) {
 	// act
 	err := d.Step(stepperMotor, steps, back, interleave)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestAdafruit2348StepperMicroStep(t *testing.T) {
@@ -158,5 +159,5 @@ func TestAdafruit2348StepperMicroStep(t *testing.T) {
 	// act
 	err := d.Step(stepperMotor, steps, back, micro)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/drivers/i2c/ads1x15_driver_1015_test.go
+++ b/drivers/i2c/ads1x15_driver_1015_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func initTestADS1015DriverWithStubbedAdaptor() (*ADS1x15Driver, *i2cTestAdaptor) {
@@ -73,38 +74,38 @@ func TestADS1015AnalogRead(t *testing.T) {
 
 	val, err := d.AnalogRead("0")
 	assert.Equal(t, 32767, val)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, err = d.AnalogRead("1")
 	assert.Equal(t, 32767, val)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, err = d.AnalogRead("2")
 	assert.Equal(t, 32767, val)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, err = d.AnalogRead("3")
 	assert.Equal(t, 32767, val)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, err = d.AnalogRead("0-1")
 	assert.Equal(t, 32767, val)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, err = d.AnalogRead("0-3")
 	assert.Equal(t, 32767, val)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, err = d.AnalogRead("1-3")
 	assert.Equal(t, 32767, val)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, err = d.AnalogRead("2-3")
 	assert.Equal(t, 32767, val)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = d.AnalogRead("3-2")
-	assert.NotNil(t, err.Error())
+	require.Error(t, err)
 }
 
 func TestADS1x15AnalogReadError(t *testing.T) {
@@ -115,14 +116,14 @@ func TestADS1x15AnalogReadError(t *testing.T) {
 	}
 
 	_, err := d.AnalogRead("0")
-	assert.ErrorContains(t, err, "read error")
+	require.ErrorContains(t, err, "read error")
 }
 
 func TestADS1x15AnalogReadInvalidPin(t *testing.T) {
 	d, _ := initTestADS1015DriverWithStubbedAdaptor()
 
 	_, err := d.AnalogRead("99")
-	assert.ErrorContains(t, err, "Invalid channel (99), must be between 0 and 3")
+	require.ErrorContains(t, err, "Invalid channel (99), must be between 0 and 3")
 }
 
 func TestADS1x15AnalogReadWriteError(t *testing.T) {
@@ -133,41 +134,41 @@ func TestADS1x15AnalogReadWriteError(t *testing.T) {
 	}
 
 	_, err := d.AnalogRead("0")
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 
 	_, err = d.AnalogRead("0-1")
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 
 	_, err = d.AnalogRead("2-3")
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 }
 
 func TestADS1x15ReadInvalidChannel(t *testing.T) {
 	d, _ := initTestADS1015DriverWithStubbedAdaptor()
 
 	_, err := d.Read(9, 1, 1600)
-	assert.ErrorContains(t, err, "Invalid channel (9), must be between 0 and 3")
+	require.ErrorContains(t, err, "Invalid channel (9), must be between 0 and 3")
 }
 
 func TestADS1x15ReadInvalidGain(t *testing.T) {
 	d, _ := initTestADS1015DriverWithStubbedAdaptor()
 
 	_, err := d.Read(0, 8, 1600)
-	assert.ErrorContains(t, err, "Gain (8) must be one of: [0 1 2 3 4 5 6 7]")
+	require.ErrorContains(t, err, "Gain (8) must be one of: [0 1 2 3 4 5 6 7]")
 }
 
 func TestADS1x15ReadInvalidDataRate(t *testing.T) {
 	d, _ := initTestADS1015DriverWithStubbedAdaptor()
 
 	_, err := d.Read(0, 1, 321)
-	assert.ErrorContains(t, err, "Invalid data rate (321). Accepted values: [128 250 490 920 1600 2400 3300]")
+	require.ErrorContains(t, err, "Invalid data rate (321). Accepted values: [128 250 490 920 1600 2400 3300]")
 }
 
 func TestADS1x15ReadDifferenceInvalidChannel(t *testing.T) {
 	d, _ := initTestADS1015DriverWithStubbedAdaptor()
 
 	_, err := d.ReadDifference(9, 1, 1600)
-	assert.ErrorContains(t, err, "Invalid channel (9), must be between 0 and 3")
+	require.ErrorContains(t, err, "Invalid channel (9), must be between 0 and 3")
 }
 
 func TestADS1015_rawRead(t *testing.T) {
@@ -269,10 +270,10 @@ func TestADS1015_rawRead(t *testing.T) {
 			// act
 			got, err := d.rawRead(channel, channelOffset, tt.gain, tt.dataRate)
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, 3, numCallsRead)
-			assert.Equal(t, 6, len(a.written))
+			assert.Len(t, a.written, 6)
 			assert.Equal(t, uint8(ads1x15PointerConfig), a.written[0])
 			assert.Equal(t, tt.wantConfig[0], a.written[1])            // MSByte: OS, MUX, PGA, MODE
 			assert.Equal(t, tt.wantConfig[1], a.written[2])            // LSByte: DR, COMP_*

--- a/drivers/i2c/ads1x15_driver_1115_test.go
+++ b/drivers/i2c/ads1x15_driver_1115_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func initTestADS1115DriverWithStubbedAdaptor() (*ADS1x15Driver, *i2cTestAdaptor) {
@@ -73,38 +74,38 @@ func TestADS1115AnalogRead(t *testing.T) {
 
 	val, err := d.AnalogRead("0")
 	assert.Equal(t, 32767, val)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, err = d.AnalogRead("1")
 	assert.Equal(t, 32767, val)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, err = d.AnalogRead("2")
 	assert.Equal(t, 32767, val)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, err = d.AnalogRead("3")
 	assert.Equal(t, 32767, val)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, err = d.AnalogRead("0-1")
 	assert.Equal(t, 32767, val)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, err = d.AnalogRead("0-3")
 	assert.Equal(t, 32767, val)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, err = d.AnalogRead("1-3")
 	assert.Equal(t, 32767, val)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, err = d.AnalogRead("2-3")
 	assert.Equal(t, 32767, val)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = d.AnalogRead("3-2")
-	assert.NotNil(t, err.Error())
+	require.Error(t, err)
 }
 
 func TestADS1115AnalogReadError(t *testing.T) {
@@ -115,14 +116,14 @@ func TestADS1115AnalogReadError(t *testing.T) {
 	}
 
 	_, err := d.AnalogRead("0")
-	assert.ErrorContains(t, err, "read error")
+	require.ErrorContains(t, err, "read error")
 }
 
 func TestADS1115AnalogReadInvalidPin(t *testing.T) {
 	d, _ := initTestADS1115DriverWithStubbedAdaptor()
 
 	_, err := d.AnalogRead("98")
-	assert.ErrorContains(t, err, "Invalid channel (98), must be between 0 and 3")
+	require.ErrorContains(t, err, "Invalid channel (98), must be between 0 and 3")
 }
 
 func TestADS1115AnalogReadWriteError(t *testing.T) {
@@ -133,41 +134,41 @@ func TestADS1115AnalogReadWriteError(t *testing.T) {
 	}
 
 	_, err := d.AnalogRead("0")
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 
 	_, err = d.AnalogRead("0-1")
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 
 	_, err = d.AnalogRead("2-3")
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 }
 
 func TestADS1115ReadInvalidChannel(t *testing.T) {
 	d, _ := initTestADS1115DriverWithStubbedAdaptor()
 
 	_, err := d.Read(7, 1, 1600)
-	assert.ErrorContains(t, err, "Invalid channel (7), must be between 0 and 3")
+	require.ErrorContains(t, err, "Invalid channel (7), must be between 0 and 3")
 }
 
 func TestADS1115ReadInvalidGain(t *testing.T) {
 	d, _ := initTestADS1115DriverWithStubbedAdaptor()
 
 	_, err := d.Read(0, 21, 1600)
-	assert.ErrorContains(t, err, "Gain (21) must be one of: [0 1 2 3 4 5 6 7]")
+	require.ErrorContains(t, err, "Gain (21) must be one of: [0 1 2 3 4 5 6 7]")
 }
 
 func TestADS1115ReadInvalidDataRate(t *testing.T) {
 	d, _ := initTestADS1115DriverWithStubbedAdaptor()
 
 	_, err := d.Read(0, 1, 678)
-	assert.ErrorContains(t, err, "Invalid data rate (678). Accepted values: [8 16 32 64 128 250 475 860]")
+	require.ErrorContains(t, err, "Invalid data rate (678). Accepted values: [8 16 32 64 128 250 475 860]")
 }
 
 func TestADS1115ReadDifferenceInvalidChannel(t *testing.T) {
 	d, _ := initTestADS1115DriverWithStubbedAdaptor()
 
 	_, err := d.ReadDifference(5, 1, 1600)
-	assert.ErrorContains(t, err, "Invalid channel (5), must be between 0 and 3")
+	require.ErrorContains(t, err, "Invalid channel (5), must be between 0 and 3")
 }
 
 func TestADS1115_rawRead(t *testing.T) {
@@ -269,10 +270,10 @@ func TestADS1115_rawRead(t *testing.T) {
 			// act
 			got, err := d.rawRead(channel, channelOffset, tt.gain, tt.dataRate)
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, 3, numCallsRead)
-			assert.Equal(t, 6, len(a.written))
+			assert.Len(t, a.written, 6)
 			assert.Equal(t, uint8(ads1x15PointerConfig), a.written[0])
 			assert.Equal(t, tt.wantConfig[0], a.written[1])            // MSByte: OS, MUX, PGA, MODE
 			assert.Equal(t, tt.wantConfig[1], a.written[2])            // LSByte: DR, COMP_*

--- a/drivers/i2c/ads1x15_driver_test.go
+++ b/drivers/i2c/ads1x15_driver_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/aio"
 )
@@ -99,5 +100,5 @@ func TestADS1x15_ads1x15BestGainForVoltage(t *testing.T) {
 	assert.Equal(t, 2, g)
 
 	_, err := ads1x15BestGainForVoltage(20.0)
-	assert.ErrorContains(t, err, "The maximum voltage which can be read is 6.144000")
+	require.ErrorContains(t, err, "The maximum voltage which can be read is 6.144000")
 }

--- a/drivers/i2c/adxl345_driver_test.go
+++ b/drivers/i2c/adxl345_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -53,7 +54,7 @@ func TestADXL345WithADXL345DataOutputRate(t *testing.T) {
 	WithADXL345DataOutputRate(setVal)(d)
 	// assert
 	assert.Equal(t, setVal, d.bwRate.rate)
-	assert.Equal(t, 0, len(a.written))
+	assert.Empty(t, a.written)
 }
 
 func TestADXL345WithADXL345FullScaleRange(t *testing.T) {
@@ -67,7 +68,7 @@ func TestADXL345WithADXL345FullScaleRange(t *testing.T) {
 	WithADXL345FullScaleRange(setVal)(d)
 	// assert
 	assert.Equal(t, setVal, d.dataFormat.fullScaleRange)
-	assert.Equal(t, 0, len(a.written))
+	assert.Empty(t, a.written)
 }
 
 func TestADXL345UseLowPower(t *testing.T) {
@@ -85,9 +86,9 @@ func TestADXL345UseLowPower(t *testing.T) {
 	// act
 	err := d.UseLowPower(setVal)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, setVal, d.bwRate.lowPower)
-	assert.Equal(t, 2, len(a.written))
+	assert.Len(t, a.written, 2)
 	assert.Equal(t, wantReg, a.written[0])
 	assert.Equal(t, wantVal, a.written[1])
 }
@@ -107,9 +108,9 @@ func TestADXL345SetRate(t *testing.T) {
 	// act
 	err := d.SetRate(setVal)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, setVal, d.bwRate.rate)
-	assert.Equal(t, 2, len(a.written))
+	assert.Len(t, a.written, 2)
 	assert.Equal(t, wantReg, a.written[0])
 	assert.Equal(t, wantVal, a.written[1])
 }
@@ -129,9 +130,9 @@ func TestADXL345SetRange(t *testing.T) {
 	// act
 	err := d.SetRange(setVal)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, setVal, d.dataFormat.fullScaleRange)
-	assert.Equal(t, 2, len(a.written))
+	assert.Len(t, a.written, 2)
 	assert.Equal(t, wantReg, a.written[0])
 	assert.Equal(t, wantVal, a.written[1])
 }
@@ -184,12 +185,12 @@ func TestADXL345RawXYZ(t *testing.T) {
 			// act
 			gotX, gotY, gotZ, err := d.RawXYZ()
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.wantX, gotX)
 			assert.Equal(t, tc.wantY, gotY)
 			assert.Equal(t, tc.wantZ, gotZ)
 			assert.Equal(t, 1, numCallsRead)
-			assert.Equal(t, 1, len(a.written))
+			assert.Len(t, a.written, 1)
 			assert.Equal(t, uint8(0x32), a.written[0])
 		})
 	}
@@ -205,7 +206,7 @@ func TestADXL345RawXYZError(t *testing.T) {
 	// act
 	_, _, _, err := d.RawXYZ()
 	// assert
-	assert.ErrorContains(t, err, "read error")
+	require.ErrorContains(t, err, "read error")
 }
 
 func TestADXL345XYZ(t *testing.T) {
@@ -252,9 +253,9 @@ func TestADXL345XYZ(t *testing.T) {
 			// act
 			x, y, z, _ := d.XYZ()
 			// assert
-			assert.Equal(t, tc.wantX, x)
-			assert.Equal(t, tc.wantY, y)
-			assert.Equal(t, tc.wantZ, z)
+			assert.InDelta(t, tc.wantX, x, 0.0)
+			assert.InDelta(t, tc.wantY, y, 0.0)
+			assert.InDelta(t, tc.wantZ, z, 0.0)
 		})
 	}
 }
@@ -269,7 +270,7 @@ func TestADXL345XYZError(t *testing.T) {
 	// act
 	_, _, _, err := d.XYZ()
 	// assert
-	assert.ErrorContains(t, err, "read error")
+	require.ErrorContains(t, err, "read error")
 }
 
 func TestADXL345_initialize(t *testing.T) {
@@ -292,8 +293,8 @@ func TestADXL345_initialize(t *testing.T) {
 	// act, assert - initialize() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 6, len(a.written))
+	require.NoError(t, err)
+	assert.Len(t, a.written, 6)
 	assert.Equal(t, wantRateReg, a.written[0])
 	assert.Equal(t, wantRateRegVal, a.written[1])
 	assert.Equal(t, wantPwrReg, a.written[2])
@@ -316,8 +317,8 @@ func TestADXL345_shutdown(t *testing.T) {
 	// act, assert - shutdown() must be called on Halt()
 	err := d.Halt()
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(a.written))
+	require.NoError(t, err)
+	assert.Len(t, a.written, 2)
 	assert.Equal(t, wantReg, a.written[0])
 	assert.Equal(t, wantVal, a.written[1])
 }

--- a/drivers/i2c/bh1750_driver_test.go
+++ b/drivers/i2c/bh1750_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -43,12 +44,12 @@ func TestBH1750Options(t *testing.T) {
 
 func TestBH1750Start(t *testing.T) {
 	d := NewBH1750Driver(newI2cTestAdaptor())
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestBH1750Halt(t *testing.T) {
 	d, _ := initTestBH1750DriverWithStubbedAdaptor()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestBH1750NullLux(t *testing.T) {
@@ -96,7 +97,7 @@ func TestBH1750LuxError(t *testing.T) {
 	}
 
 	_, err := d.Lux()
-	assert.ErrorContains(t, err, "wrong number of bytes read")
+	require.ErrorContains(t, err, "wrong number of bytes read")
 }
 
 func TestBH1750RawSensorDataError(t *testing.T) {
@@ -106,5 +107,5 @@ func TestBH1750RawSensorDataError(t *testing.T) {
 	}
 
 	_, err := d.RawSensorData()
-	assert.ErrorContains(t, err, "wrong number of bytes read")
+	require.ErrorContains(t, err, "wrong number of bytes read")
 }

--- a/drivers/i2c/blinkm_driver_test.go
+++ b/drivers/i2c/blinkm_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -42,12 +43,12 @@ func TestBlinkMOptions(t *testing.T) {
 
 func TestBlinkMStart(t *testing.T) {
 	d := NewBlinkMDriver(newI2cTestAdaptor())
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestBlinkMHalt(t *testing.T) {
 	d, _ := initTestBlinkMDriverWithStubbedAdaptor()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 // Commands
@@ -125,7 +126,7 @@ func TestBlinkMFirmwareVersion(t *testing.T) {
 	}
 
 	_, err := d.FirmwareVersion()
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 }
 
 func TestBlinkMColor(t *testing.T) {
@@ -153,7 +154,7 @@ func TestBlinkMColor(t *testing.T) {
 	}
 
 	_, err := d.Color()
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 }
 
 func TestBlinkMFade(t *testing.T) {
@@ -163,7 +164,7 @@ func TestBlinkMFade(t *testing.T) {
 	}
 
 	err := d.Fade(100, 100, 100)
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 }
 
 func TestBlinkMRGB(t *testing.T) {
@@ -173,5 +174,5 @@ func TestBlinkMRGB(t *testing.T) {
 	}
 
 	err := d.Rgb(100, 100, 100)
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 }

--- a/drivers/i2c/bme280_driver_test.go
+++ b/drivers/i2c/bme280_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -72,8 +73,8 @@ func TestBME280Measurements(t *testing.T) {
 	}
 	_ = bme280.Start()
 	hum, err := bme280.Humidity()
-	assert.NoError(t, err)
-	assert.Equal(t, float32(51.20179), hum)
+	require.NoError(t, err)
+	assert.InDelta(t, float32(51.20179), hum, 0.0)
 }
 
 func TestBME280InitH1Error(t *testing.T) {
@@ -92,7 +93,7 @@ func TestBME280InitH1Error(t *testing.T) {
 		return buf.Len(), nil
 	}
 
-	assert.ErrorContains(t, bme280.Start(), "h1 read error")
+	require.ErrorContains(t, bme280.Start(), "h1 read error")
 }
 
 func TestBME280InitH2Error(t *testing.T) {
@@ -111,7 +112,7 @@ func TestBME280InitH2Error(t *testing.T) {
 		return buf.Len(), nil
 	}
 
-	assert.ErrorContains(t, bme280.Start(), "h2 read error")
+	require.ErrorContains(t, bme280.Start(), "h2 read error")
 }
 
 func TestBME280HumidityWriteError(t *testing.T) {
@@ -122,8 +123,8 @@ func TestBME280HumidityWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	hum, err := bme280.Humidity()
-	assert.ErrorContains(t, err, "write error")
-	assert.Equal(t, float32(0.0), hum)
+	require.ErrorContains(t, err, "write error")
+	assert.InDelta(t, float32(0.0), hum, 0.0)
 }
 
 func TestBME280HumidityReadError(t *testing.T) {
@@ -134,8 +135,8 @@ func TestBME280HumidityReadError(t *testing.T) {
 		return 0, errors.New("read error")
 	}
 	hum, err := bme280.Humidity()
-	assert.ErrorContains(t, err, "read error")
-	assert.Equal(t, float32(0.0), hum)
+	require.ErrorContains(t, err, "read error")
+	assert.InDelta(t, float32(0.0), hum, 0.0)
 }
 
 func TestBME280HumidityNotEnabled(t *testing.T) {
@@ -159,8 +160,8 @@ func TestBME280HumidityNotEnabled(t *testing.T) {
 	}
 	_ = bme280.Start()
 	hum, err := bme280.Humidity()
-	assert.ErrorContains(t, err, "Humidity disabled")
-	assert.Equal(t, float32(0.0), hum)
+	require.ErrorContains(t, err, "Humidity disabled")
+	assert.InDelta(t, float32(0.0), hum, 0.0)
 }
 
 func TestBME280_initializationBME280(t *testing.T) {
@@ -186,5 +187,5 @@ func TestBME280_initializationBME280(t *testing.T) {
 		}
 		return 0, nil
 	}
-	assert.NoError(t, bme280.Start())
+	require.NoError(t, bme280.Start())
 }

--- a/drivers/i2c/bmp180_driver_test.go
+++ b/drivers/i2c/bmp180_driver_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -72,11 +73,11 @@ func TestBMP180Measurements(t *testing.T) {
 	}
 	_ = bmp180.Start()
 	temp, err := bmp180.Temperature()
-	assert.NoError(t, err)
-	assert.Equal(t, float32(15.0), temp)
+	require.NoError(t, err)
+	assert.InDelta(t, float32(15.0), temp, 0.0)
 	pressure, err := bmp180.Pressure()
-	assert.NoError(t, err)
-	assert.Equal(t, float32(69964), pressure)
+	require.NoError(t, err)
+	assert.InDelta(t, float32(69964), pressure, 0.0)
 }
 
 func TestBMP180TemperatureError(t *testing.T) {
@@ -108,7 +109,7 @@ func TestBMP180TemperatureError(t *testing.T) {
 	}
 	_ = bmp180.Start()
 	_, err := bmp180.Temperature()
-	assert.ErrorContains(t, err, "temp error")
+	require.ErrorContains(t, err, "temp error")
 }
 
 func TestBMP180PressureError(t *testing.T) {
@@ -138,7 +139,7 @@ func TestBMP180PressureError(t *testing.T) {
 	}
 	_ = bmp180.Start()
 	_, err := bmp180.Pressure()
-	assert.ErrorContains(t, err, "press error")
+	require.ErrorContains(t, err, "press error")
 }
 
 func TestBMP180PressureWriteError(t *testing.T) {
@@ -150,7 +151,7 @@ func TestBMP180PressureWriteError(t *testing.T) {
 	}
 
 	_, err := bmp180.Pressure()
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 }
 
 func TestBMP180_initialization(t *testing.T) {
@@ -183,9 +184,9 @@ func TestBMP180_initialization(t *testing.T) {
 	// act, assert - initialization() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, numCallsRead)
-	assert.Equal(t, 1, len(a.written))
+	assert.Len(t, a.written, 1)
 	assert.Equal(t, uint8(0xAA), a.written[0])
 	assert.Equal(t, int16(408), d.calCoeffs.ac1)
 	assert.Equal(t, int16(-72), d.calCoeffs.ac2)

--- a/drivers/i2c/bmp280_driver_test.go
+++ b/drivers/i2c/bmp280_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -54,7 +55,7 @@ func TestWithBMP280TemperatureOversampling(t *testing.T) {
 	WithBMP280TemperatureOversampling(setVal)(d)
 	// assert
 	assert.Equal(t, setVal, d.ctrlTempOversamp)
-	assert.Equal(t, 0, len(a.written))
+	assert.Empty(t, a.written)
 }
 
 func TestWithBMP280IIRFilter(t *testing.T) {
@@ -68,7 +69,7 @@ func TestWithBMP280IIRFilter(t *testing.T) {
 	WithBMP280IIRFilter(setVal)(d)
 	// assert
 	assert.Equal(t, setVal, d.confFilter)
-	assert.Equal(t, 0, len(a.written))
+	assert.Empty(t, a.written)
 }
 
 func TestBMP280Measurements(t *testing.T) {
@@ -88,14 +89,14 @@ func TestBMP280Measurements(t *testing.T) {
 	}
 	_ = d.Start()
 	temp, err := d.Temperature()
-	assert.NoError(t, err)
-	assert.Equal(t, float32(25.014637), temp)
+	require.NoError(t, err)
+	assert.InDelta(t, float32(25.014637), temp, 0.0)
 	pressure, err := d.Pressure()
-	assert.NoError(t, err)
-	assert.Equal(t, float32(99545.414), pressure)
+	require.NoError(t, err)
+	assert.InDelta(t, float32(99545.414), pressure, 0.0)
 	alt, err := d.Altitude()
-	assert.NoError(t, err)
-	assert.Equal(t, float32(149.22713), alt)
+	require.NoError(t, err)
+	assert.InDelta(t, float32(149.22713), alt, 0.0)
 }
 
 func TestBMP280TemperatureWriteError(t *testing.T) {
@@ -106,8 +107,8 @@ func TestBMP280TemperatureWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	temp, err := d.Temperature()
-	assert.ErrorContains(t, err, "write error")
-	assert.Equal(t, float32(0.0), temp)
+	require.ErrorContains(t, err, "write error")
+	assert.InDelta(t, float32(0.0), temp, 0.0)
 }
 
 func TestBMP280TemperatureReadError(t *testing.T) {
@@ -118,8 +119,8 @@ func TestBMP280TemperatureReadError(t *testing.T) {
 		return 0, errors.New("read error")
 	}
 	temp, err := d.Temperature()
-	assert.ErrorContains(t, err, "read error")
-	assert.Equal(t, float32(0.0), temp)
+	require.ErrorContains(t, err, "read error")
+	assert.InDelta(t, float32(0.0), temp, 0.0)
 }
 
 func TestBMP280PressureWriteError(t *testing.T) {
@@ -130,8 +131,8 @@ func TestBMP280PressureWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	press, err := d.Pressure()
-	assert.ErrorContains(t, err, "write error")
-	assert.Equal(t, float32(0.0), press)
+	require.ErrorContains(t, err, "write error")
+	assert.InDelta(t, float32(0.0), press, 0.0)
 }
 
 func TestBMP280PressureReadError(t *testing.T) {
@@ -142,8 +143,8 @@ func TestBMP280PressureReadError(t *testing.T) {
 		return 0, errors.New("read error")
 	}
 	press, err := d.Pressure()
-	assert.ErrorContains(t, err, "read error")
-	assert.Equal(t, float32(0.0), press)
+	require.ErrorContains(t, err, "read error")
+	assert.InDelta(t, float32(0.0), press, 0.0)
 }
 
 func TestBMP280_initialization(t *testing.T) {
@@ -188,9 +189,9 @@ func TestBMP280_initialization(t *testing.T) {
 	// act, assert - initialization() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, numCallsRead)
-	assert.Equal(t, 5, len(a.written))
+	assert.Len(t, a.written, 5)
 	assert.Equal(t, wantCalibReg, a.written[0])
 	assert.Equal(t, wantCtrlReg, a.written[1])
 	assert.Equal(t, wantCtrlRegVal, a.written[2])

--- a/drivers/i2c/bmp388_driver_test.go
+++ b/drivers/i2c/bmp388_driver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -84,14 +85,14 @@ func TestBMP388Measurements(t *testing.T) {
 	}
 	_ = d.Start()
 	temp, err := d.Temperature(2)
-	assert.NoError(t, err)
-	assert.Equal(t, float32(22.906143), temp)
+	require.NoError(t, err)
+	assert.InDelta(t, float32(22.906143), temp, 0.0)
 	pressure, err := d.Pressure(2)
-	assert.NoError(t, err)
-	assert.Equal(t, float32(98874.85), pressure)
+	require.NoError(t, err)
+	assert.InDelta(t, float32(98874.85), pressure, 0.0)
 	alt, err := d.Altitude(2)
-	assert.NoError(t, err)
-	assert.Equal(t, float32(205.89395), alt)
+	require.NoError(t, err)
+	assert.InDelta(t, float32(205.89395), alt, 0.0)
 }
 
 func TestBMP388TemperatureWriteError(t *testing.T) {
@@ -102,8 +103,8 @@ func TestBMP388TemperatureWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	temp, err := d.Temperature(2)
-	assert.ErrorContains(t, err, "write error")
-	assert.Equal(t, float32(0.0), temp)
+	require.ErrorContains(t, err, "write error")
+	assert.InDelta(t, float32(0.0), temp, 0.0)
 }
 
 func TestBMP388TemperatureReadError(t *testing.T) {
@@ -114,8 +115,8 @@ func TestBMP388TemperatureReadError(t *testing.T) {
 		return 0, errors.New("read error")
 	}
 	temp, err := d.Temperature(2)
-	assert.ErrorContains(t, err, "read error")
-	assert.Equal(t, float32(0.0), temp)
+	require.ErrorContains(t, err, "read error")
+	assert.InDelta(t, float32(0.0), temp, 0.0)
 }
 
 func TestBMP388PressureWriteError(t *testing.T) {
@@ -126,8 +127,8 @@ func TestBMP388PressureWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	press, err := d.Pressure(2)
-	assert.ErrorContains(t, err, "write error")
-	assert.Equal(t, float32(0.0), press)
+	require.ErrorContains(t, err, "write error")
+	assert.InDelta(t, float32(0.0), press, 0.0)
 }
 
 func TestBMP388PressureReadError(t *testing.T) {
@@ -138,8 +139,8 @@ func TestBMP388PressureReadError(t *testing.T) {
 		return 0, errors.New("read error")
 	}
 	press, err := d.Pressure(2)
-	assert.ErrorContains(t, err, "read error")
-	assert.Equal(t, float32(0.0), press)
+	require.ErrorContains(t, err, "read error")
+	assert.InDelta(t, float32(0.0), press, 0.0)
 }
 
 func TestBMP388_initialization(t *testing.T) {
@@ -176,25 +177,25 @@ func TestBMP388_initialization(t *testing.T) {
 	// act, assert - initialization() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 2, numCallsRead)
-	assert.Equal(t, 6, len(a.written))
+	assert.Len(t, a.written, 6)
 	assert.Equal(t, wantChipIDReg, a.written[0])
 	assert.Equal(t, wantCalibReg, a.written[1])
 	assert.Equal(t, wantCommandReg, a.written[2])
 	assert.Equal(t, wantCommandRegVal, a.written[3])
 	assert.Equal(t, wantConfReg, a.written[4])
 	assert.Equal(t, wantConfRegVal, a.written[5])
-	assert.Equal(t, float32(7.021568e+06), d.calCoeffs.t1)
-	assert.Equal(t, float32(1.7549843e-05), d.calCoeffs.t2)
-	assert.Equal(t, float32(-3.5527137e-14), d.calCoeffs.t3)
-	assert.Equal(t, float32(-0.015769958), d.calCoeffs.p1)
-	assert.Equal(t, float32(-3.5410747e-05), d.calCoeffs.p2)
-	assert.Equal(t, float32(8.1490725e-09), d.calCoeffs.p3)
-	assert.Equal(t, float32(0), d.calCoeffs.p4)
-	assert.Equal(t, float32(208056), d.calCoeffs.p5)
-	assert.Equal(t, float32(490.875), d.calCoeffs.p6)
-	assert.Equal(t, float32(-0.05078125), d.calCoeffs.p7)
-	assert.Equal(t, float32(-0.00030517578), d.calCoeffs.p8)
-	assert.Equal(t, float32(5.8957283e-11), d.calCoeffs.p9)
+	assert.InDelta(t, float32(7.021568e+06), d.calCoeffs.t1, 0.0)
+	assert.InDelta(t, float32(1.7549843e-05), d.calCoeffs.t2, 0.0)
+	assert.InDelta(t, float32(-3.5527137e-14), d.calCoeffs.t3, 0.0)
+	assert.InDelta(t, float32(-0.015769958), d.calCoeffs.p1, 0.0)
+	assert.InDelta(t, float32(-3.5410747e-05), d.calCoeffs.p2, 0.0)
+	assert.InDelta(t, float32(8.1490725e-09), d.calCoeffs.p3, 0.0)
+	assert.InDelta(t, float32(0), d.calCoeffs.p4, 0.0)
+	assert.InDelta(t, float32(208056), d.calCoeffs.p5, 0.0)
+	assert.InDelta(t, float32(490.875), d.calCoeffs.p6, 0.0)
+	assert.InDelta(t, float32(-0.05078125), d.calCoeffs.p7, 0.0)
+	assert.InDelta(t, float32(-0.00030517578), d.calCoeffs.p8, 0.0)
+	assert.InDelta(t, float32(5.8957283e-11), d.calCoeffs.p9, 0.0)
 }

--- a/drivers/i2c/ccs811_driver_test.go
+++ b/drivers/i2c/ccs811_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -148,7 +149,7 @@ func TestCCS811GetTemperature(t *testing.T) {
 			// act
 			temp, err := d.GetTemperature()
 			// assert
-			assert.Equal(t, tc.temp, temp)
+			assert.InDelta(t, tc.temp, temp, 0.0)
 			assert.Equal(t, tc.err, err)
 		})
 	}
@@ -255,9 +256,9 @@ func TestCCS811_initialize(t *testing.T) {
 	// arrange, act - initialize() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, numCallsRead)
-	assert.Equal(t, 9, len(a.written))
+	assert.Len(t, a.written, 9)
 	assert.Equal(t, wantChipIDReg, a.written[0])
 	assert.Equal(t, wantResetReg, a.written[1])
 	assert.Equal(t, wantResetRegSequence, a.written[2:6])

--- a/drivers/i2c/drv2605l_driver_test.go
+++ b/drivers/i2c/drv2605l_driver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -51,7 +52,7 @@ func TestDRV2605LOptions(t *testing.T) {
 
 func TestDRV2605LStart(t *testing.T) {
 	d := NewDRV2605LDriver(newI2cTestAdaptor())
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestDRV2605LHalt(t *testing.T) {
@@ -62,7 +63,7 @@ func TestDRV2605LHalt(t *testing.T) {
 	writeNewStandbyModeData := []byte{drv2605RegMode, 42 | drv2605Standby}
 	d, a := initTestDRV2605LDriverWithStubbedAdaptor()
 	a.written = []byte{}
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 	assert.Equal(t, append(append(writeStopPlaybackData, readCurrentStandbyModeData), writeNewStandbyModeData...), a.written)
 }
 
@@ -76,7 +77,7 @@ func TestDRV2605LGetPause(t *testing.T) {
 func TestDRV2605LSequenceTermination(t *testing.T) {
 	d, a := initTestDRV2605LDriverWithStubbedAdaptor()
 	a.written = []byte{}
-	assert.NoError(t, d.SetSequence([]byte{1, 2}))
+	require.NoError(t, d.SetSequence([]byte{1, 2}))
 	assert.Equal(t, []byte{
 		drv2605RegWaveSeq1, 1,
 		drv2605RegWaveSeq2, 2,
@@ -87,7 +88,7 @@ func TestDRV2605LSequenceTermination(t *testing.T) {
 func TestDRV2605LSequenceTruncation(t *testing.T) {
 	d, a := initTestDRV2605LDriverWithStubbedAdaptor()
 	a.written = []byte{}
-	assert.NoError(t, d.SetSequence([]byte{1, 2, 3, 4, 5, 6, 7, 8, 99, 100}))
+	require.NoError(t, d.SetSequence([]byte{1, 2, 3, 4, 5, 6, 7, 8, 99, 100}))
 	assert.Equal(t, []byte{
 		drv2605RegWaveSeq1, 1,
 		drv2605RegWaveSeq2, 2,
@@ -102,7 +103,7 @@ func TestDRV2605LSequenceTruncation(t *testing.T) {
 
 func TestDRV2605LSetMode(t *testing.T) {
 	d, _ := initTestDRV2605LDriverWithStubbedAdaptor()
-	assert.NoError(t, d.SetMode(DRV2605ModeIntTrig))
+	require.NoError(t, d.SetMode(DRV2605ModeIntTrig))
 }
 
 func TestDRV2605LSetModeReadError(t *testing.T) {
@@ -110,12 +111,12 @@ func TestDRV2605LSetModeReadError(t *testing.T) {
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		return 0, errors.New("read error")
 	}
-	assert.ErrorContains(t, d.SetMode(DRV2605ModeIntTrig), "read error")
+	require.ErrorContains(t, d.SetMode(DRV2605ModeIntTrig), "read error")
 }
 
 func TestDRV2605LSetStandbyMode(t *testing.T) {
 	d, _ := initTestDRV2605LDriverWithStubbedAdaptor()
-	assert.NoError(t, d.SetStandbyMode(true))
+	require.NoError(t, d.SetStandbyMode(true))
 }
 
 func TestDRV2605LSetStandbyModeReadError(t *testing.T) {
@@ -123,15 +124,15 @@ func TestDRV2605LSetStandbyModeReadError(t *testing.T) {
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		return 0, errors.New("read error")
 	}
-	assert.ErrorContains(t, d.SetStandbyMode(true), "read error")
+	require.ErrorContains(t, d.SetStandbyMode(true), "read error")
 }
 
 func TestDRV2605LSelectLibrary(t *testing.T) {
 	d, _ := initTestDRV2605LDriverWithStubbedAdaptor()
-	assert.NoError(t, d.SelectLibrary(1))
+	require.NoError(t, d.SelectLibrary(1))
 }
 
 func TestDRV2605LGo(t *testing.T) {
 	d, _ := initTestDRV2605LDriverWithStubbedAdaptor()
-	assert.NoError(t, d.Go())
+	require.NoError(t, d.Go())
 }

--- a/drivers/i2c/grovepi_driver_test.go
+++ b/drivers/i2c/grovepi_driver_test.go
@@ -2,10 +2,12 @@ package i2c
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/aio"
 	"gobot.io/x/gobot/v2/drivers/gpio"
@@ -152,15 +154,15 @@ func TestGrovePiSomeRead(t *testing.T) {
 			// act
 			switch {
 			case strings.Contains(name, "DigitalRead"):
-				got, err = g.DigitalRead(fmt.Sprintf("%d", tc.usedPin))
+				got, err = g.DigitalRead(strconv.Itoa(tc.usedPin))
 			case strings.Contains(name, "AnalogRead"):
-				got, err = g.AnalogRead(fmt.Sprintf("%d", tc.usedPin))
+				got, err = g.AnalogRead(strconv.Itoa(tc.usedPin))
 			case strings.Contains(name, "UltrasonicRead"):
-				got, err = g.UltrasonicRead(fmt.Sprintf("%d", tc.usedPin), 2)
+				got, err = g.UltrasonicRead(strconv.Itoa(tc.usedPin), 2)
 			case strings.Contains(name, "FirmwareVersionRead"):
 				gotString, err = g.FirmwareVersionRead()
 			case strings.Contains(name, "DHTRead"):
-				gotF1, gotF2, err = g.DHTRead(fmt.Sprintf("%d", tc.usedPin), 1, 2)
+				gotF1, gotF2, err = g.DHTRead(strconv.Itoa(tc.usedPin), 1, 2)
 			default:
 				t.Errorf("unknown command %s", name)
 				return
@@ -168,10 +170,10 @@ func TestGrovePiSomeRead(t *testing.T) {
 			// assert
 			assert.Equal(t, tc.wantErr, err)
 			assert.Equal(t, tc.wantWritten, a.written)
-			assert.Equal(t, len(tc.simResponse), numCallsRead)
+			assert.Len(t, tc.simResponse, numCallsRead)
 			assert.Equal(t, tc.wantResult, got)
-			assert.Equal(t, tc.wantResultF1, gotF1)
-			assert.Equal(t, tc.wantResultF2, gotF2)
+			assert.InDelta(t, tc.wantResultF1, gotF1, 0.0)
+			assert.InDelta(t, tc.wantResultF2, gotF2, 0.0)
 			assert.Equal(t, tc.wantResultString, gotString)
 		})
 	}
@@ -211,15 +213,15 @@ func TestGrovePiSomeWrite(t *testing.T) {
 			// act
 			switch name {
 			case "DigitalWrite":
-				err = g.DigitalWrite(fmt.Sprintf("%d", tc.usedPin), byte(tc.usedValue))
+				err = g.DigitalWrite(strconv.Itoa(tc.usedPin), byte(tc.usedValue))
 			case "AnalogWrite":
-				err = g.AnalogWrite(fmt.Sprintf("%d", tc.usedPin), tc.usedValue)
+				err = g.AnalogWrite(strconv.Itoa(tc.usedPin), tc.usedValue)
 			default:
 				t.Errorf("unknown command %s", name)
 				return
 			}
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.wantWritten, a.written)
 		})
 	}

--- a/drivers/i2c/hmc5883l_driver_test.go
+++ b/drivers/i2c/hmc5883l_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -30,7 +31,7 @@ func TestNewHMC5883LDriver(t *testing.T) {
 	assert.Equal(t, uint32(15000), d.outputRate)
 	assert.Equal(t, int8(0), d.applyBias)
 	assert.Equal(t, 0, d.measurementMode)
-	assert.Equal(t, 390.0, d.gain)
+	assert.InDelta(t, 390.0, d.gain, 0.0)
 }
 
 func TestHMC5883LOptions(t *testing.T) {
@@ -56,7 +57,7 @@ func TestHMC5883LWithHMC5883LApplyBias(t *testing.T) {
 func TestHMC5883LWithHMC5883LGain(t *testing.T) {
 	d := NewHMC5883LDriver(newI2cTestAdaptor())
 	WithHMC5883LGain(230)(d)
-	assert.Equal(t, 230.0, d.gain)
+	assert.InDelta(t, 230.0, d.gain, 0.0)
 }
 
 func TestHMC5883LRead(t *testing.T) {
@@ -121,10 +122,10 @@ func TestHMC5883LRead(t *testing.T) {
 			// act
 			gotX, gotY, gotZ, err := d.Read()
 			// assert
-			assert.NoError(t, err)
-			assert.Equal(t, tc.wantX, gotX)
-			assert.Equal(t, tc.wantY, gotY)
-			assert.Equal(t, tc.wantZ, gotZ)
+			require.NoError(t, err)
+			assert.InDelta(t, tc.wantX, gotX, 0.0)
+			assert.InDelta(t, tc.wantY, gotY, 0.0)
+			assert.InDelta(t, tc.wantZ, gotZ, 0.0)
 		})
 	}
 }
@@ -177,12 +178,12 @@ func TestHMC5883L_readRawData(t *testing.T) {
 			// act
 			gotX, gotY, gotZ, err := d.readRawData()
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.wantX, gotX)
 			assert.Equal(t, tc.wantY, gotY)
 			assert.Equal(t, tc.wantZ, gotZ)
 			assert.Equal(t, 1, numCallsRead)
-			assert.Equal(t, 1, len(a.written))
+			assert.Len(t, a.written, 1)
 			assert.Equal(t, uint8(hmc5883lAxisX), a.written[0])
 		})
 	}
@@ -203,8 +204,8 @@ func TestHMC5883L_initialize(t *testing.T) {
 	// act, assert - initialize() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 6, len(a.written))
+	require.NoError(t, err)
+	assert.Len(t, a.written, 6)
 	assert.Equal(t, uint8(hmc5883lRegA), a.written[0])
 	assert.Equal(t, wantRegA, a.written[1])
 	assert.Equal(t, uint8(hmc5883lRegB), a.written[2])

--- a/drivers/i2c/hmc6352_driver_test.go
+++ b/drivers/i2c/hmc6352_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -42,12 +43,12 @@ func TestHMC6352Options(t *testing.T) {
 
 func TestHMC6352Start(t *testing.T) {
 	d := NewHMC6352Driver(newI2cTestAdaptor())
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestHMC6352Halt(t *testing.T) {
 	d, _ := initTestHMC6352DriverWithStubbedAdaptor()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestHMC6352Heading(t *testing.T) {
@@ -80,7 +81,7 @@ func TestHMC6352Heading(t *testing.T) {
 
 	heading, err = d.Heading()
 	assert.Equal(t, uint16(0), heading)
-	assert.ErrorContains(t, err, "read error")
+	require.ErrorContains(t, err, "read error")
 
 	// when write error
 	d, a = initTestHMC6352DriverWithStubbedAdaptor()
@@ -90,5 +91,5 @@ func TestHMC6352Heading(t *testing.T) {
 
 	heading, err = d.Heading()
 	assert.Equal(t, uint16(0), heading)
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 }

--- a/drivers/i2c/i2c_connection_test.go
+++ b/drivers/i2c/i2c_connection_test.go
@@ -8,6 +8,7 @@ import (
 	"unsafe"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/system"
 )
@@ -77,7 +78,7 @@ func TestI2CAddress(t *testing.T) {
 
 func TestI2CClose(t *testing.T) {
 	c := NewConnection(initI2CDevice(), 0x06)
-	assert.NoError(t, c.Close())
+	require.NoError(t, c.Close())
 }
 
 func TestI2CRead(t *testing.T) {
@@ -89,7 +90,7 @@ func TestI2CRead(t *testing.T) {
 func TestI2CReadAddressError(t *testing.T) {
 	c := NewConnection(initI2CDeviceAddressError(), 0x06)
 	_, err := c.Read([]byte{})
-	assert.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
+	require.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
 }
 
 func TestI2CWrite(t *testing.T) {
@@ -101,7 +102,7 @@ func TestI2CWrite(t *testing.T) {
 func TestI2CWriteAddressError(t *testing.T) {
 	c := NewConnection(initI2CDeviceAddressError(), 0x06)
 	_, err := c.Write([]byte{0x01})
-	assert.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
+	require.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
 }
 
 func TestI2CReadByte(t *testing.T) {
@@ -113,7 +114,7 @@ func TestI2CReadByte(t *testing.T) {
 func TestI2CReadByteAddressError(t *testing.T) {
 	c := NewConnection(initI2CDeviceAddressError(), 0x06)
 	_, err := c.ReadByte()
-	assert.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
+	require.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
 }
 
 func TestI2CReadByteData(t *testing.T) {
@@ -125,7 +126,7 @@ func TestI2CReadByteData(t *testing.T) {
 func TestI2CReadByteDataAddressError(t *testing.T) {
 	c := NewConnection(initI2CDeviceAddressError(), 0x06)
 	_, err := c.ReadByteData(0x01)
-	assert.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
+	require.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
 }
 
 func TestI2CReadWordData(t *testing.T) {
@@ -137,65 +138,65 @@ func TestI2CReadWordData(t *testing.T) {
 func TestI2CReadWordDataAddressError(t *testing.T) {
 	c := NewConnection(initI2CDeviceAddressError(), 0x06)
 	_, err := c.ReadWordData(0x01)
-	assert.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
+	require.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
 }
 
 func TestI2CWriteByte(t *testing.T) {
 	c := NewConnection(initI2CDevice(), 0x06)
 	err := c.WriteByte(0x01)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestI2CWriteByteAddressError(t *testing.T) {
 	c := NewConnection(initI2CDeviceAddressError(), 0x06)
 	err := c.WriteByte(0x01)
-	assert.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
+	require.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
 }
 
 func TestI2CWriteByteData(t *testing.T) {
 	c := NewConnection(initI2CDevice(), 0x06)
 	err := c.WriteByteData(0x01, 0x01)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestI2CWriteByteDataAddressError(t *testing.T) {
 	c := NewConnection(initI2CDeviceAddressError(), 0x06)
 	err := c.WriteByteData(0x01, 0x01)
-	assert.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
+	require.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
 }
 
 func TestI2CWriteWordData(t *testing.T) {
 	c := NewConnection(initI2CDevice(), 0x06)
 	err := c.WriteWordData(0x01, 0x01)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestI2CWriteWordDataAddressError(t *testing.T) {
 	c := NewConnection(initI2CDeviceAddressError(), 0x06)
 	err := c.WriteWordData(0x01, 0x01)
-	assert.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
+	require.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
 }
 
 func TestI2CWriteBlockData(t *testing.T) {
 	c := NewConnection(initI2CDevice(), 0x06)
 	err := c.WriteBlockData(0x01, []byte{0x01, 0x02})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestI2CWriteBlockDataAddressError(t *testing.T) {
 	c := NewConnection(initI2CDeviceAddressError(), 0x06)
 	err := c.WriteBlockData(0x01, []byte{0x01, 0x02})
-	assert.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
+	require.ErrorContains(t, err, "Setting address failed with syscall.Errno operation not permitted")
 }
 
 func Test_setBit(t *testing.T) {
-	var expectedVal uint8 = 129
-	actualVal := setBit(1, 7)
-	assert.Equal(t, actualVal, expectedVal)
+	var wantVal uint8 = 129
+	gotVal := setBit(1, 7)
+	assert.Equal(t, wantVal, gotVal)
 }
 
 func Test_clearBit(t *testing.T) {
-	var expectedVal uint8
-	actualVal := clearBit(128, 7)
-	assert.Equal(t, actualVal, expectedVal)
+	var wantVal uint8
+	gotVal := clearBit(128, 7)
+	assert.Equal(t, wantVal, gotVal)
 }

--- a/drivers/i2c/i2c_driver_test.go
+++ b/drivers/i2c/i2c_driver_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -34,8 +35,8 @@ func TestNewDriver(t *testing.T) {
 	assert.Equal(t, 0x15, d.defaultAddress)
 	assert.Equal(t, a, d.connector)
 	assert.Nil(t, d.connection)
-	assert.NoError(t, d.afterStart())
-	assert.NoError(t, d.beforeHalt())
+	require.NoError(t, d.afterStart())
+	require.NoError(t, d.beforeHalt())
 	assert.NotNil(t, d.Config)
 	assert.NotNil(t, d.Commander)
 	assert.NotNil(t, d.mutex)
@@ -61,8 +62,8 @@ func TestStart(t *testing.T) {
 	// arrange
 	d, a := initDriverWithStubbedAdaptor()
 	// act, assert
-	assert.NoError(t, d.Start())
-	assert.Equal(t, a.address, 0x15)
+	require.NoError(t, d.Start())
+	assert.Equal(t, 0x15, a.address)
 }
 
 func TestStartConnectError(t *testing.T) {
@@ -70,14 +71,14 @@ func TestStartConnectError(t *testing.T) {
 	d, a := initDriverWithStubbedAdaptor()
 	a.Testi2cConnectErr(true)
 	// act, assert
-	assert.ErrorContains(t, d.Start(), "Invalid i2c connection")
+	require.ErrorContains(t, d.Start(), "Invalid i2c connection")
 }
 
 func TestHalt(t *testing.T) {
 	// arrange
 	d := initTestDriver()
 	// act, assert
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestWrite(t *testing.T) {
@@ -98,7 +99,7 @@ func TestWrite(t *testing.T) {
 	// act
 	err := d.Write(address, value)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, numCallsWrite)
 	assert.Equal(t, wantAddress, a.written[0])
 	assert.Equal(t, uint8(value), a.written[1])
@@ -129,7 +130,7 @@ func TestRead(t *testing.T) {
 	// act
 	val, err := d.Read(address)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int(want), val)
 	assert.Equal(t, 1, numCallsWrite)
 	assert.Equal(t, wantAddress, a.written[0])

--- a/drivers/i2c/ina3221_driver_test.go
+++ b/drivers/i2c/ina3221_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -42,12 +43,12 @@ func TestINA3221Options(t *testing.T) {
 
 func TestINA3221Start(t *testing.T) {
 	d := NewINA3221Driver(newI2cTestAdaptor())
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestINA3221Halt(t *testing.T) {
 	d, _ := initTestINA3221DriverWithStubbedAdaptor()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestINA3221GetBusVoltage(t *testing.T) {
@@ -59,8 +60,8 @@ func TestINA3221GetBusVoltage(t *testing.T) {
 	}
 
 	v, err := d.GetBusVoltage(INA3221Channel1)
-	assert.Equal(t, float64(13.928), v)
-	assert.NoError(t, err)
+	assert.InDelta(t, float64(13.928), v, 0.0)
+	require.NoError(t, err)
 }
 
 func TestINA3221GetBusVoltageReadError(t *testing.T) {
@@ -70,7 +71,7 @@ func TestINA3221GetBusVoltageReadError(t *testing.T) {
 	}
 
 	_, err := d.GetBusVoltage(INA3221Channel1)
-	assert.ErrorContains(t, err, "read error")
+	require.ErrorContains(t, err, "read error")
 }
 
 func TestINA3221GetShuntVoltage(t *testing.T) {
@@ -82,8 +83,8 @@ func TestINA3221GetShuntVoltage(t *testing.T) {
 	}
 
 	v, err := d.GetShuntVoltage(INA3221Channel1)
-	assert.Equal(t, float64(7.48), v)
-	assert.NoError(t, err)
+	assert.InDelta(t, float64(7.48), v, 0.0)
+	require.NoError(t, err)
 }
 
 func TestINA3221GetShuntVoltageReadError(t *testing.T) {
@@ -93,7 +94,7 @@ func TestINA3221GetShuntVoltageReadError(t *testing.T) {
 	}
 
 	_, err := d.GetShuntVoltage(INA3221Channel1)
-	assert.ErrorContains(t, err, "read error")
+	require.ErrorContains(t, err, "read error")
 }
 
 func TestINA3221GetCurrent(t *testing.T) {
@@ -105,8 +106,8 @@ func TestINA3221GetCurrent(t *testing.T) {
 	}
 
 	v, err := d.GetCurrent(INA3221Channel1)
-	assert.Equal(t, float64(74.8), v)
-	assert.NoError(t, err)
+	assert.InDelta(t, float64(74.8), v, 0.0)
+	require.NoError(t, err)
 }
 
 func TestINA3221CurrentReadError(t *testing.T) {
@@ -116,7 +117,7 @@ func TestINA3221CurrentReadError(t *testing.T) {
 	}
 
 	_, err := d.GetCurrent(INA3221Channel1)
-	assert.ErrorContains(t, err, "read error")
+	require.ErrorContains(t, err, "read error")
 }
 
 func TestINA3221GetLoadVoltage(t *testing.T) {
@@ -130,8 +131,8 @@ func TestINA3221GetLoadVoltage(t *testing.T) {
 	}
 
 	v, err := d.GetLoadVoltage(INA3221Channel2)
-	assert.Equal(t, float64(13.935480), v)
-	assert.NoError(t, err)
+	assert.InDelta(t, float64(13.935480), v, 0.0)
+	require.NoError(t, err)
 }
 
 func TestINA3221GetLoadVoltageReadError(t *testing.T) {
@@ -141,5 +142,5 @@ func TestINA3221GetLoadVoltageReadError(t *testing.T) {
 	}
 
 	_, err := d.GetLoadVoltage(INA3221Channel2)
-	assert.ErrorContains(t, err, "read error")
+	require.ErrorContains(t, err, "read error")
 }

--- a/drivers/i2c/jhd1313m1_driver_test.go
+++ b/drivers/i2c/jhd1313m1_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -54,13 +55,13 @@ func TestJHD1313MDriverOptions(t *testing.T) {
 
 func TestJHD1313MDriverStart(t *testing.T) {
 	d := initTestJHD1313M1Driver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestJHD1313MStartConnectError(t *testing.T) {
 	d, adaptor := initTestJHD1313M1DriverWithStubbedAdaptor()
 	adaptor.Testi2cConnectErr(true)
-	assert.ErrorContains(t, d.Start(), "Invalid i2c connection")
+	require.ErrorContains(t, d.Start(), "Invalid i2c connection")
 }
 
 func TestJHD1313MDriverStartWriteError(t *testing.T) {
@@ -68,19 +69,19 @@ func TestJHD1313MDriverStartWriteError(t *testing.T) {
 	adaptor.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
-	assert.ErrorContains(t, d.Start(), "write error")
+	require.ErrorContains(t, d.Start(), "write error")
 }
 
 func TestJHD1313MDriverHalt(t *testing.T) {
 	d := initTestJHD1313M1Driver()
 	_ = d.Start()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestJHD1313MDriverSetRgb(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	_ = d.Start()
-	assert.NoError(t, d.SetRGB(0x00, 0x00, 0x00))
+	require.NoError(t, d.SetRGB(0x00, 0x00, 0x00))
 }
 
 func TestJHD1313MDriverSetRgbError(t *testing.T) {
@@ -90,13 +91,13 @@ func TestJHD1313MDriverSetRgbError(t *testing.T) {
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
-	assert.ErrorContains(t, d.SetRGB(0x00, 0x00, 0x00), "write error")
+	require.ErrorContains(t, d.SetRGB(0x00, 0x00, 0x00), "write error")
 }
 
 func TestJHD1313MDriverClear(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	_ = d.Start()
-	assert.NoError(t, d.Clear())
+	require.NoError(t, d.Clear())
 }
 
 func TestJHD1313MDriverClearError(t *testing.T) {
@@ -106,19 +107,19 @@ func TestJHD1313MDriverClearError(t *testing.T) {
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
-	assert.ErrorContains(t, d.Clear(), "write error")
+	require.ErrorContains(t, d.Clear(), "write error")
 }
 
 func TestJHD1313MDriverHome(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	_ = d.Start()
-	assert.NoError(t, d.Home())
+	require.NoError(t, d.Home())
 }
 
 func TestJHD1313MDriverWrite(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	_ = d.Start()
-	assert.NoError(t, d.Write("Hello"))
+	require.NoError(t, d.Write("Hello"))
 }
 
 func TestJHD1313MDriverWriteError(t *testing.T) {
@@ -128,13 +129,13 @@ func TestJHD1313MDriverWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 
-	assert.ErrorContains(t, d.Write("Hello"), "write error")
+	require.ErrorContains(t, d.Write("Hello"), "write error")
 }
 
 func TestJHD1313MDriverWriteTwoLines(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	_ = d.Start()
-	assert.NoError(t, d.Write("Hello\nthere"))
+	require.NoError(t, d.Write("Hello\nthere"))
 }
 
 func TestJHD1313MDriverWriteTwoLinesError(t *testing.T) {
@@ -144,19 +145,19 @@ func TestJHD1313MDriverWriteTwoLinesError(t *testing.T) {
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
-	assert.ErrorContains(t, d.Write("Hello\nthere"), "write error")
+	require.ErrorContains(t, d.Write("Hello\nthere"), "write error")
 }
 
 func TestJHD1313MDriverSetPosition(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	_ = d.Start()
-	assert.NoError(t, d.SetPosition(2))
+	require.NoError(t, d.SetPosition(2))
 }
 
 func TestJHD1313MDriverSetSecondLinePosition(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	_ = d.Start()
-	assert.NoError(t, d.SetPosition(18))
+	require.NoError(t, d.SetPosition(18))
 }
 
 func TestJHD1313MDriverSetPositionInvalid(t *testing.T) {
@@ -169,27 +170,27 @@ func TestJHD1313MDriverSetPositionInvalid(t *testing.T) {
 func TestJHD1313MDriverScroll(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	_ = d.Start()
-	assert.NoError(t, d.Scroll(true))
+	require.NoError(t, d.Scroll(true))
 }
 
 func TestJHD1313MDriverReverseScroll(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	_ = d.Start()
-	assert.NoError(t, d.Scroll(false))
+	require.NoError(t, d.Scroll(false))
 }
 
 func TestJHD1313MDriverSetCustomChar(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	data := [8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 	_ = d.Start()
-	assert.NoError(t, d.SetCustomChar(0, data))
+	require.NoError(t, d.SetCustomChar(0, data))
 }
 
 func TestJHD1313MDriverSetCustomCharError(t *testing.T) {
 	d, _ := initTestJHD1313M1DriverWithStubbedAdaptor()
 	data := [8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 	_ = d.Start()
-	assert.ErrorContains(t, d.SetCustomChar(10, data), "can't set a custom character at a position greater than 7")
+	require.ErrorContains(t, d.SetCustomChar(10, data), "can't set a custom character at a position greater than 7")
 }
 
 func TestJHD1313MDriverSetCustomCharWriteError(t *testing.T) {
@@ -200,7 +201,7 @@ func TestJHD1313MDriverSetCustomCharWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	data := [8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
-	assert.ErrorContains(t, d.SetCustomChar(0, data), "write error")
+	require.ErrorContains(t, d.SetCustomChar(0, data), "write error")
 }
 
 func TestJHD1313MDriverCommands(t *testing.T) {

--- a/drivers/i2c/l3gd20h_driver_test.go
+++ b/drivers/i2c/l3gd20h_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -130,8 +131,8 @@ func TestL3GD20HFullScaleRange(t *testing.T) {
 	// act
 	got, err := d.FullScaleRange()
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(a.written))
+	require.NoError(t, err)
+	assert.Len(t, a.written, 1)
 	assert.Equal(t, uint8(0x23), a.written[0])
 	assert.Equal(t, readValue, got)
 }
@@ -196,12 +197,12 @@ func TestL3GD20HMeasurement(t *testing.T) {
 			// act
 			x, y, z, err := d.XYZ()
 			// assert
-			assert.NoError(t, err)
-			assert.Equal(t, 1, len(a.written))
+			require.NoError(t, err)
+			assert.Len(t, a.written, 1)
 			assert.Equal(t, uint8(0xA8), a.written[0])
-			assert.Equal(t, tc.wantX, x)
-			assert.Equal(t, tc.wantY, y)
-			assert.Equal(t, tc.wantZ, z)
+			assert.InDelta(t, tc.wantX, x, 0.0)
+			assert.InDelta(t, tc.wantY, y, 0.0)
+			assert.InDelta(t, tc.wantZ, z, 0.0)
 		})
 	}
 }
@@ -214,7 +215,7 @@ func TestL3GD20HMeasurementError(t *testing.T) {
 
 	_ = d.Start()
 	_, _, _, err := d.XYZ()
-	assert.ErrorContains(t, err, "read error")
+	require.ErrorContains(t, err, "read error")
 }
 
 func TestL3GD20HMeasurementWriteError(t *testing.T) {
@@ -223,7 +224,7 @@ func TestL3GD20HMeasurementWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	_, _, _, err := d.XYZ()
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 }
 
 func TestL3GD20H_initialize(t *testing.T) {
@@ -250,7 +251,7 @@ func TestL3GD20H_initialize(t *testing.T) {
 	// arrange, act - initialize() must be called on Start()
 	_, a := initL3GD20HWithStubbedAdaptor()
 	// assert
-	assert.Equal(t, 6, len(a.written))
+	assert.Len(t, a.written, 6)
 	assert.Equal(t, uint8(0x20), a.written[0])
 	assert.Equal(t, uint8(0x00), a.written[1])
 	assert.Equal(t, uint8(0x20), a.written[2])

--- a/drivers/i2c/lidarlite_driver_test.go
+++ b/drivers/i2c/lidarlite_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -48,12 +49,12 @@ func TestLIDARLiteDriverOptions(t *testing.T) {
 
 func TestLIDARLiteDriverStart(t *testing.T) {
 	d := NewLIDARLiteDriver(newI2cTestAdaptor())
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestLIDARLiteDriverHalt(t *testing.T) {
 	d := initTestLIDARLiteDriver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestLIDARLiteDriverDistance(t *testing.T) {
@@ -72,7 +73,7 @@ func TestLIDARLiteDriverDistance(t *testing.T) {
 
 	distance, err := d.Distance()
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int(25345), distance)
 
 	// when insufficient bytes have been read
@@ -93,7 +94,7 @@ func TestLIDARLiteDriverDistance(t *testing.T) {
 
 	distance, err = d.Distance()
 	assert.Equal(t, int(0), distance)
-	assert.ErrorContains(t, err, "read error")
+	require.ErrorContains(t, err, "read error")
 }
 
 func TestLIDARLiteDriverDistanceError1(t *testing.T) {
@@ -104,7 +105,7 @@ func TestLIDARLiteDriverDistanceError1(t *testing.T) {
 
 	distance, err := d.Distance()
 	assert.Equal(t, int(0), distance)
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 }
 
 func TestLIDARLiteDriverDistanceError2(t *testing.T) {
@@ -118,7 +119,7 @@ func TestLIDARLiteDriverDistanceError2(t *testing.T) {
 
 	distance, err := d.Distance()
 	assert.Equal(t, int(0), distance)
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 }
 
 func TestLIDARLiteDriverDistanceError3(t *testing.T) {
@@ -138,5 +139,5 @@ func TestLIDARLiteDriverDistanceError3(t *testing.T) {
 
 	distance, err := d.Distance()
 	assert.Equal(t, int(0), distance)
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 }

--- a/drivers/i2c/mcp23017_driver_test.go
+++ b/drivers/i2c/mcp23017_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -147,8 +148,8 @@ func TestMCP23017WriteGPIO(t *testing.T) {
 		// act
 		err := d.WriteGPIO(testPin, testPort, uint8(bitState))
 		// assert
-		assert.NoError(t, err)
-		assert.Equal(t, 6, len(a.written))
+		require.NoError(t, err)
+		assert.Len(t, a.written, 6)
 		assert.Equal(t, wantReg1, a.written[0])
 		assert.Equal(t, wantReg1, a.written[1])
 		assert.Equal(t, wantReg1Val, a.written[2])
@@ -186,8 +187,8 @@ func TestMCP23017WriteGPIONoRefresh(t *testing.T) {
 		// act
 		err := d.WriteGPIO(testPin, testPort, uint8(bitState))
 		// assert
-		assert.NoError(t, err)
-		assert.Equal(t, 2, len(a.written))
+		require.NoError(t, err)
+		assert.Len(t, a.written, 2)
 		assert.Equal(t, wantReg1, a.written[0])
 		assert.Equal(t, wantReg2, a.written[1])
 		assert.Equal(t, 2, numCallsRead)
@@ -223,8 +224,8 @@ func TestMCP23017WriteGPIONoAutoDir(t *testing.T) {
 		// act
 		err := d.WriteGPIO(testPin, testPort, uint8(bitState))
 		// assert
-		assert.NoError(t, err)
-		assert.Equal(t, 3, len(a.written))
+		require.NoError(t, err)
+		assert.Len(t, a.written, 3)
 		assert.Equal(t, wantReg, a.written[0])
 		assert.Equal(t, wantReg, a.written[1])
 		assert.Equal(t, wantRegVal, a.written[2])
@@ -241,7 +242,7 @@ func TestMCP23017CommandsWriteGPIOErrIODIR(t *testing.T) {
 	// act
 	err := d.WriteGPIO(7, "A", 0)
 	// assert
-	assert.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=0): write error")
+	require.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=0): write error")
 }
 
 func TestMCP23017CommandsWriteGPIOErrOLAT(t *testing.T) {
@@ -258,7 +259,7 @@ func TestMCP23017CommandsWriteGPIOErrOLAT(t *testing.T) {
 	// act
 	err := d.WriteGPIO(7, "A", 0)
 	// assert
-	assert.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=20): write error")
+	require.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=20): write error")
 }
 
 func TestMCP23017ReadGPIO(t *testing.T) {
@@ -290,9 +291,9 @@ func TestMCP23017ReadGPIO(t *testing.T) {
 		// act
 		val, err := d.ReadGPIO(testPin, testPort)
 		// assert
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, 2, numCallsRead)
-		assert.Equal(t, 4, len(a.written))
+		assert.Len(t, a.written, 4)
 		assert.Equal(t, wantReg1, a.written[0])
 		assert.Equal(t, wantReg1, a.written[1])
 		assert.Equal(t, wantReg1Val, a.written[2])
@@ -328,9 +329,9 @@ func TestMCP23017ReadGPIONoRefresh(t *testing.T) {
 		// act
 		val, err := d.ReadGPIO(testPin, testPort)
 		// assert
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, 2, numCallsRead)
-		assert.Equal(t, 2, len(a.written))
+		assert.Len(t, a.written, 2)
 		assert.Equal(t, wantReg1, a.written[0])
 		assert.Equal(t, wantReg2, a.written[1])
 		assert.Equal(t, uint8(bitState), val)
@@ -363,9 +364,9 @@ func TestMCP23017ReadGPIONoAutoDir(t *testing.T) {
 		// act
 		val, err := d.ReadGPIO(testPin, testPort)
 		// assert
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, 1, numCallsRead)
-		assert.Equal(t, 1, len(a.written))
+		assert.Len(t, a.written, 1)
 		assert.Equal(t, wantReg2, a.written[0])
 		assert.Equal(t, uint8(bitState), val)
 	}
@@ -381,7 +382,7 @@ func TestMCP23017ReadGPIOErr(t *testing.T) {
 	// act
 	_, err := d.ReadGPIO(7, "A")
 	// assert
-	assert.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=0): read error")
+	require.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=0): read error")
 }
 
 func TestMCP23017SetPinMode(t *testing.T) {
@@ -413,8 +414,8 @@ func TestMCP23017SetPinMode(t *testing.T) {
 		// act
 		err := d.SetPinMode(testPin, testPort, uint8(bitState))
 		// assert
-		assert.NoError(t, err)
-		assert.Equal(t, 3, len(a.written))
+		require.NoError(t, err)
+		assert.Len(t, a.written, 3)
 		assert.Equal(t, wantReg, a.written[0])
 		assert.Equal(t, wantReg, a.written[1])
 		assert.Equal(t, wantRegVal, a.written[2])
@@ -431,7 +432,7 @@ func TestMCP23017SetPinModeErr(t *testing.T) {
 	// act
 	err := d.SetPinMode(7, "A", 0)
 	// assert
-	assert.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=0): write error")
+	require.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=0): write error")
 }
 
 func TestMCP23017SetPullUp(t *testing.T) {
@@ -463,8 +464,8 @@ func TestMCP23017SetPullUp(t *testing.T) {
 		// act
 		err := d.SetPullUp(testPin, testPort, uint8(bitState))
 		// assert
-		assert.NoError(t, err)
-		assert.Equal(t, 3, len(a.written))
+		require.NoError(t, err)
+		assert.Len(t, a.written, 3)
 		assert.Equal(t, wantReg, a.written[0])
 		assert.Equal(t, wantReg, a.written[1])
 		assert.Equal(t, wantSetVal, a.written[2])
@@ -481,7 +482,7 @@ func TestMCP23017SetPullUpErr(t *testing.T) {
 	// act
 	err := d.SetPullUp(7, "A", 0)
 	// assert
-	assert.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=12): write error")
+	require.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=12): write error")
 }
 
 func TestMCP23017SetGPIOPolarity(t *testing.T) {
@@ -513,8 +514,8 @@ func TestMCP23017SetGPIOPolarity(t *testing.T) {
 		// act
 		err := d.SetGPIOPolarity(testPin, testPort, uint8(bitState))
 		// assert
-		assert.NoError(t, err)
-		assert.Equal(t, 3, len(a.written))
+		require.NoError(t, err)
+		assert.Len(t, a.written, 3)
 		assert.Equal(t, wantReg, a.written[0])
 		assert.Equal(t, wantReg, a.written[1])
 		assert.Equal(t, wantSetVal, a.written[2])
@@ -531,7 +532,7 @@ func TestMCP23017SetGPIOPolarityErr(t *testing.T) {
 	// act
 	err := d.SetGPIOPolarity(7, "A", 0)
 	// assert
-	assert.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=2): write error")
+	require.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=2): write error")
 }
 
 func TestMCP23017_write(t *testing.T) {
@@ -539,13 +540,13 @@ func TestMCP23017_write(t *testing.T) {
 	d, _ := initTestMCP23017WithStubbedAdaptor(0)
 	port := d.getPort("A")
 	err := d.write(port.IODIR, uint8(7), 0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// set bit
 	d, _ = initTestMCP23017WithStubbedAdaptor(0)
 	port = d.getPort("B")
 	err = d.write(port.IODIR, uint8(7), 1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// write error
 	d, a := initTestMCP23017WithStubbedAdaptor(0)
@@ -553,7 +554,7 @@ func TestMCP23017_write(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	err = d.write(port.IODIR, uint8(7), 0)
-	assert.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=1): write error")
+	require.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=1): write error")
 
 	// read error
 	d, a = initTestMCP23017WithStubbedAdaptor(0)
@@ -561,12 +562,12 @@ func TestMCP23017_write(t *testing.T) {
 		return len(b), errors.New("read error")
 	}
 	err = d.write(port.IODIR, uint8(7), 0)
-	assert.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=1): read error")
+	require.ErrorContains(t, err, "MCP write-read: MCP write-ReadByteData(reg=1): read error")
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		return len(b), nil
 	}
 	err = d.write(port.IODIR, uint8(7), 1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestMCP23017_read(t *testing.T) {
@@ -588,7 +589,7 @@ func TestMCP23017_read(t *testing.T) {
 
 	val, err := d.read(port.IODIR)
 	assert.Equal(t, uint8(0), val)
-	assert.ErrorContains(t, err, "MCP write-ReadByteData(reg=0): read error")
+	require.ErrorContains(t, err, "MCP write-ReadByteData(reg=0): read error")
 
 	// read
 	d, a = initTestMCP23017WithStubbedAdaptor(0)
@@ -604,25 +605,25 @@ func TestMCP23017_read(t *testing.T) {
 func TestMCP23017_getPort(t *testing.T) {
 	// port A
 	d := initTestMCP23017(0)
-	expectedPort := mcp23017GetBank(0).portA
-	actualPort := d.getPort("A")
-	assert.Equal(t, actualPort, expectedPort)
+	wantPort := mcp23017GetBank(0).portA
+	gotPort := d.getPort("A")
+	assert.Equal(t, wantPort, gotPort)
 
 	// port B
 	d = initTestMCP23017(0)
-	expectedPort = mcp23017GetBank(0).portB
-	actualPort = d.getPort("B")
-	assert.Equal(t, actualPort, expectedPort)
+	wantPort = mcp23017GetBank(0).portB
+	gotPort = d.getPort("B")
+	assert.Equal(t, wantPort, gotPort)
 
 	// default
 	d = initTestMCP23017(0)
-	expectedPort = mcp23017GetBank(0).portA
-	actualPort = d.getPort("")
-	assert.Equal(t, actualPort, expectedPort)
+	wantPort = mcp23017GetBank(0).portA
+	gotPort = d.getPort("")
+	assert.Equal(t, wantPort, gotPort)
 
 	// port A bank 1
 	d = initTestMCP23017(1)
-	expectedPort = mcp23017GetBank(1).portA
-	actualPort = d.getPort("")
-	assert.Equal(t, actualPort, expectedPort)
+	wantPort = mcp23017GetBank(1).portA
+	gotPort = d.getPort("")
+	assert.Equal(t, wantPort, gotPort)
 }

--- a/drivers/i2c/mma7660_driver_test.go
+++ b/drivers/i2c/mma7660_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -43,29 +44,29 @@ func TestMMA7660Options(t *testing.T) {
 
 func TestMMA7660Start(t *testing.T) {
 	d := NewMMA7660Driver(newI2cTestAdaptor())
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestMMA7660Halt(t *testing.T) {
 	d, _ := initTestMMA7660DriverWithStubbedAdaptor()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestMMA7660Acceleration(t *testing.T) {
 	d, _ := initTestMMA7660DriverWithStubbedAdaptor()
 	x, y, z := d.Acceleration(21.0, 21.0, 21.0)
-	assert.Equal(t, 1.0, x)
-	assert.Equal(t, 1.0, y)
-	assert.Equal(t, 1.0, z)
+	assert.InDelta(t, 1.0, x, 0.0)
+	assert.InDelta(t, 1.0, y, 0.0)
+	assert.InDelta(t, 1.0, z, 0.0)
 }
 
 func TestMMA7660NullXYZ(t *testing.T) {
 	d, _ := initTestMMA7660DriverWithStubbedAdaptor()
 
 	x, y, z, _ := d.XYZ()
-	assert.Equal(t, 0.0, x)
-	assert.Equal(t, 0.0, y)
-	assert.Equal(t, 0.0, z)
+	assert.InDelta(t, 0.0, x, 0.0)
+	assert.InDelta(t, 0.0, y, 0.0)
+	assert.InDelta(t, 0.0, z, 0.0)
 }
 
 func TestMMA7660XYZ(t *testing.T) {
@@ -78,9 +79,9 @@ func TestMMA7660XYZ(t *testing.T) {
 	}
 
 	x, y, z, _ := d.XYZ()
-	assert.Equal(t, 17.0, x)
-	assert.Equal(t, 18.0, y)
-	assert.Equal(t, 19.0, z)
+	assert.InDelta(t, 17.0, x, 0.0)
+	assert.InDelta(t, 18.0, y, 0.0)
+	assert.InDelta(t, 19.0, z, 0.0)
 }
 
 func TestMMA7660XYZError(t *testing.T) {
@@ -90,7 +91,7 @@ func TestMMA7660XYZError(t *testing.T) {
 	}
 
 	_, _, _, err := d.XYZ()
-	assert.ErrorContains(t, err, "read error")
+	require.ErrorContains(t, err, "read error")
 }
 
 func TestMMA7660XYZNotReady(t *testing.T) {

--- a/drivers/i2c/mpl115a2_driver_test.go
+++ b/drivers/i2c/mpl115a2_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -78,18 +79,18 @@ func TestMPL115A2ReadData(t *testing.T) {
 	press, errP := d.Pressure()
 	temp, errT := d.Temperature()
 	// assert
-	assert.NoError(t, errP)
-	assert.NoError(t, errT)
+	require.NoError(t, errP)
+	require.NoError(t, errT)
 	assert.Equal(t, 2, readCallCounter)
-	assert.Equal(t, 6, len(a.written))
+	assert.Len(t, a.written, 6)
 	assert.Equal(t, uint8(0x12), a.written[0])
 	assert.Equal(t, uint8(0x00), a.written[1])
 	assert.Equal(t, uint8(0x00), a.written[2])
 	assert.Equal(t, uint8(0x12), a.written[3])
 	assert.Equal(t, uint8(0x00), a.written[4])
 	assert.Equal(t, uint8(0x00), a.written[5])
-	assert.Equal(t, float32(96.585915), press)
-	assert.Equal(t, float32(23.317757), temp)
+	assert.InDelta(t, float32(96.585915), press, 0.0)
+	assert.InDelta(t, float32(23.317757), temp, 0.0)
 }
 
 func TestMPL115A2ReadDataError(t *testing.T) {
@@ -101,7 +102,7 @@ func TestMPL115A2ReadDataError(t *testing.T) {
 	}
 	_, err := d.Pressure()
 
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 }
 
 func TestMPL115A2_initialization(t *testing.T) {
@@ -124,12 +125,12 @@ func TestMPL115A2_initialization(t *testing.T) {
 	// act, assert - initialization() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, readCallCounter)
-	assert.Equal(t, 1, len(a.written))
+	assert.Len(t, a.written, 1)
 	assert.Equal(t, uint8(0x04), a.written[0])
-	assert.Equal(t, float32(2009.75), d.a0)
-	assert.Equal(t, float32(-2.3758545), d.b1)
-	assert.Equal(t, float32(-0.9204712), d.b2)
-	assert.Equal(t, float32(0.0007901192), d.c12)
+	assert.InDelta(t, float32(2009.75), d.a0, 0.0)
+	assert.InDelta(t, float32(-2.3758545), d.b1, 0.0)
+	assert.InDelta(t, float32(-0.9204712), d.b2, 0.0)
+	assert.InDelta(t, float32(0.0007901192), d.c12, 0.0)
 }

--- a/drivers/i2c/mpu6050_driver_test.go
+++ b/drivers/i2c/mpu6050_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -36,7 +37,7 @@ func TestNewMPU6050Driver(t *testing.T) {
 	assert.Equal(t, MPU6050AccelFsConfig(0x00), d.accelFs)
 	assert.Equal(t, MPU6050GyroFsConfig(0x00), d.gyroFs)
 	assert.Equal(t, MPU6050Pwr1ClockConfig(0x01), d.clock)
-	assert.Equal(t, 9.80665, d.gravity)
+	assert.InDelta(t, 9.80665, d.gravity, 0.0)
 }
 
 func TestMPU6050Options(t *testing.T) {
@@ -69,7 +70,7 @@ func TestWithMPU6050ClockSource(t *testing.T) {
 
 func TestWithMPU6050Gravity(t *testing.T) {
 	d := NewMPU6050Driver(newI2cTestAdaptor(), WithMPU6050Gravity(1.0))
-	assert.Equal(t, 1.0, d.gravity)
+	assert.InDelta(t, 1.0, d.gravity, 0.0)
 }
 
 func TestMPU6050GetData(t *testing.T) {
@@ -113,7 +114,7 @@ func TestMPU6050GetData(t *testing.T) {
 	// assert
 	assert.Equal(t, wantAccel, d.Accelerometer)
 	assert.Equal(t, wantGyro, d.Gyroscope)
-	assert.Equal(t, wantTemp, d.Temperature)
+	assert.InDelta(t, wantTemp, d.Temperature, 0.0)
 }
 
 func TestMPU6050GetDataReadError(t *testing.T) {
@@ -124,7 +125,7 @@ func TestMPU6050GetDataReadError(t *testing.T) {
 		return 0, errors.New("read error")
 	}
 
-	assert.ErrorContains(t, d.GetData(), "read error")
+	require.ErrorContains(t, d.GetData(), "read error")
 }
 
 func TestMPU6050GetDataWriteError(t *testing.T) {
@@ -135,7 +136,7 @@ func TestMPU6050GetDataWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 
-	assert.ErrorContains(t, d.GetData(), "write error")
+	require.ErrorContains(t, d.GetData(), "write error")
 }
 
 func TestMPU6050_initialize(t *testing.T) {
@@ -172,9 +173,9 @@ func TestMPU6050_initialize(t *testing.T) {
 	// act, assert - initialize() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, readCallCounter)
-	assert.Equal(t, 13, len(a.written))
+	assert.Len(t, a.written, 13)
 	assert.Equal(t, uint8(0x6B), a.written[0])
 	assert.Equal(t, uint8(0x80), a.written[1])
 	assert.Equal(t, uint8(0x6B), a.written[2])

--- a/drivers/i2c/pca9501_driver_test.go
+++ b/drivers/i2c/pca9501_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -160,9 +161,9 @@ func TestPCA9501WriteGPIO(t *testing.T) {
 			// act
 			err := d.WriteGPIO(tc.pin, tc.setVal)
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, 2, numCallsRead)
-			assert.Equal(t, 2, len(a.written))
+			assert.Len(t, a.written, 2)
 			assert.Equal(t, tc.wantPin, a.written[0])
 			assert.Equal(t, tc.wantState, a.written[1])
 		})
@@ -193,7 +194,7 @@ func TestPCA9501WriteGPIOErrorAtWriteDirection(t *testing.T) {
 	err := d.WriteGPIO(7, 0)
 	// assert
 	assert.Equal(t, wantErr, err)
-	assert.True(t, numCallsRead < 2)
+	assert.Less(t, numCallsRead, 2)
 	assert.Equal(t, 1, numCallsWrite)
 }
 
@@ -254,10 +255,10 @@ func TestPCA9501ReadGPIO(t *testing.T) {
 			// act
 			got, err := d.ReadGPIO(pin)
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.want, got)
 			assert.Equal(t, 2, numCallsRead)
-			assert.Equal(t, 1, len(a.written))
+			assert.Len(t, a.written, 1)
 			assert.Equal(t, wantCtrlState, a.written[0])
 		})
 	}
@@ -334,7 +335,7 @@ func TestPCA9501WriteEEPROM(t *testing.T) {
 	// act
 	err := d.WriteEEPROM(addressEEPROM, want)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, numCallsWrite)
 	assert.Equal(t, addressEEPROM, a.written[0])
 	assert.Equal(t, want, a.written[1])
@@ -363,7 +364,7 @@ func TestPCA9501ReadEEPROM(t *testing.T) {
 	// act
 	val, err := d.ReadEEPROM(addressEEPROM)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, want, val)
 	assert.Equal(t, 1, numCallsWrite)
 	assert.Equal(t, addressEEPROM, a.written[0])
@@ -419,6 +420,6 @@ func TestPCA9501_initialize(t *testing.T) {
 	// act
 	err := d.initialize()
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, want, a.address)
 }

--- a/drivers/i2c/pca953x_driver_test.go
+++ b/drivers/i2c/pca953x_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -159,7 +160,7 @@ func TestPCA953xReadGPIO(t *testing.T) {
 			got, err := d.ReadGPIO(tc.idx)
 			// assert
 			assert.Equal(t, tc.wantErr, err)
-			assert.Equal(t, 1, len(a.written))
+			assert.Len(t, a.written, 1)
 			assert.Equal(t, wantReg, a.written[0])
 			assert.Equal(t, tc.want, got)
 		})
@@ -200,7 +201,7 @@ func TestPCA953xWritePeriod(t *testing.T) {
 			// act
 			err := d.WritePeriod(tc.idx, tc.val)
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.wantWritten, a.written)
 		})
 	}
@@ -251,7 +252,7 @@ func TestPCA953xReadPeriod(t *testing.T) {
 			got, err := d.ReadPeriod(tc.idx)
 			// assert
 			assert.Equal(t, tc.wantErr, err)
-			assert.Equal(t, tc.want, got)
+			assert.InDelta(t, tc.want, got, 0.0)
 			assert.Equal(t, tc.wantWritten, a.written)
 		})
 	}
@@ -291,7 +292,7 @@ func TestPCA953xWriteFrequency(t *testing.T) {
 			// act
 			err := d.WriteFrequency(tc.idx, tc.val)
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.wantWritten, a.written)
 		})
 	}
@@ -342,7 +343,7 @@ func TestPCA953xReadFrequency(t *testing.T) {
 			got, err := d.ReadFrequency(tc.idx)
 			// assert
 			assert.Equal(t, tc.wantErr, err)
-			assert.Equal(t, tc.want, got)
+			assert.InDelta(t, tc.want, got, 0.0)
 			assert.Equal(t, tc.wantWritten, a.written)
 		})
 	}
@@ -382,7 +383,7 @@ func TestPCA953xWriteDutyCyclePercent(t *testing.T) {
 			// act
 			err := d.WriteDutyCyclePercent(tc.idx, tc.val)
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.wantWritten, a.written)
 		})
 	}
@@ -433,7 +434,7 @@ func TestPCA953xReadDutyCyclePercent(t *testing.T) {
 			got, err := d.ReadDutyCyclePercent(tc.idx)
 			// assert
 			assert.Equal(t, tc.wantErr, err)
-			assert.Equal(t, tc.want, got)
+			assert.InDelta(t, tc.want, got, 0.0)
 			assert.Equal(t, tc.wantWritten, a.written)
 		})
 	}
@@ -465,12 +466,12 @@ func TestPCA953x_readRegister(t *testing.T) {
 	// act
 	val, err := d.readRegister(wantRegAddress)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, numCallsRead)
 	assert.Equal(t, 1, numCallsWrite)
 	assert.Equal(t, wantRegVal, val)
 	assert.Equal(t, wantReadByteCount, readByteCount)
-	assert.Equal(t, 1, len(a.written))
+	assert.Len(t, a.written, 1)
 	assert.Equal(t, uint8(wantRegAddress), a.written[0])
 }
 
@@ -491,10 +492,10 @@ func TestPCA953x_writeRegister(t *testing.T) {
 	// act
 	err := d.writeRegister(wantRegAddress, wantRegVal)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, numCallsWrite)
 	assert.Equal(t, 1, numCallsWrite)
-	assert.Equal(t, wantByteCount, len(a.written))
+	assert.Len(t, a.written, wantByteCount)
 	assert.Equal(t, uint8(wantRegAddress), a.written[0])
 	assert.Equal(t, wantRegVal, a.written[1])
 }
@@ -539,7 +540,7 @@ func TestPCA953x_pca953xCalcPeriod(t *testing.T) {
 			// act
 			val := pca953xCalcPeriod(tc.psc)
 			// assert
-			assert.Equal(t, tc.want, float32(math.Round(float64(val)*10000)/10000))
+			assert.InDelta(t, tc.want, float32(math.Round(float64(val)*10000)/10000), 0.0)
 		})
 	}
 }
@@ -585,7 +586,7 @@ func TestPCA953x_pca953xCalcDutyCyclePercent(t *testing.T) {
 			// act
 			val := pca953xCalcDutyCyclePercent(tc.pwm)
 			// assert
-			assert.Equal(t, tc.want, float32(math.Round(float64(val)*10)/10))
+			assert.InDelta(t, tc.want, float32(math.Round(float64(val)*10)/10), 0.0)
 		})
 	}
 }

--- a/drivers/i2c/pca9685_driver_test.go
+++ b/drivers/i2c/pca9685_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/gpio"
 )
@@ -57,7 +58,7 @@ func TestPCA9685Start(t *testing.T) {
 		return 1, nil
 	}
 	// act & assert
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestPCA9685StartError(t *testing.T) {
@@ -68,7 +69,7 @@ func TestPCA9685StartError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	// act & assert
-	assert.ErrorContains(t, d.Start(), "write error")
+	require.ErrorContains(t, d.Start(), "write error")
 }
 
 func TestPCA9685Halt(t *testing.T) {
@@ -78,9 +79,9 @@ func TestPCA9685Halt(t *testing.T) {
 	// act
 	err := d.Halt()
 	// assert
-	assert.NoError(t, err)
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(a.written))
+	require.NoError(t, err)
+	require.NoError(t, err)
+	assert.Len(t, a.written, 2)
 	assert.Equal(t, []byte{0xFD, 0x10}, a.written)
 }
 
@@ -91,7 +92,7 @@ func TestPCA9685HaltError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	// act & assert
-	assert.ErrorContains(t, d.Halt(), "write error")
+	require.ErrorContains(t, d.Halt(), "write error")
 }
 
 func TestPCA9685SetPWM(t *testing.T) {
@@ -126,8 +127,8 @@ func TestPCA9685SetPWM(t *testing.T) {
 			// act
 			err := d.SetPWM(tc.pin, tc.onCounts, tc.offCounts)
 			// assert
-			assert.NoError(t, err)
-			assert.Equal(t, 8, len(a.written))
+			require.NoError(t, err)
+			assert.Len(t, a.written, 8)
 			for writeIdx, wantVal := range tc.wantLedOnTimeOffTimeSet {
 				assert.Equal(t, wantVal, a.written[writeIdx], "index %d differs", writeIdx)
 			}
@@ -142,7 +143,7 @@ func TestPCA9685SetPWMError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	// act & assert
-	assert.ErrorContains(t, d.SetPWM(0, 0, 256), "write error")
+	require.ErrorContains(t, d.SetPWM(0, 0, 256), "write error")
 }
 
 func TestPCA9685SetAllPWM(t *testing.T) {
@@ -180,8 +181,8 @@ func TestPCA9685SetAllPWM(t *testing.T) {
 			// act
 			err := d.SetAllPWM(tc.onCounts, tc.offCounts)
 			// assert
-			assert.NoError(t, err)
-			assert.Equal(t, 8, len(a.written))
+			require.NoError(t, err)
+			assert.Len(t, a.written, 8)
 			for writeIdx, wantVal := range tc.wantLedOnTimeOffTimeSet {
 				assert.Equal(t, wantVal, a.written[writeIdx], "index %d differs", writeIdx)
 			}
@@ -196,7 +197,7 @@ func TestPCA9685SetAllPWMError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	// act & assert
-	assert.ErrorContains(t, d.SetAllPWM(0, 256), "write error")
+	require.ErrorContains(t, d.SetAllPWM(0, 256), "write error")
 }
 
 func TestPCA9685SetPWMFreq(t *testing.T) {
@@ -240,8 +241,8 @@ func TestPCA9685SetPWMFreq(t *testing.T) {
 			// act
 			err := d.SetPWMFreq(tc.freq)
 			// assert
-			assert.NoError(t, err)
-			assert.Equal(t, 9, len(a.written))
+			require.NoError(t, err)
+			assert.Len(t, a.written, 9)
 			var writeIdx int
 			// for read old mode:
 			assert.Equal(t, wantMode1SleepSequence[0], a.written[writeIdx], "index %d differs", writeIdx)
@@ -274,7 +275,7 @@ func TestPCA9685SetPWMFreqReadError(t *testing.T) {
 		return 0, errors.New("read error")
 	}
 	// act & assert
-	assert.ErrorContains(t, d.SetPWMFreq(60), "read error")
+	require.ErrorContains(t, d.SetPWMFreq(60), "read error")
 }
 
 func TestPCA9685SetPWMFreqWriteError(t *testing.T) {
@@ -284,7 +285,7 @@ func TestPCA9685SetPWMFreqWriteError(t *testing.T) {
 		return 0, errors.New("write error")
 	}
 	// act & assert
-	assert.ErrorContains(t, d.SetPWMFreq(60), "write error")
+	require.ErrorContains(t, d.SetPWMFreq(60), "write error")
 }
 
 func TestPCA9685Commands(t *testing.T) {
@@ -323,8 +324,8 @@ func TestPCA9685_initialize(t *testing.T) {
 	// act, assert - initialize() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 15, len(a.written))
+	require.NoError(t, err)
+	assert.Len(t, a.written, 15)
 	var writeIdx int
 	for idx, wantVal := range wantAllLedOnTimeOffTimeSequence {
 		assert.Equal(t, wantVal, a.written[writeIdx], "index %d (%d) differs", writeIdx, idx)

--- a/drivers/i2c/pcf8583_driver_test.go
+++ b/drivers/i2c/pcf8583_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -210,10 +211,10 @@ func TestPCF8583WriteTime(t *testing.T) {
 	// act
 	err := d.WriteTime(initDate)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, initDate.Year(), d.yearOffset)
 	assert.Equal(t, 1, numCallsRead)
-	assert.Equal(t, 11, len(a.written))
+	assert.Len(t, a.written, 11)
 	assert.Equal(t, uint8(pcf8583Reg_CTRL), a.written[0])
 	assert.Equal(t, uint8(pcf8583Reg_CTRL), a.written[1])
 	assert.Equal(t, wantCtrlStop, a.written[2])
@@ -246,9 +247,9 @@ func TestPCF8583WriteTimeNoTimeModeFails(t *testing.T) {
 	// act
 	err := d.WriteTime(time.Now())
 	// assert
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "wrong mode 0x30")
-	assert.Equal(t, 1, len(a.written))
+	assert.Len(t, a.written, 1)
 	assert.Equal(t, uint8(pcf8583Reg_CTRL), a.written[0])
 	assert.Equal(t, 1, numCallsRead)
 }
@@ -292,8 +293,8 @@ func TestPCF8583ReadTime(t *testing.T) {
 	// act
 	got, err := d.ReadTime()
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(a.written))
+	require.NoError(t, err)
+	assert.Len(t, a.written, 1)
 	assert.Equal(t, uint8(pcf8583Reg_CTRL), a.written[0])
 	assert.Equal(t, 2, numCallsRead)
 	assert.Equal(t, want, got)
@@ -318,10 +319,10 @@ func TestPCF8583ReadTimeNoTimeModeFails(t *testing.T) {
 	// act
 	got, err := d.ReadTime()
 	// assert
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "wrong mode 0x20")
 	assert.Equal(t, time.Time{}, got)
-	assert.Equal(t, 1, len(a.written))
+	assert.Len(t, a.written, 1)
 	assert.Equal(t, uint8(pcf8583Reg_CTRL), a.written[0])
 	assert.Equal(t, 1, numCallsRead)
 }
@@ -357,9 +358,9 @@ func TestPCF8583WriteCounter(t *testing.T) {
 	// act
 	err := d.WriteCounter(initCount)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, numCallsRead)
-	assert.Equal(t, 8, len(a.written))
+	assert.Len(t, a.written, 8)
 	assert.Equal(t, uint8(pcf8583Reg_CTRL), a.written[0])
 	assert.Equal(t, uint8(pcf8583Reg_CTRL), a.written[1])
 	assert.Equal(t, wantCtrlStop, a.written[2])
@@ -389,9 +390,9 @@ func TestPCF8583WriteCounterNoCounterModeFails(t *testing.T) {
 	// act
 	err := d.WriteCounter(123)
 	// assert
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "wrong mode 0x10")
-	assert.Equal(t, 1, len(a.written))
+	assert.Len(t, a.written, 1)
 	assert.Equal(t, uint8(pcf8583Reg_CTRL), a.written[0])
 	assert.Equal(t, 1, numCallsRead)
 }
@@ -430,8 +431,8 @@ func TestPCF8583ReadCounter(t *testing.T) {
 	// act
 	got, err := d.ReadCounter()
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(a.written))
+	require.NoError(t, err)
+	assert.Len(t, a.written, 1)
 	assert.Equal(t, uint8(pcf8583Reg_CTRL), a.written[0])
 	assert.Equal(t, 2, numCallsRead)
 	assert.Equal(t, want, got)
@@ -456,10 +457,10 @@ func TestPCF8583ReadCounterNoCounterModeFails(t *testing.T) {
 	// act
 	got, err := d.ReadCounter()
 	// assert
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "wrong mode 0x30")
 	assert.Equal(t, int32(0), got)
-	assert.Equal(t, 1, len(a.written))
+	assert.Len(t, a.written, 1)
 	assert.Equal(t, uint8(pcf8583Reg_CTRL), a.written[0])
 	assert.Equal(t, 1, numCallsRead)
 }
@@ -480,8 +481,8 @@ func TestPCF8583WriteRam(t *testing.T) {
 	// act
 	err := d.WriteRAM(wantRAMAddress-pcf8583RamOffset, wantRAMValue)
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(a.written))
+	require.NoError(t, err)
+	assert.Len(t, a.written, 2)
 	assert.Equal(t, wantRAMAddress, a.written[0])
 	assert.Equal(t, wantRAMValue, a.written[1])
 }
@@ -493,9 +494,9 @@ func TestPCF8583WriteRamAddressOverflowFails(t *testing.T) {
 	// act
 	err := d.WriteRAM(uint8(0xF0), 15)
 	// assert
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "overflow 256")
-	assert.Equal(t, 0, len(a.written))
+	assert.Empty(t, a.written)
 }
 
 func TestPCF8583ReadRam(t *testing.T) {
@@ -521,9 +522,9 @@ func TestPCF8583ReadRam(t *testing.T) {
 	// act
 	got, err := d.ReadRAM(wantRAMAddress - pcf8583RamOffset)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, want, got)
-	assert.Equal(t, 1, len(a.written))
+	assert.Len(t, a.written, 1)
 	assert.Equal(t, wantRAMAddress, a.written[0])
 	assert.Equal(t, 1, numCallsRead)
 }
@@ -545,10 +546,10 @@ func TestPCF8583ReadRamAddressOverflowFails(t *testing.T) {
 	// act
 	got, err := d.ReadRAM(uint8(0xF0))
 	// assert
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "overflow 256")
 	assert.Equal(t, uint8(0), got)
-	assert.Equal(t, 0, len(a.written))
+	assert.Empty(t, a.written)
 	assert.Equal(t, 0, numCallsRead)
 }
 
@@ -572,9 +573,9 @@ func TestPCF8583_initializeNoModeSwitch(t *testing.T) {
 	// act, assert - initialize() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, numCallsRead)
-	assert.Equal(t, 1, len(a.written))
+	assert.Len(t, a.written, 1)
 	assert.Equal(t, uint8(pcf8583Reg_CTRL), a.written[0])
 }
 
@@ -604,9 +605,9 @@ func TestPCF8583_initializeWithModeSwitch(t *testing.T) {
 	// act, assert - initialize() must be called on Start()
 	err := d.Start()
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, numCallsRead)
-	assert.Equal(t, 3, len(a.written))
+	assert.Len(t, a.written, 3)
 	assert.Equal(t, uint8(pcf8583Reg_CTRL), a.written[0])
 	assert.Equal(t, uint8(pcf8583Reg_CTRL), a.written[1])
 	assert.Equal(t, wantReg0Val, a.written[2])

--- a/drivers/i2c/pcf8591_driver_test.go
+++ b/drivers/i2c/pcf8591_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -35,12 +36,12 @@ func TestNewPCF8591Driver(t *testing.T) {
 
 func TestPCF8591Start(t *testing.T) {
 	d := NewPCF8591Driver(newI2cTestAdaptor())
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestPCF8591Halt(t *testing.T) {
 	d := NewPCF8591Driver(newI2cTestAdaptor())
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestPCF8591WithPCF8591With400kbitStabilization(t *testing.T) {
@@ -78,8 +79,8 @@ func TestPCF8591AnalogReadSingle(t *testing.T) {
 	// act
 	got, err := d.AnalogRead(description)
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(a.written))
+	require.NoError(t, err)
+	assert.Len(t, a.written, 1)
 	assert.Equal(t, ctrlByteOn, a.written[0])
 	assert.Equal(t, 2, numCallsRead)
 	assert.Equal(t, want, got)
@@ -120,8 +121,8 @@ func TestPCF8591AnalogReadDiff(t *testing.T) {
 	// act
 	got, err := d.AnalogRead(description)
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(a.written))
+	require.NoError(t, err)
+	assert.Len(t, a.written, 1)
 	assert.Equal(t, ctrlByteOn, a.written[0])
 	assert.Equal(t, 2, numCallsRead)
 	assert.Equal(t, want, got)
@@ -146,8 +147,8 @@ func TestPCF8591AnalogWrite(t *testing.T) {
 	// act
 	err := d.AnalogWrite("", int(want))
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(a.written))
+	require.NoError(t, err)
+	assert.Len(t, a.written, 2)
 	assert.Equal(t, ctrlByteOn, a.written[0])
 	assert.Equal(t, want, a.written[1])
 }
@@ -171,8 +172,8 @@ func TestPCF8591AnalogOutputState(t *testing.T) {
 		// act
 		err := d.AnalogOutputState(bitState == 1)
 		// assert
-		assert.NoError(t, err)
-		assert.Equal(t, 1, len(a.written))
+		require.NoError(t, err)
+		assert.Len(t, a.written, 1)
 		assert.Equal(t, wantCtrlByteVal, a.written[0])
 	}
 }

--- a/drivers/i2c/sht2x_driver_test.go
+++ b/drivers/i2c/sht2x_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -42,12 +43,12 @@ func TestSHT2xOptions(t *testing.T) {
 
 func TestSHT2xStart(t *testing.T) {
 	d := NewSHT2xDriver(newI2cTestAdaptor())
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestSHT2xHalt(t *testing.T) {
 	d, _ := initTestSHT2xDriverWithStubbedAdaptor()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestSHT2xReset(t *testing.T) {
@@ -57,7 +58,7 @@ func TestSHT2xReset(t *testing.T) {
 	}
 	_ = d.Start()
 	err := d.Reset()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestSHT2xMeasurements(t *testing.T) {
@@ -75,11 +76,11 @@ func TestSHT2xMeasurements(t *testing.T) {
 	}
 	_ = d.Start()
 	temp, err := d.Temperature()
-	assert.NoError(t, err)
-	assert.Equal(t, float32(18.809052), temp)
+	require.NoError(t, err)
+	assert.InDelta(t, float32(18.809052), temp, 0.0)
 	hum, err := d.Humidity()
-	assert.NoError(t, err)
-	assert.Equal(t, float32(40.279907), hum)
+	require.NoError(t, err)
+	assert.InDelta(t, float32(40.279907), hum, 0.0)
 }
 
 func TestSHT2xAccuracy(t *testing.T) {
@@ -100,7 +101,7 @@ func TestSHT2xAccuracy(t *testing.T) {
 	_ = d.SetAccuracy(SHT2xAccuracyLow)
 	assert.Equal(t, SHT2xAccuracyLow, d.Accuracy())
 	err := d.sendAccuracy()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestSHT2xTemperatureCrcError(t *testing.T) {
@@ -116,8 +117,8 @@ func TestSHT2xTemperatureCrcError(t *testing.T) {
 		return buf.Len(), nil
 	}
 	temp, err := d.Temperature()
-	assert.ErrorContains(t, err, "Invalid crc")
-	assert.Equal(t, float32(0.0), temp)
+	require.ErrorContains(t, err, "Invalid crc")
+	assert.InDelta(t, float32(0.0), temp, 0.0)
 }
 
 func TestSHT2xHumidityCrcError(t *testing.T) {
@@ -133,8 +134,8 @@ func TestSHT2xHumidityCrcError(t *testing.T) {
 		return buf.Len(), nil
 	}
 	hum, err := d.Humidity()
-	assert.ErrorContains(t, err, "Invalid crc")
-	assert.Equal(t, float32(0.0), hum)
+	require.ErrorContains(t, err, "Invalid crc")
+	assert.InDelta(t, float32(0.0), hum, 0.0)
 }
 
 func TestSHT2xTemperatureLengthError(t *testing.T) {
@@ -151,7 +152,7 @@ func TestSHT2xTemperatureLengthError(t *testing.T) {
 	}
 	temp, err := d.Temperature()
 	assert.Equal(t, ErrNotEnoughBytes, err)
-	assert.Equal(t, float32(0.0), temp)
+	assert.InDelta(t, float32(0.0), temp, 0.0)
 }
 
 func TestSHT2xHumidityLengthError(t *testing.T) {
@@ -168,5 +169,5 @@ func TestSHT2xHumidityLengthError(t *testing.T) {
 	}
 	hum, err := d.Humidity()
 	assert.Equal(t, ErrNotEnoughBytes, err)
-	assert.Equal(t, float32(0.0), hum)
+	assert.InDelta(t, float32(0.0), hum, 0.0)
 }

--- a/drivers/i2c/sht3x_driver_test.go
+++ b/drivers/i2c/sht3x_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -42,12 +43,12 @@ func TestSHT3xOptions(t *testing.T) {
 
 func TestSHT3xStart(t *testing.T) {
 	d := NewSHT3xDriver(newI2cTestAdaptor())
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestSHT3xHalt(t *testing.T) {
 	d, _ := initTestSHT3xDriverWithStubbedAdaptor()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestSHT3xSampleNormal(t *testing.T) {
@@ -58,13 +59,13 @@ func TestSHT3xSampleNormal(t *testing.T) {
 	}
 
 	temp, rh, _ := d.Sample()
-	assert.Equal(t, float32(85.523003), temp)
-	assert.Equal(t, float32(74.5845), rh)
+	assert.InDelta(t, float32(85.523003), temp, 0.0)
+	assert.InDelta(t, float32(74.5845), rh, 0.0)
 
 	// check the temp with the units in F
 	d.Units = "F"
 	temp, _, _ = d.Sample()
-	assert.Equal(t, float32(185.9414), temp)
+	assert.InDelta(t, float32(185.9414), temp, 0.0)
 }
 
 func TestSHT3xSampleBadCrc(t *testing.T) {
@@ -155,7 +156,7 @@ func TestSHT3xHeater(t *testing.T) {
 	}
 
 	status, err := d.Heater()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, status)
 
 	// heater disabled
@@ -165,7 +166,7 @@ func TestSHT3xHeater(t *testing.T) {
 	}
 
 	status, err = d.Heater()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, status)
 
 	// heater crc failed
@@ -184,7 +185,7 @@ func TestSHT3xHeater(t *testing.T) {
 	}
 
 	_, err = d.Heater()
-	assert.NotNil(t, err)
+	require.Error(t, err)
 }
 
 func TestSHT3xSetHeater(t *testing.T) {
@@ -199,11 +200,11 @@ func TestSHT3xSetAccuracy(t *testing.T) {
 	assert.Equal(t, byte(SHT3xAccuracyHigh), d.Accuracy())
 
 	err := d.SetAccuracy(SHT3xAccuracyMedium)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, byte(SHT3xAccuracyMedium), d.Accuracy())
 
 	err = d.SetAccuracy(SHT3xAccuracyLow)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, byte(SHT3xAccuracyLow), d.Accuracy())
 
 	err = d.SetAccuracy(0xff)
@@ -219,6 +220,6 @@ func TestSHT3xSerialNumber(t *testing.T) {
 
 	sn, err := d.SerialNumber()
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, uint32(0x2000beef), sn)
 }

--- a/drivers/i2c/ssd1306_driver_test.go
+++ b/drivers/i2c/ssd1306_driver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -47,7 +48,7 @@ func TestSSD1306StartDefault(t *testing.T) {
 	)
 	d := NewSSD1306Driver(newI2cTestAdaptor(),
 		WithSSD1306DisplayWidth(width), WithSSD1306DisplayHeight(height), WithSSD1306ExternalVCC(externalVCC))
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestSSD1306Start128x32(t *testing.T) {
@@ -58,7 +59,7 @@ func TestSSD1306Start128x32(t *testing.T) {
 	)
 	d := NewSSD1306Driver(newI2cTestAdaptor(),
 		WithSSD1306DisplayWidth(width), WithSSD1306DisplayHeight(height), WithSSD1306ExternalVCC(externalVCC))
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestSSD1306Start96x16(t *testing.T) {
@@ -69,7 +70,7 @@ func TestSSD1306Start96x16(t *testing.T) {
 	)
 	d := NewSSD1306Driver(newI2cTestAdaptor(),
 		WithSSD1306DisplayWidth(width), WithSSD1306DisplayHeight(height), WithSSD1306ExternalVCC(externalVCC))
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestSSD1306StartExternalVCC(t *testing.T) {
@@ -80,7 +81,7 @@ func TestSSD1306StartExternalVCC(t *testing.T) {
 	)
 	d := NewSSD1306Driver(newI2cTestAdaptor(),
 		WithSSD1306DisplayWidth(width), WithSSD1306DisplayHeight(height), WithSSD1306ExternalVCC(externalVCC))
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestSSD1306StartSizeError(t *testing.T) {
@@ -91,12 +92,12 @@ func TestSSD1306StartSizeError(t *testing.T) {
 	)
 	d := NewSSD1306Driver(newI2cTestAdaptor(),
 		WithSSD1306DisplayWidth(width), WithSSD1306DisplayHeight(height), WithSSD1306ExternalVCC(externalVCC))
-	assert.ErrorContains(t, d.Start(), "128x54 resolution is unsupported, supported resolutions: 128x64, 128x32, 96x16")
+	require.ErrorContains(t, d.Start(), "128x54 resolution is unsupported, supported resolutions: 128x64, 128x32, 96x16")
 }
 
 func TestSSD1306Halt(t *testing.T) {
 	s, _ := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
-	assert.NoError(t, s.Halt())
+	require.NoError(t, s.Halt())
 }
 
 func TestSSD1306Options(t *testing.T) {
@@ -109,17 +110,17 @@ func TestSSD1306Options(t *testing.T) {
 func TestSSD1306Display(t *testing.T) {
 	s, _ := initTestSSD1306DriverWithStubbedAdaptor(96, 16, false)
 	_ = s.Start()
-	assert.NoError(t, s.Display())
+	require.NoError(t, s.Display())
 }
 
 func TestSSD1306ShowImage(t *testing.T) {
 	s, _ := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
 	_ = s.Start()
 	img := image.NewRGBA(image.Rect(0, 0, 640, 480))
-	assert.ErrorContains(t, s.ShowImage(img), "image must match display width and height: 128x64")
+	require.ErrorContains(t, s.ShowImage(img), "image must match display width and height: 128x64")
 
 	img = image.NewRGBA(image.Rect(0, 0, 128, 64))
-	assert.NoError(t, s.ShowImage(img))
+	require.NoError(t, s.ShowImage(img))
 }
 
 func TestSSD1306Command(t *testing.T) {
@@ -135,7 +136,7 @@ func TestSSD1306Command(t *testing.T) {
 		return 0, nil
 	}
 	err := s.command(0xFF)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestSSD1306Commands(t *testing.T) {
@@ -151,7 +152,7 @@ func TestSSD1306Commands(t *testing.T) {
 		return 0, nil
 	}
 	err := s.commands([]byte{0x00, 0xFF})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestSSD1306On(t *testing.T) {
@@ -167,7 +168,7 @@ func TestSSD1306On(t *testing.T) {
 		return 0, nil
 	}
 	err := s.On()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestSSD1306Off(t *testing.T) {
@@ -183,7 +184,7 @@ func TestSSD1306Off(t *testing.T) {
 		return 0, nil
 	}
 	err := s.Off()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestSSD1306Reset(t *testing.T) {
@@ -200,7 +201,7 @@ func TestSSD1306Reset(t *testing.T) {
 		return 0, nil
 	}
 	err := s.Reset()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // COMMANDS

--- a/drivers/i2c/th02_driver_test.go
+++ b/drivers/i2c/th02_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -102,8 +103,8 @@ func TestTH02FastMode(t *testing.T) {
 			// act
 			got, err := d.FastMode()
 			// assert
-			assert.NoError(t, err)
-			assert.Equal(t, 1, len(a.written))
+			require.NoError(t, err)
+			assert.Len(t, a.written, 1)
 			assert.Equal(t, uint8(0x03), a.written[0])
 			assert.Equal(t, tc.want, got)
 		})
@@ -130,9 +131,9 @@ func TestTH02SetHeater(t *testing.T) {
 			// act
 			err := d.SetHeater(tc.heater)
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.heater, d.heating)
-			assert.Equal(t, 2, len(a.written))
+			assert.Len(t, a.written, 2)
 			assert.Equal(t, uint8(0x03), a.written[0])
 			assert.Equal(t, tc.want, a.written[1])
 		})
@@ -162,8 +163,8 @@ func TestTH02Heater(t *testing.T) {
 			// act
 			got, err := d.Heater()
 			// assert
-			assert.NoError(t, err)
-			assert.Equal(t, 1, len(a.written))
+			require.NoError(t, err)
+			assert.Len(t, a.written, 1)
 			assert.Equal(t, uint8(0x03), a.written[0])
 			assert.Equal(t, tc.want, got)
 		})
@@ -186,8 +187,8 @@ func TestTH02SerialNumber(t *testing.T) {
 	// act
 	sn, err := d.SerialNumber()
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(a.written))
+	require.NoError(t, err)
+	assert.Len(t, a.written, 1)
 	assert.Equal(t, uint8(0x11), a.written[0])
 	assert.Equal(t, want, sn)
 }
@@ -297,9 +298,9 @@ func TestTH02Sample(t *testing.T) {
 			// act
 			temp, rh, err := d.Sample()
 			// assert
-			assert.NoError(t, err)
-			assert.Equal(t, tc.wantRH, rh)
-			assert.Equal(t, tc.wantT, temp)
+			require.NoError(t, err)
+			assert.InDelta(t, tc.wantRH, rh, 0.0)
+			assert.InDelta(t, tc.wantT, temp, 0.0)
 		})
 	}
 }
@@ -485,7 +486,7 @@ func TestTH02_createConfig(t *testing.T) {
 			d.fastMode = tc.fast
 			d.heating = tc.heating
 			got := d.createConfig(tc.meas, tc.readTemp)
-			assert.Equal(t, got, tc.want)
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/drivers/i2c/tsl2561_driver_test.go
+++ b/drivers/i2c/tsl2561_driver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -60,7 +61,7 @@ func TestTSL2561DriverStart(t *testing.T) {
 	d := NewTSL2561Driver(a)
 	a.i2cReadImpl = testIDReader
 
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestTSL2561DriverStartNotFound(t *testing.T) {
@@ -72,12 +73,12 @@ func TestTSL2561DriverStartNotFound(t *testing.T) {
 		copy(b, buf.Bytes())
 		return buf.Len(), nil
 	}
-	assert.ErrorContains(t, d.Start(), "TSL2561 device not found (0x1)")
+	require.ErrorContains(t, d.Start(), "TSL2561 device not found (0x1)")
 }
 
 func TestTSL2561DriverHalt(t *testing.T) {
 	d, _ := initTestTSL2561Driver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestTSL2561DriverRead16(t *testing.T) {
@@ -93,7 +94,7 @@ func TestTSL2561DriverRead16(t *testing.T) {
 		return buf.Len(), nil
 	}
 	val, err := d.connection.ReadWordData(1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, uint16(0xAEEA), val)
 }
 
@@ -157,7 +158,7 @@ func TestTSL2561DriverGetDataWriteError(t *testing.T) {
 	}
 
 	_, _, err := d.getData()
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 }
 
 func TestTSL2561DriverGetDataReadError(t *testing.T) {
@@ -167,7 +168,7 @@ func TestTSL2561DriverGetDataReadError(t *testing.T) {
 	}
 
 	_, _, err := d.getData()
-	assert.ErrorContains(t, err, "read error")
+	require.ErrorContains(t, err, "read error")
 }
 
 func TestTSL2561DriverGetLuminocity(t *testing.T) {
@@ -180,7 +181,7 @@ func TestTSL2561DriverGetLuminocity(t *testing.T) {
 		return buf.Len(), nil
 	}
 	bb, ir, err := d.GetLuminocity()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, uint16(12365), bb)
 	assert.Equal(t, uint16(12365), ir)
 	assert.Equal(t, uint32(72), d.CalculateLux(bb, ir))
@@ -202,7 +203,7 @@ func TestTSL2561DriverGetLuminocityAutoGain(t *testing.T) {
 
 	_ = d.Start()
 	bb, ir, err := d.GetLuminocity()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, uint16(12365), bb)
 	assert.Equal(t, uint16(12365), ir)
 	assert.Equal(t, uint32(72), d.CalculateLux(bb, ir))
@@ -213,7 +214,7 @@ func TestTSL2561SetIntegrationTimeError(t *testing.T) {
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
-	assert.ErrorContains(t, d.SetIntegrationTime(TSL2561IntegrationTime101MS), "write error")
+	require.ErrorContains(t, d.SetIntegrationTime(TSL2561IntegrationTime101MS), "write error")
 }
 
 func TestTSL2561SetGainError(t *testing.T) {
@@ -221,7 +222,7 @@ func TestTSL2561SetGainError(t *testing.T) {
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
-	assert.ErrorContains(t, d.SetGain(TSL2561Gain16X), "write error")
+	require.ErrorContains(t, d.SetGain(TSL2561Gain16X), "write error")
 }
 
 func TestTSL2561getHiLo13MS(t *testing.T) {

--- a/drivers/i2c/wiichuck_driver_test.go
+++ b/drivers/i2c/wiichuck_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -44,7 +45,7 @@ func TestWiichuckDriverStart(t *testing.T) {
 	d.interval = 1 * time.Millisecond
 	sem := make(chan bool)
 
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 
 	go func() {
 		for {
@@ -67,7 +68,7 @@ func TestWiichuckDriverStart(t *testing.T) {
 
 func TestWiichuckDriverHalt(t *testing.T) {
 	d := initTestWiichuckDriverWithStubbedAdaptor()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestWiichuckDriverCanParse(t *testing.T) {
@@ -78,10 +79,10 @@ func TestWiichuckDriverCanParse(t *testing.T) {
 	_ = d.update(decryptedValue)
 
 	// - This should be done by WiichuckDriver.parse
-	assert.Equal(t, float64(45), d.data["sx"])
-	assert.Equal(t, float64(44), d.data["sy"])
-	assert.Equal(t, float64(0), d.data["z"])
-	assert.Equal(t, float64(0), d.data["c"])
+	assert.InDelta(t, float64(45), d.data["sx"], 0.0)
+	assert.InDelta(t, float64(44), d.data["sy"], 0.0)
+	assert.InDelta(t, float64(0), d.data["z"], 0.0)
+	assert.InDelta(t, float64(0), d.data["c"], 0.0)
 }
 
 func TestWiichuckDriverCanAdjustOrigins(t *testing.T) {
@@ -92,8 +93,8 @@ func TestWiichuckDriverCanAdjustOrigins(t *testing.T) {
 	_ = d.update(decryptedValue)
 
 	// - This should be done by WiichuckDriver.adjustOrigins
-	assert.Equal(t, float64(45), d.Joystick()["sx_origin"])
-	assert.Equal(t, float64(44), d.Joystick()["sy_origin"])
+	assert.InDelta(t, float64(45), d.Joystick()["sx_origin"], 0.0)
+	assert.InDelta(t, float64(44), d.Joystick()["sy_origin"], 0.0)
 }
 
 func TestWiichuckDriverCButton(t *testing.T) {
@@ -107,7 +108,7 @@ func TestWiichuckDriverCButton(t *testing.T) {
 	done := make(chan bool)
 
 	_ = d.On(d.Event(C), func(data interface{}) {
-		assert.Equal(t, true, data)
+		assert.Equal(t, true, data) //nolint:testifylint // data is an interface
 		done <- true
 	})
 
@@ -130,7 +131,7 @@ func TestWiichuckDriverZButton(t *testing.T) {
 	done := make(chan bool)
 
 	_ = d.On(d.Event(Z), func(data interface{}) {
-		assert.Equal(t, true, data)
+		assert.Equal(t, true, data) //nolint:testifylint // data is an interface
 		done <- true
 	})
 
@@ -177,37 +178,37 @@ func TestWiichuckDriverEncrypted(t *testing.T) {
 
 	_ = d.update(encryptedValue)
 
-	assert.Equal(t, float64(0), d.data["sx"])
-	assert.Equal(t, float64(0), d.data["sy"])
-	assert.Equal(t, float64(0), d.data["z"])
-	assert.Equal(t, float64(0), d.data["c"])
+	assert.InDelta(t, float64(0), d.data["sx"], 0.0)
+	assert.InDelta(t, float64(0), d.data["sy"], 0.0)
+	assert.InDelta(t, float64(0), d.data["z"], 0.0)
+	assert.InDelta(t, float64(0), d.data["c"], 0.0)
 
-	assert.Equal(t, float64(-1), d.Joystick()["sx_origin"])
-	assert.Equal(t, float64(-1), d.Joystick()["sy_origin"])
+	assert.InDelta(t, float64(-1), d.Joystick()["sx_origin"], 0.0)
+	assert.InDelta(t, float64(-1), d.Joystick()["sy_origin"], 0.0)
 }
 
 func TestWiichuckDriverSetJoystickDefaultValue(t *testing.T) {
 	d := initTestWiichuckDriverWithStubbedAdaptor()
 
-	assert.Equal(t, float64(-1), d.Joystick()["sy_origin"])
+	assert.InDelta(t, float64(-1), d.Joystick()["sy_origin"], 0.0)
 
 	d.setJoystickDefaultValue("sy_origin", float64(2))
 
-	assert.Equal(t, float64(2), d.Joystick()["sy_origin"])
+	assert.InDelta(t, float64(2), d.Joystick()["sy_origin"], 0.0)
 
 	// when current default value is not -1 it keeps the current value
 	d.setJoystickDefaultValue("sy_origin", float64(20))
 
-	assert.Equal(t, float64(2), d.Joystick()["sy_origin"])
+	assert.InDelta(t, float64(2), d.Joystick()["sy_origin"], 0.0)
 }
 
 func TestWiichuckDriverCalculateJoystickValue(t *testing.T) {
 	d := initTestWiichuckDriverWithStubbedAdaptor()
 
-	assert.Equal(t, float64(15), d.calculateJoystickValue(float64(20), float64(5)))
-	assert.Equal(t, float64(-1), d.calculateJoystickValue(float64(1), float64(2)))
-	assert.Equal(t, float64(5), d.calculateJoystickValue(float64(10), float64(5)))
-	assert.Equal(t, float64(-5), d.calculateJoystickValue(float64(5), float64(10)))
+	assert.InDelta(t, float64(15), d.calculateJoystickValue(float64(20), float64(5)), 0.0)
+	assert.InDelta(t, float64(-1), d.calculateJoystickValue(float64(1), float64(2)), 0.0)
+	assert.InDelta(t, float64(5), d.calculateJoystickValue(float64(10), float64(5)), 0.0)
+	assert.InDelta(t, float64(-5), d.calculateJoystickValue(float64(5), float64(10)), 0.0)
 }
 
 func TestWiichuckDriverIsEncrypted(t *testing.T) {
@@ -232,49 +233,49 @@ func TestWiichuckDriverIsEncrypted(t *testing.T) {
 func TestWiichuckDriverDecode(t *testing.T) {
 	d := initTestWiichuckDriverWithStubbedAdaptor()
 
-	assert.Equal(t, float64(46), d.decode(byte(0)))
-	assert.Equal(t, float64(138), d.decode(byte(100)))
-	assert.Equal(t, float64(246), d.decode(byte(200)))
-	assert.Equal(t, float64(0), d.decode(byte(254)))
+	assert.InDelta(t, float64(46), d.decode(byte(0)), 0.0)
+	assert.InDelta(t, float64(138), d.decode(byte(100)), 0.0)
+	assert.InDelta(t, float64(246), d.decode(byte(200)), 0.0)
+	assert.InDelta(t, float64(0), d.decode(byte(254)), 0.0)
 }
 
 func TestWiichuckDriverParse(t *testing.T) {
 	d := initTestWiichuckDriverWithStubbedAdaptor()
 
-	assert.Equal(t, float64(0), d.data["sx"])
-	assert.Equal(t, float64(0), d.data["sy"])
-	assert.Equal(t, float64(0), d.data["z"])
-	assert.Equal(t, float64(0), d.data["c"])
+	assert.InDelta(t, float64(0), d.data["sx"], 0.0)
+	assert.InDelta(t, float64(0), d.data["sy"], 0.0)
+	assert.InDelta(t, float64(0), d.data["z"], 0.0)
+	assert.InDelta(t, float64(0), d.data["c"], 0.0)
 
 	// First pass
 	d.parse([]byte{12, 23, 34, 45, 56, 67})
 
-	assert.Equal(t, float64(50), d.data["sx"])
-	assert.Equal(t, float64(23), d.data["sy"])
-	assert.Equal(t, float64(1), d.data["z"])
-	assert.Equal(t, float64(2), d.data["c"])
+	assert.InDelta(t, float64(50), d.data["sx"], 0.0)
+	assert.InDelta(t, float64(23), d.data["sy"], 0.0)
+	assert.InDelta(t, float64(1), d.data["z"], 0.0)
+	assert.InDelta(t, float64(2), d.data["c"], 0.0)
 
 	// Second pass
 	d.parse([]byte{70, 81, 92, 103, 204, 205})
 
-	assert.Equal(t, float64(104), d.data["sx"])
-	assert.Equal(t, float64(93), d.data["sy"])
-	assert.Equal(t, float64(1), d.data["z"])
-	assert.Equal(t, float64(0), d.data["c"])
+	assert.InDelta(t, float64(104), d.data["sx"], 0.0)
+	assert.InDelta(t, float64(93), d.data["sy"], 0.0)
+	assert.InDelta(t, float64(1), d.data["z"], 0.0)
+	assert.InDelta(t, float64(0), d.data["c"], 0.0)
 }
 
 func TestWiichuckDriverAdjustOrigins(t *testing.T) {
 	d := initTestWiichuckDriverWithStubbedAdaptor()
 
-	assert.Equal(t, float64(-1), d.Joystick()["sy_origin"])
-	assert.Equal(t, float64(-1), d.Joystick()["sx_origin"])
+	assert.InDelta(t, float64(-1), d.Joystick()["sy_origin"], 0.0)
+	assert.InDelta(t, float64(-1), d.Joystick()["sx_origin"], 0.0)
 
 	// First pass
 	d.parse([]byte{1, 2, 3, 4, 5, 6})
 	d.adjustOrigins()
 
-	assert.Equal(t, float64(44), d.Joystick()["sy_origin"])
-	assert.Equal(t, float64(45), d.Joystick()["sx_origin"])
+	assert.InDelta(t, float64(44), d.Joystick()["sy_origin"], 0.0)
+	assert.InDelta(t, float64(45), d.Joystick()["sx_origin"], 0.0)
 
 	// Second pass
 	d = initTestWiichuckDriverWithStubbedAdaptor()
@@ -282,8 +283,8 @@ func TestWiichuckDriverAdjustOrigins(t *testing.T) {
 	d.parse([]byte{61, 72, 83, 94, 105, 206})
 	d.adjustOrigins()
 
-	assert.Equal(t, float64(118), d.Joystick()["sy_origin"])
-	assert.Equal(t, float64(65), d.Joystick()["sx_origin"])
+	assert.InDelta(t, float64(118), d.Joystick()["sy_origin"], 0.0)
+	assert.InDelta(t, float64(65), d.Joystick()["sx_origin"], 0.0)
 }
 
 func TestWiichuckDriverSetName(t *testing.T) {

--- a/drivers/i2c/yl40_driver_test.go
+++ b/drivers/i2c/yl40_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func initTestYL40DriverWithStubbedAdaptor() (*YL40Driver, *i2cTestAdaptor) {
@@ -107,13 +108,13 @@ func TestYL40DriverReadBrightness(t *testing.T) {
 	got, err := yl.ReadBrightness()
 	got2, err2 := yl.Brightness()
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(adaptor.written))
+	require.NoError(t, err)
+	assert.Len(t, adaptor.written, 1)
 	assert.Equal(t, ctrlByteOn, adaptor.written[0])
 	assert.Equal(t, 2, numCallsRead)
-	assert.Equal(t, want, got)
-	assert.NoError(t, err2)
-	assert.Equal(t, want, got2)
+	assert.InDelta(t, want, got, 0.0)
+	require.NoError(t, err2)
+	assert.InDelta(t, want, got2, 0.0)
 }
 
 func TestYL40DriverReadTemperature(t *testing.T) {
@@ -143,13 +144,13 @@ func TestYL40DriverReadTemperature(t *testing.T) {
 	got, err := yl.ReadTemperature()
 	got2, err2 := yl.Temperature()
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(adaptor.written))
+	require.NoError(t, err)
+	assert.Len(t, adaptor.written, 1)
 	assert.Equal(t, ctrlByteOn, adaptor.written[0])
 	assert.Equal(t, 2, numCallsRead)
-	assert.Equal(t, want, got)
-	assert.NoError(t, err2)
-	assert.Equal(t, want, got2)
+	assert.InDelta(t, want, got, 0.0)
+	require.NoError(t, err2)
+	assert.InDelta(t, want, got2, 0.0)
 }
 
 func TestYL40DriverReadAIN2(t *testing.T) {
@@ -178,13 +179,13 @@ func TestYL40DriverReadAIN2(t *testing.T) {
 	got, err := yl.ReadAIN2()
 	got2, err2 := yl.AIN2()
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(adaptor.written))
+	require.NoError(t, err)
+	assert.Len(t, adaptor.written, 1)
 	assert.Equal(t, ctrlByteOn, adaptor.written[0])
 	assert.Equal(t, 2, numCallsRead)
-	assert.Equal(t, want, got)
-	assert.NoError(t, err2)
-	assert.Equal(t, want, got2)
+	assert.InDelta(t, want, got, 0.0)
+	require.NoError(t, err2)
+	assert.InDelta(t, want, got2, 0.0)
 }
 
 func TestYL40DriverReadPotentiometer(t *testing.T) {
@@ -213,13 +214,13 @@ func TestYL40DriverReadPotentiometer(t *testing.T) {
 	got, err := yl.ReadPotentiometer()
 	got2, err2 := yl.Potentiometer()
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(adaptor.written))
+	require.NoError(t, err)
+	assert.Len(t, adaptor.written, 1)
 	assert.Equal(t, ctrlByteOn, adaptor.written[0])
 	assert.Equal(t, 2, numCallsRead)
-	assert.Equal(t, want, got)
-	assert.NoError(t, err2)
-	assert.Equal(t, want, got2)
+	assert.InDelta(t, want, got, 0.0)
+	require.NoError(t, err2)
+	assert.InDelta(t, want, got2, 0.0)
 }
 
 func TestYL40DriverAnalogWrite(t *testing.T) {
@@ -238,20 +239,20 @@ func TestYL40DriverAnalogWrite(t *testing.T) {
 	// act
 	err := pcf.Write(write)
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(adaptor.written))
+	require.NoError(t, err)
+	assert.Len(t, adaptor.written, 2)
 	assert.Equal(t, ctrlByteOn, adaptor.written[0])
 	assert.Equal(t, want, adaptor.written[1])
 }
 
 func TestYL40DriverStart(t *testing.T) {
 	yl := NewYL40Driver(newI2cTestAdaptor())
-	assert.NoError(t, yl.Start())
+	require.NoError(t, yl.Start())
 }
 
 func TestYL40DriverHalt(t *testing.T) {
 	yl := NewYL40Driver(newI2cTestAdaptor())
-	assert.NoError(t, yl.Halt())
+	require.NoError(t, yl.Halt())
 }
 
 func fEqual(want interface{}, got interface{}) bool {

--- a/drivers/spi/apa102_test.go
+++ b/drivers/spi/apa102_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -40,5 +41,5 @@ func TestDriverLEDs(t *testing.T) {
 	d.SetRGBA(2, color.RGBA{255, 255, 255, 15})
 	d.SetRGBA(3, color.RGBA{255, 255, 255, 15})
 
-	assert.NoError(t, d.Draw())
+	require.NoError(t, d.Draw())
 }

--- a/drivers/spi/mcp3002_test.go
+++ b/drivers/spi/mcp3002_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/aio"
 )
@@ -87,6 +88,6 @@ func TestMCP3002ReadWithError(t *testing.T) {
 	// act
 	got, err := d.Read(0)
 	// assert
-	assert.ErrorContains(t, err, "error while SPI read in mock")
+	require.ErrorContains(t, err, "error while SPI read in mock")
 	assert.Equal(t, 0, got)
 }

--- a/drivers/spi/mcp3004_test.go
+++ b/drivers/spi/mcp3004_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/aio"
 )
@@ -93,6 +94,6 @@ func TestMCP3004ReadWithError(t *testing.T) {
 	// act
 	got, err := d.Read(0)
 	// assert
-	assert.ErrorContains(t, err, "error while SPI read in mock")
+	require.ErrorContains(t, err, "error while SPI read in mock")
 	assert.Equal(t, 0, got)
 }

--- a/drivers/spi/mcp3008_test.go
+++ b/drivers/spi/mcp3008_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/aio"
 )
@@ -93,6 +94,6 @@ func TestMCP3008ReadWithError(t *testing.T) {
 	// act
 	got, err := d.Read(0)
 	// assert
-	assert.ErrorContains(t, err, "error while SPI read in mock")
+	require.ErrorContains(t, err, "error while SPI read in mock")
 	assert.Equal(t, 0, got)
 }

--- a/drivers/spi/mcp3202_test.go
+++ b/drivers/spi/mcp3202_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/aio"
 )
@@ -87,6 +88,6 @@ func TestMCP3202ReadWithError(t *testing.T) {
 	// act
 	got, err := d.Read(0)
 	// assert
-	assert.ErrorContains(t, err, "error while SPI read in mock")
+	require.ErrorContains(t, err, "error while SPI read in mock")
 	assert.Equal(t, 0, got)
 }

--- a/drivers/spi/mcp3204_test.go
+++ b/drivers/spi/mcp3204_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/aio"
 )
@@ -93,6 +94,6 @@ func TestMCP3204ReadWithError(t *testing.T) {
 	// act
 	got, err := d.Read(0)
 	// assert
-	assert.ErrorContains(t, err, "error while SPI read in mock")
+	require.ErrorContains(t, err, "error while SPI read in mock")
 	assert.Equal(t, 0, got)
 }

--- a/drivers/spi/mcp3208_test.go
+++ b/drivers/spi/mcp3208_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/aio"
 )
@@ -93,6 +94,6 @@ func TestMCP3208ReadWithError(t *testing.T) {
 	// act
 	got, err := d.Read(0)
 	// assert
-	assert.ErrorContains(t, err, "error while SPI read in mock")
+	require.ErrorContains(t, err, "error while SPI read in mock")
 	assert.Equal(t, 0, got)
 }

--- a/drivers/spi/mcp3304_test.go
+++ b/drivers/spi/mcp3304_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/aio"
 )
@@ -93,6 +94,6 @@ func TestMCP3304ReadWithError(t *testing.T) {
 	// act
 	got, err := d.Read(0)
 	// assert
-	assert.ErrorContains(t, err, "error while SPI read in mock")
+	require.ErrorContains(t, err, "error while SPI read in mock")
 	assert.Equal(t, 0, got)
 }

--- a/drivers/spi/mfrc522_driver_test.go
+++ b/drivers/spi/mfrc522_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -39,6 +40,6 @@ func TestMFRC522WriteByteData(t *testing.T) {
 	// act
 	err := d.connection.WriteByteData(0x00, 0x00)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []byte{0x00, 0x00}, a.spi.Written())
 }

--- a/drivers/spi/spi_connection_test.go
+++ b/drivers/spi/spi_connection_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/system"
 )
@@ -38,7 +39,7 @@ func TestReadCommandData(t *testing.T) {
 	got := []byte{0x01, 0x02}
 	err := c.ReadCommandData(command, got)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, command, sysdev.Written())
 	assert.Equal(t, want, got)
 }
@@ -54,7 +55,7 @@ func TestReadByteData(t *testing.T) {
 	// act
 	got, err := c.ReadByteData(reg)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []byte{reg, 0x00}, sysdev.Written()) // for read register we need n+1 bytes
 	assert.Equal(t, want, got)
 }
@@ -71,7 +72,7 @@ func TestReadBlockData(t *testing.T) {
 	got := make([]byte, 4)
 	err := c.ReadBlockData(reg, got)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []byte{reg, 0x00, 0x00, 0x00, 0x00}, sysdev.Written()) // for read registers we need n+1 bytes
 	assert.Equal(t, want, got)
 }
@@ -83,7 +84,7 @@ func TestWriteByte(t *testing.T) {
 	// act
 	err := c.WriteByte(want)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []byte{want}, sysdev.Written())
 }
 
@@ -97,7 +98,7 @@ func TestWriteByteData(t *testing.T) {
 	// act
 	err := c.WriteByteData(reg, val)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []byte{reg, val}, sysdev.Written())
 }
 
@@ -109,7 +110,7 @@ func TestWriteBlockData(t *testing.T) {
 	// act
 	err := c.WriteBlockData(reg, data)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, append([]byte{reg}, data...), sysdev.Written())
 }
 
@@ -120,6 +121,6 @@ func TestWriteBytes(t *testing.T) {
 	// act
 	err := c.WriteBytes(want)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, want, sysdev.Written())
 }

--- a/drivers/spi/spi_driver.go
+++ b/drivers/spi/spi_driver.go
@@ -43,31 +43,31 @@ type Connection gobot.SpiOperations
 // optional SPI params such as which SPI bus it wants to use.
 type Config interface {
 	// SetBusNumber sets which bus to use
-	SetBusNumber(int)
+	SetBusNumber(bus int)
 
 	// GetBusNumberOrDefault gets which bus to use
 	GetBusNumberOrDefault(def int) int
 
 	// SetChipNumber sets which chip to use
-	SetChipNumber(int)
+	SetChipNumber(chip int)
 
 	// GetChipNumberOrDefault gets which chip to use
 	GetChipNumberOrDefault(def int) int
 
 	// SetMode sets which mode to use
-	SetMode(int)
+	SetMode(mode int)
 
 	// GetModeOrDefault gets which mode to use
 	GetModeOrDefault(def int) int
 
 	// SetUsedBits sets how many bits to use
-	SetBitCount(int)
+	SetBitCount(count int)
 
 	// GetBitCountOrDefault gets how many bits to use
 	GetBitCountOrDefault(def int) int
 
 	// SetSpeed sets which speed to use (in Hz)
-	SetSpeed(int64)
+	SetSpeed(speed int64)
 
 	// GetSpeedOrDefault gets which speed to use (in Hz)
 	GetSpeedOrDefault(def int64) int64

--- a/drivers/spi/spi_driver_test.go
+++ b/drivers/spi/spi_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -30,12 +31,12 @@ func TestNewDriver(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	d := NewDriver(newSpiTestAdaptor(), "SPI_BASIC")
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestHalt(t *testing.T) {
 	d, _ := initTestDriverWithStubbedAdaptor()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestSetName(t *testing.T) {

--- a/drivers/spi/ssd1306_driver_test.go
+++ b/drivers/spi/ssd1306_driver_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -19,29 +19,29 @@ func initTestSSDDriver() *SSD1306Driver {
 
 func TestDriverSSDStart(t *testing.T) {
 	d := initTestSSDDriver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestDriverSSDHalt(t *testing.T) {
 	d := initTestSSDDriver()
 	_ = d.Start()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestDriverSSDDisplay(t *testing.T) {
 	d := initTestSSDDriver()
 	_ = d.Start()
-	assert.NoError(t, d.Display())
+	require.NoError(t, d.Display())
 }
 
 func TestSSD1306DriverShowImage(t *testing.T) {
 	d := initTestSSDDriver()
 	_ = d.Start()
 	img := image.NewRGBA(image.Rect(0, 0, 640, 480))
-	assert.ErrorContains(t, d.ShowImage(img), "Image must match the display width and height")
+	require.ErrorContains(t, d.ShowImage(img), "Image must match the display width and height")
 
 	img = image.NewRGBA(image.Rect(0, 0, 128, 64))
-	assert.NoError(t, d.ShowImage(img))
+	require.NoError(t, d.ShowImage(img))
 }
 
 type gpioTestAdaptor struct {

--- a/master_test.go
+++ b/master_test.go
@@ -10,6 +10,7 @@ import (
 
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func initTestMaster() *Master {
@@ -41,7 +42,7 @@ func TestNullReadWriteCloser(t *testing.T) {
 	assert.Equal(t, 3, i)
 	i, _ = n.Read(make([]byte, 10))
 	assert.Equal(t, 10, i)
-	assert.NoError(t, n.Close())
+	require.NoError(t, n.Close())
 }
 
 func TestMasterRobot(t *testing.T) {
@@ -63,14 +64,14 @@ func TestMasterToJSON(t *testing.T) {
 		return nil
 	})
 	json := NewJSONMaster(g)
-	assert.Equal(t, g.Robots().Len(), len(json.Robots))
-	assert.Equal(t, len(g.Commands()), len(json.Commands))
+	assert.Len(t, json.Robots, g.Robots().Len())
+	assert.Len(t, json.Commands, len(g.Commands()))
 }
 
 func TestMasterStart(t *testing.T) {
 	g := initTestMaster()
-	assert.NoError(t, g.Start())
-	assert.NoError(t, g.Stop())
+	require.NoError(t, g.Start())
+	require.NoError(t, g.Stop())
 	assert.False(t, g.Running())
 }
 
@@ -82,7 +83,7 @@ func TestMasterStartAutoRun(t *testing.T) {
 	assert.True(t, g.Running())
 
 	// stop it
-	assert.NoError(t, g.Stop())
+	require.NoError(t, g.Stop())
 	assert.False(t, g.Running())
 }
 
@@ -99,7 +100,7 @@ func TestMasterStartDriverErrors(t *testing.T) {
 	want = multierror.Append(want, e)
 
 	assert.Equal(t, want, g.Start())
-	assert.NoError(t, g.Stop())
+	require.NoError(t, g.Stop())
 
 	testDriverStart = func() (err error) { return }
 }
@@ -138,7 +139,7 @@ func TestMasterStartRobotAdaptorErrors(t *testing.T) {
 	}
 
 	assert.Equal(t, want, g.Start())
-	assert.NoError(t, g.Stop())
+	require.NoError(t, g.Stop())
 
 	testAdaptorConnect = func() (err error) { return }
 }

--- a/platforms/adaptors/digitalpinsadaptor.go
+++ b/platforms/adaptors/digitalpinsadaptor.go
@@ -17,7 +17,7 @@ type (
 )
 
 type digitalPinsOptioner interface {
-	setDigitalPinInitializer(digitalPinInitializer)
+	setDigitalPinInitializer(initializer digitalPinInitializer)
 	setDigitalPinsForSystemGpiod()
 	setDigitalPinsForSystemSpi(sclkPin, nssPin, mosiPin, misoPin string)
 	prepareDigitalPinsActiveLow(pin string, otherPins ...string)

--- a/platforms/adaptors/i2cbusadaptor_test.go
+++ b/platforms/adaptors/i2cbusadaptor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2/drivers/i2c"
 	"gobot.io/x/gobot/v2/system"
 )
@@ -33,22 +34,22 @@ func initTestI2cAdaptorWithMockedFilesystem(mockPaths []string) (*I2cBusAdaptor,
 
 func TestI2cWorkflow(t *testing.T) {
 	a, _ := initTestI2cAdaptorWithMockedFilesystem([]string{i2cBus1})
-	assert.Equal(t, 0, len(a.buses))
+	assert.Empty(t, a.buses)
 
 	con, err := a.GetI2cConnection(0xff, 1)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(a.buses))
+	require.NoError(t, err)
+	assert.Len(t, a.buses, 1)
 
 	_, err = con.Write([]byte{0x00, 0x01})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	data := []byte{42, 42}
 	_, err = con.Read(data)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []byte{0x00, 0x01}, data)
 
-	assert.NoError(t, a.Finalize())
-	assert.Equal(t, 0, len(a.buses))
+	require.NoError(t, a.Finalize())
+	assert.Empty(t, a.buses)
 }
 
 func TestI2cGetI2cConnection(t *testing.T) {
@@ -56,40 +57,40 @@ func TestI2cGetI2cConnection(t *testing.T) {
 	a, _ := initTestI2cAdaptorWithMockedFilesystem([]string{i2cBus1})
 	// assert working connection
 	c1, e1 := a.GetI2cConnection(0xff, 1)
-	assert.NoError(t, e1)
+	require.NoError(t, e1)
 	assert.NotNil(t, c1)
-	assert.Equal(t, 1, len(a.buses))
+	assert.Len(t, a.buses, 1)
 	// assert invalid bus gets error
 	c2, e2 := a.GetI2cConnection(0x01, 99)
-	assert.ErrorContains(t, e2, "99 not valid")
+	require.ErrorContains(t, e2, "99 not valid")
 	assert.Nil(t, c2)
-	assert.Equal(t, 1, len(a.buses))
+	assert.Len(t, a.buses, 1)
 	// assert unconnected gets error
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 	c3, e3 := a.GetI2cConnection(0x01, 99)
-	assert.ErrorContains(t, e3, "not connected")
+	require.ErrorContains(t, e3, "not connected")
 	assert.Nil(t, c3)
-	assert.Equal(t, 0, len(a.buses))
+	assert.Empty(t, a.buses)
 }
 
 func TestI2cFinalize(t *testing.T) {
 	// arrange
 	a, fs := initTestI2cAdaptorWithMockedFilesystem([]string{i2cBus1})
 	// assert that finalize before connect is working
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 	// arrange
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 	_, _ = a.GetI2cConnection(0xaf, 1)
-	assert.Equal(t, 1, len(a.buses))
+	assert.Len(t, a.buses, 1)
 	// assert that Finalize after GetI2cConnection is working and clean up
-	assert.NoError(t, a.Finalize())
-	assert.Equal(t, 0, len(a.buses))
+	require.NoError(t, a.Finalize())
+	assert.Empty(t, a.buses)
 	// assert that finalize after finalize is working
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 	// assert that close error is recognized
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 	con, _ := a.GetI2cConnection(0xbf, 1)
-	assert.Equal(t, 1, len(a.buses))
+	assert.Len(t, a.buses, 1)
 	_, _ = con.Write([]byte{0xbf})
 	fs.WithCloseError = true
 	err := a.Finalize()
@@ -99,12 +100,12 @@ func TestI2cFinalize(t *testing.T) {
 func TestI2cReConnect(t *testing.T) {
 	// arrange
 	a, _ := initTestI2cAdaptorWithMockedFilesystem([]string{i2cBus1})
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 	// act
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 	// assert
 	assert.NotNil(t, a.buses)
-	assert.Equal(t, 0, len(a.buses))
+	assert.Empty(t, a.buses)
 }
 
 func TestI2cGetDefaultBus(t *testing.T) {

--- a/platforms/adaptors/pwmpinsadaptor.go
+++ b/platforms/adaptors/pwmpinsadaptor.go
@@ -21,9 +21,9 @@ type (
 )
 
 type pwmPinsOption interface {
-	setInitializer(pwmPinInitializer)
-	setDefaultPeriod(uint32)
-	setPolarityInvertedIdentifier(string)
+	setInitializer(initializer pwmPinInitializer)
+	setDefaultPeriod(period uint32)
+	setPolarityInvertedIdentifier(id string)
 }
 
 // PWMPinsAdaptor is a adaptor for PWM pins, normally used for composition in platforms.

--- a/platforms/adaptors/spibusadaptor_test.go
+++ b/platforms/adaptors/spibusadaptor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2/drivers/spi"
 	"gobot.io/x/gobot/v2/system"
 )
@@ -40,7 +41,7 @@ func TestNewSpiAdaptor(t *testing.T) {
 	assert.Equal(t, 4, a.SpiDefaultBitCount())
 	assert.Equal(t, int64(5), a.SpiDefaultMaxSpeed())
 	_, err := a.GetSpiConnection(10, 0, 0, 8, 10000000)
-	assert.ErrorContains(t, err, "not connected")
+	require.ErrorContains(t, err, "not connected")
 }
 
 func TestGetSpiConnection(t *testing.T) {
@@ -53,32 +54,32 @@ func TestGetSpiConnection(t *testing.T) {
 		maxSpeed = int64(11)
 	)
 	a, spi := initTestSpiBusAdaptorWithMockedSpi()
-	assert.Equal(t, 0, len(a.connections))
+	assert.Empty(t, a.connections)
 	// act
 	con1, err1 := a.GetSpiConnection(busNum, chipNum, mode, bits, maxSpeed)
 	// assert
-	assert.NoError(t, err1)
+	require.NoError(t, err1)
 	assert.NotNil(t, con1)
-	assert.Equal(t, 1, len(a.connections))
+	assert.Len(t, a.connections, 1)
 	// assert cached connection
 	con1a, err2 := a.GetSpiConnection(busNum, chipNum, mode, bits, maxSpeed)
-	assert.NoError(t, err2)
+	require.NoError(t, err2)
 	assert.Equal(t, con1, con1a)
-	assert.Equal(t, 1, len(a.connections))
+	assert.Len(t, a.connections, 1)
 	// assert second connection
 	con2, err3 := a.GetSpiConnection(busNum, chipNum+1, mode, bits, maxSpeed)
-	assert.NoError(t, err3)
+	require.NoError(t, err3)
 	assert.NotNil(t, con2)
 	assert.NotEqual(t, con1, con2)
-	assert.Equal(t, 2, len(a.connections))
+	assert.Len(t, a.connections, 2)
 	// assert bus validation error
 	con, err := a.GetSpiConnection(busNum+1, chipNum, mode, bits, maxSpeed)
-	assert.ErrorContains(t, err, "16 not valid")
+	require.ErrorContains(t, err, "16 not valid")
 	assert.Nil(t, con)
 	// assert create error
 	spi.CreateError = true
 	con, err = a.GetSpiConnection(busNum, chipNum+2, mode, bits, maxSpeed)
-	assert.ErrorContains(t, err, "error while create SPI connection in mock")
+	require.ErrorContains(t, err, "error while create SPI connection in mock")
 	assert.Nil(t, con)
 }
 
@@ -86,20 +87,20 @@ func TestSpiFinalize(t *testing.T) {
 	// arrange
 	a, _ := initTestSpiBusAdaptorWithMockedSpi()
 	_, e := a.GetSpiConnection(spiTestAllowedBus, 2, 3, 4, 5)
-	assert.NoError(t, e)
-	assert.Equal(t, 1, len(a.connections))
+	require.NoError(t, e)
+	assert.Len(t, a.connections, 1)
 	// act
 	err := a.Finalize()
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 0, len(a.connections))
+	require.NoError(t, err)
+	assert.Empty(t, a.connections)
 }
 
 func TestSpiFinalizeWithError(t *testing.T) {
 	// arrange
 	a, spi := initTestSpiBusAdaptorWithMockedSpi()
 	_, e := a.GetSpiConnection(spiTestAllowedBus, 2, 3, 4, 5)
-	assert.NoError(t, e)
+	require.NoError(t, e)
 	spi.SetCloseError(true)
 	// act
 	err := a.Finalize()
@@ -110,10 +111,10 @@ func TestSpiFinalizeWithError(t *testing.T) {
 func TestSpiReConnect(t *testing.T) {
 	// arrange
 	a, _ := initTestSpiBusAdaptorWithMockedSpi()
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 	// act
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 	// assert
 	assert.NotNil(t, a.connections)
-	assert.Equal(t, 0, len(a.connections))
+	assert.Empty(t, a.connections)
 }

--- a/platforms/audio/audio_adaptor_test.go
+++ b/platforms/audio/audio_adaptor_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -16,8 +17,8 @@ var _ gobot.Adaptor = (*Adaptor)(nil)
 func TestAudioAdaptor(t *testing.T) {
 	a := NewAdaptor()
 
-	assert.NoError(t, a.Connect())
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Connect())
+	require.NoError(t, a.Finalize())
 }
 
 func TestAudioAdaptorName(t *testing.T) {
@@ -40,7 +41,7 @@ func TestAudioAdaptorCommandsMp3(t *testing.T) {
 func TestAudioAdaptorCommandsUnknown(t *testing.T) {
 	cmd, err := CommandName("whatever.unk")
 	assert.NotEqual(t, "mpg123", cmd)
-	assert.ErrorContains(t, err, "Unknown filetype for audio file.")
+	require.ErrorContains(t, err, "Unknown filetype for audio file.")
 }
 
 func TestAudioAdaptorSoundWithNoFilename(t *testing.T) {
@@ -65,7 +66,7 @@ func TestAudioAdaptorSoundWithValidMP3Filename(t *testing.T) {
 
 	errors := a.Sound("../../examples/laser.mp3")
 
-	assert.Equal(t, 0, len(errors))
+	assert.Empty(t, errors)
 }
 
 func myExecCommand(command string, args ...string) *exec.Cmd {

--- a/platforms/audio/audio_driver_test.go
+++ b/platforms/audio/audio_driver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -20,9 +21,9 @@ func TestAudioDriver(t *testing.T) {
 
 	assert.NotNil(t, d.Connection())
 
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestAudioDriverName(t *testing.T) {
@@ -46,5 +47,5 @@ func TestAudioDriverSoundWithDefaultFilename(t *testing.T) {
 	d := NewDriver(NewAdaptor(), "../../examples/laser.mp3")
 
 	errors := d.Play()
-	assert.Equal(t, 0, len(errors))
+	assert.Empty(t, errors)
 }

--- a/platforms/ble/battery_driver_test.go
+++ b/platforms/ble/battery_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -24,8 +25,8 @@ func TestBatteryDriver(t *testing.T) {
 
 func TestBatteryDriverStartAndHalt(t *testing.T) {
 	d := initTestBatteryDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
 }
 
 func TestBatteryDriverRead(t *testing.T) {

--- a/platforms/ble/ble_client_adaptor.go
+++ b/platforms/ble/ble_client_adaptor.go
@@ -18,17 +18,16 @@ var (
 
 // BLEConnector is the interface that a BLE ClientAdaptor must implement
 type BLEConnector interface {
-	Connect() error
+	gobot.Adaptor
+
 	Reconnect() error
 	Disconnect() error
-	Finalize() error
-	Name() string
-	SetName(string)
 	Address() string
-	ReadCharacteristic(string) ([]byte, error)
-	WriteCharacteristic(string, []byte) error
-	Subscribe(string, func([]byte, error)) error
-	WithoutResponses(bool)
+
+	ReadCharacteristic(cUUID string) ([]byte, error)
+	WriteCharacteristic(cUUID string, data []byte) error
+	Subscribe(cUUID string, f func([]byte, error)) error
+	WithoutResponses(use bool)
 }
 
 // ClientAdaptor represents a Client Connection to a BLE Peripheral

--- a/platforms/ble/device_information_driver_test.go
+++ b/platforms/ble/device_information_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -24,8 +25,8 @@ func TestDeviceInformationDriver(t *testing.T) {
 
 func TestDeviceInformationDriverStartAndHalt(t *testing.T) {
 	d := initTestDeviceInformationDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
 }
 
 func TestDeviceInformationDriverGetModelNumber(t *testing.T) {

--- a/platforms/ble/generic_access_driver_test.go
+++ b/platforms/ble/generic_access_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -24,8 +25,8 @@ func TestGenericAccessDriver(t *testing.T) {
 
 func TestGenericAccessDriverStartAndHalt(t *testing.T) {
 	d := initTestGenericAccessDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
 }
 
 func TestGenericAccessDriverGetDeviceName(t *testing.T) {

--- a/platforms/chip/chip_adaptor_test.go
+++ b/platforms/chip/chip_adaptor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/gpio"
 	"gobot.io/x/gobot/v2/drivers/i2c"
@@ -71,8 +72,8 @@ func TestNewProAdaptor(t *testing.T) {
 
 func TestFinalizeErrorAfterGPIO(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem()
-	assert.NoError(t, a.Connect())
-	assert.NoError(t, a.DigitalWrite("CSID7", 1))
+	require.NoError(t, a.Connect())
+	require.NoError(t, a.DigitalWrite("CSID7", 1))
 
 	fs.WithWriteError = true
 
@@ -85,8 +86,8 @@ func TestFinalizeErrorAfterPWM(t *testing.T) {
 	fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents = "0"
 	fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents = "0"
 
-	assert.NoError(t, a.Connect())
-	assert.NoError(t, a.PwmWrite("PWM0", 100))
+	require.NoError(t, a.Connect())
+	require.NoError(t, a.PwmWrite("PWM0", 100))
 
 	fs.WithWriteError = true
 
@@ -105,8 +106,8 @@ func TestDigitalIO(t *testing.T) {
 	i, _ := a.DigitalRead("TWI2-SDA")
 	assert.Equal(t, 1, i)
 
-	assert.ErrorContains(t, a.DigitalWrite("XIO-P10", 1), "'XIO-P10' is not a valid id for a digital pin")
-	assert.NoError(t, a.Finalize())
+	require.ErrorContains(t, a.DigitalWrite("XIO-P10", 1), "'XIO-P10' is not a valid id for a digital pin")
+	require.NoError(t, a.Finalize())
 }
 
 func TestProDigitalIO(t *testing.T) {
@@ -120,8 +121,8 @@ func TestProDigitalIO(t *testing.T) {
 	i, _ := a.DigitalRead("TWI2-SDA")
 	assert.Equal(t, 1, i)
 
-	assert.ErrorContains(t, a.DigitalWrite("XIO-P0", 1), "'XIO-P0' is not a valid id for a digital pin")
-	assert.NoError(t, a.Finalize())
+	require.ErrorContains(t, a.DigitalWrite("XIO-P0", 1), "'XIO-P0' is not a valid id for a digital pin")
+	require.NoError(t, a.Finalize())
 }
 
 func TestPWM(t *testing.T) {
@@ -132,7 +133,7 @@ func TestPWM(t *testing.T) {
 	_ = a.Connect()
 
 	err := a.PwmWrite("PWM0", 100)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "0", fs.Files["/sys/class/pwm/pwmchip0/export"].Contents)
 	assert.Equal(t, "1", fs.Files["/sys/class/pwm/pwmchip0/pwm0/enable"].Contents)
@@ -141,18 +142,18 @@ func TestPWM(t *testing.T) {
 	assert.Equal(t, "normal", fs.Files["/sys/class/pwm/pwmchip0/pwm0/polarity"].Contents)
 
 	err = a.ServoWrite("PWM0", 0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "500000", fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents)
 	assert.Equal(t, "10000000", fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents)
 
 	err = a.ServoWrite("PWM0", 180)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "2000000", fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents)
 	assert.Equal(t, "10000000", fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents) // pwmPeriodDefault
 
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 }
 
 func TestI2cDefaultBus(t *testing.T) {
@@ -165,11 +166,11 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a := NewAdaptor()
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-2"})
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 	con, err := a.GetI2cConnection(0xff, 2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = con.Write([]byte{0xbf})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/dexter/gopigo3/driver_test.go
+++ b/platforms/dexter/gopigo3/driver_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/spi"
 )
@@ -22,12 +22,12 @@ func initTestDriver() *Driver {
 
 func TestDriverStart(t *testing.T) {
 	d := initTestDriver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestDriverHalt(t *testing.T) {
 	d := initTestDriver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestDriverManufacturerName(t *testing.T) {

--- a/platforms/digispark/digispark_adaptor_test.go
+++ b/platforms/digispark/digispark_adaptor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/gpio"
 )
@@ -92,56 +93,56 @@ func TestDigisparkAdaptorName(t *testing.T) {
 
 func TestDigisparkAdaptorConnect(t *testing.T) {
 	a := initTestAdaptor()
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 }
 
 func TestDigisparkAdaptorFinalize(t *testing.T) {
 	a := initTestAdaptor()
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 }
 
 func TestDigisparkAdaptorDigitalWrite(t *testing.T) {
 	a := initTestAdaptor()
 	err := a.DigitalWrite("0", uint8(1))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, uint8(0), a.littleWire.(*mock).pin)
 	assert.Equal(t, uint8(1), a.littleWire.(*mock).state)
 
 	err = a.DigitalWrite("?", uint8(1))
-	assert.NotNil(t, err)
+	require.Error(t, err)
 
 	errorFunc = func() error { return errors.New("pin mode error") }
 	err = a.DigitalWrite("0", uint8(1))
-	assert.ErrorContains(t, err, "pin mode error")
+	require.ErrorContains(t, err, "pin mode error")
 }
 
 func TestDigisparkAdaptorServoWrite(t *testing.T) {
 	a := initTestAdaptor()
 	err := a.ServoWrite("2", uint8(80))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, uint8(80), a.littleWire.(*mock).locationA)
 	assert.Equal(t, uint8(80), a.littleWire.(*mock).locationB)
 
 	a = initTestAdaptor()
 	errorFunc = func() error { return errors.New("servo error") }
 	err = a.ServoWrite("2", uint8(80))
-	assert.ErrorContains(t, err, "servo error")
+	require.ErrorContains(t, err, "servo error")
 }
 
 func TestDigisparkAdaptorPwmWrite(t *testing.T) {
 	a := initTestAdaptor()
 	err := a.PwmWrite("1", uint8(100))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, uint8(100), a.littleWire.(*mock).pwmChannelA)
 	assert.Equal(t, uint8(100), a.littleWire.(*mock).pwmChannelB)
 
 	a = initTestAdaptor()
 	pwmInitErrorFunc = func() error { return errors.New("pwminit error") }
 	err = a.PwmWrite("1", uint8(100))
-	assert.ErrorContains(t, err, "pwminit error")
+	require.ErrorContains(t, err, "pwminit error")
 
 	a = initTestAdaptor()
 	errorFunc = func() error { return errors.New("pwm error") }
 	err = a.PwmWrite("1", uint8(100))
-	assert.ErrorContains(t, err, "pwm error")
+	require.ErrorContains(t, err, "pwm error")
 }

--- a/platforms/digispark/digispark_i2c_test.go
+++ b/platforms/digispark/digispark_i2c_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2/drivers/i2c"
 )
 
@@ -45,7 +46,7 @@ func TestDigisparkAdaptorI2cGetI2cConnection(t *testing.T) {
 	c, err = a.GetI2cConnection(availableI2cAddress, a.DefaultI2cBus())
 
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, c)
 }
 
@@ -57,7 +58,7 @@ func TestDigisparkAdaptorI2cGetI2cConnectionFailWithInvalidBus(t *testing.T) {
 	c, err := a.GetI2cConnection(0x40, 1)
 
 	// assert
-	assert.ErrorContains(t, err, "Invalid bus number 1, only 0 is supported")
+	require.ErrorContains(t, err, "Invalid bus number 1, only 0 is supported")
 	assert.Nil(t, c)
 }
 
@@ -72,7 +73,7 @@ func TestDigisparkAdaptorI2cStartFailWithWrongAddress(t *testing.T) {
 
 	// assert
 	assert.Equal(t, 0, count)
-	assert.ErrorContains(t, err, fmt.Sprintf("Invalid address, only %d is supported", availableI2cAddress))
+	require.ErrorContains(t, err, fmt.Sprintf("Invalid address, only %d is supported", availableI2cAddress))
 	assert.Equal(t, maxUint8, a.littleWire.(*i2cMock).direction)
 }
 
@@ -87,7 +88,7 @@ func TestDigisparkAdaptorI2cWrite(t *testing.T) {
 	count, err := c.Write(data)
 
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.False(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(0), a.littleWire.(*i2cMock).direction)
@@ -107,7 +108,7 @@ func TestDigisparkAdaptorI2cWriteByte(t *testing.T) {
 	err := c.WriteByte(data)
 
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.False(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(0), a.littleWire.(*i2cMock).direction)
@@ -127,7 +128,7 @@ func TestDigisparkAdaptorI2cWriteByteData(t *testing.T) {
 	err := c.WriteByteData(reg, data)
 
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.False(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(0), a.littleWire.(*i2cMock).direction)
@@ -147,7 +148,7 @@ func TestDigisparkAdaptorI2cWriteWordData(t *testing.T) {
 	err := c.WriteWordData(reg, data)
 
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.False(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(0), a.littleWire.(*i2cMock).direction)
@@ -167,7 +168,7 @@ func TestDigisparkAdaptorI2cWriteBlockData(t *testing.T) {
 	err := c.WriteBlockData(reg, data)
 
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.False(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(0), a.littleWire.(*i2cMock).direction)
@@ -188,7 +189,7 @@ func TestDigisparkAdaptorI2cRead(t *testing.T) {
 
 	// assert
 	assert.Equal(t, dataLen, count)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.True(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(1), a.littleWire.(*i2cMock).direction)
@@ -206,7 +207,7 @@ func TestDigisparkAdaptorI2cReadByte(t *testing.T) {
 	data, err := c.ReadByte()
 
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.True(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(1), a.littleWire.(*i2cMock).direction)
@@ -225,7 +226,7 @@ func TestDigisparkAdaptorI2cReadByteData(t *testing.T) {
 	data, err := c.ReadByteData(reg)
 
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.True(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(1), a.littleWire.(*i2cMock).direction)
@@ -247,7 +248,7 @@ func TestDigisparkAdaptorI2cReadWordData(t *testing.T) {
 	data, err := c.ReadWordData(reg)
 
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.True(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(1), a.littleWire.(*i2cMock).direction)
@@ -269,7 +270,7 @@ func TestDigisparkAdaptorI2cReadBlockData(t *testing.T) {
 	err := c.ReadBlockData(reg, data)
 
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, a.littleWire.(*i2cMock).writeStartWasSend)
 	assert.True(t, a.littleWire.(*i2cMock).readStartWasSend)
 	assert.Equal(t, uint8(1), a.littleWire.(*i2cMock).direction)
@@ -288,7 +289,7 @@ func TestDigisparkAdaptorI2cUpdateDelay(t *testing.T) {
 	err := c.(*digisparkI2cConnection).UpdateDelay(uint(100))
 
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, uint(100), a.littleWire.(*i2cMock).duration)
 }
 

--- a/platforms/digispark/littleWire.go
+++ b/platforms/digispark/littleWire.go
@@ -12,14 +12,14 @@ import (
 )
 
 type lw interface {
-	digitalWrite(uint8, uint8) error
-	pinMode(uint8, uint8) error
+	digitalWrite(pin uint8, state uint8) error
+	pinMode(pin uint8, mode uint8) error
 	pwmInit() error
 	pwmStop() error
-	pwmUpdateCompare(uint8, uint8) error
-	pwmUpdatePrescaler(uint) error
+	pwmUpdateCompare(channelA uint8, channelb uint8) error
+	pwmUpdatePrescaler(value uint) error
 	servoInit() error
-	servoUpdateLocation(uint8, uint8) error
+	servoUpdateLocation(locationA uint8, locationB uint8) error
 	i2cInit() error
 	i2cStart(address7bit uint8, direction uint8) error
 	i2cWrite(sendBuffer []byte, length int, endWithStop uint8) error

--- a/platforms/dragonboard/dragonboard_adaptor_test.go
+++ b/platforms/dragonboard/dragonboard_adaptor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/gpio"
 	"gobot.io/x/gobot/v2/drivers/i2c"
@@ -54,8 +55,8 @@ func TestDigitalIO(t *testing.T) {
 	i, _ := a.DigitalRead("GPIO_A")
 	assert.Equal(t, 1, i)
 
-	assert.ErrorContains(t, a.DigitalWrite("GPIO_M", 1), "'GPIO_M' is not a valid id for a digital pin")
-	assert.NoError(t, a.Finalize())
+	require.ErrorContains(t, a.DigitalWrite("GPIO_M", 1), "'GPIO_M' is not a valid id for a digital pin")
+	require.NoError(t, a.Finalize())
 }
 
 func TestFinalizeErrorAfterGPIO(t *testing.T) {
@@ -70,8 +71,8 @@ func TestFinalizeErrorAfterGPIO(t *testing.T) {
 	}
 	fs := a.sys.UseMockFilesystem(mockPaths)
 
-	assert.NoError(t, a.Connect())
-	assert.NoError(t, a.DigitalWrite("GPIO_B", 1))
+	require.NoError(t, a.Connect())
+	require.NoError(t, a.DigitalWrite("GPIO_B", 1))
 
 	fs.WithWriteError = true
 
@@ -89,11 +90,11 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a := NewAdaptor()
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-1"})
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 	con, err := a.GetI2cConnection(0xff, 1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = con.Write([]byte{0xbf})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/firmata/client/client_test.go
+++ b/platforms/firmata/client/client_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const semPublishWait = 10 * time.Millisecond
@@ -114,23 +115,23 @@ func initTestFirmataWithReadWriteCloser(name string, data ...[]byte) (*Client, r
 
 func TestPins(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name(), testDataCapabilitiesResponse, testDataAnalogMappingResponse)
-	assert.Equal(t, 20, len(b.Pins()))
-	assert.Equal(t, 6, len(b.analogPins))
+	assert.Len(t, b.Pins(), 20)
+	assert.Len(t, b.analogPins, 6)
 }
 
 func TestProtocolVersionQuery(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
-	assert.NoError(t, b.ProtocolVersionQuery())
+	require.NoError(t, b.ProtocolVersionQuery())
 }
 
 func TestFirmwareQuery(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
-	assert.NoError(t, b.FirmwareQuery())
+	require.NoError(t, b.FirmwareQuery())
 }
 
 func TestPinStateQuery(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
-	assert.NoError(t, b.PinStateQuery(1))
+	require.NoError(t, b.PinStateQuery(1))
 }
 
 func TestProcessProtocolVersion(t *testing.T) {
@@ -232,23 +233,23 @@ func TestProcessDigitalRead4(t *testing.T) {
 
 func TestDigitalWrite(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name(), testDataCapabilitiesResponse)
-	assert.NoError(t, b.DigitalWrite(13, 0))
+	require.NoError(t, b.DigitalWrite(13, 0))
 }
 
 func TestSetPinMode(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name(), testDataCapabilitiesResponse)
-	assert.NoError(t, b.SetPinMode(13, Output))
+	require.NoError(t, b.SetPinMode(13, Output))
 }
 
 func TestAnalogWrite(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name(), testDataCapabilitiesResponse)
-	assert.NoError(t, b.AnalogWrite(0, 128))
+	require.NoError(t, b.AnalogWrite(0, 128))
 }
 
 func TestReportAnalog(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
-	assert.NoError(t, b.ReportAnalog(0, 1))
-	assert.NoError(t, b.ReportAnalog(0, 0))
+	require.NoError(t, b.ReportAnalog(0, 1))
+	require.NoError(t, b.ReportAnalog(0, 0))
 }
 
 func TestProcessPinState13(t *testing.T) {
@@ -272,22 +273,22 @@ func TestProcessPinState13(t *testing.T) {
 
 func TestI2cConfig(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
-	assert.NoError(t, b.I2cConfig(100))
+	require.NoError(t, b.I2cConfig(100))
 }
 
 func TestI2cWrite(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
-	assert.NoError(t, b.I2cWrite(0x00, []byte{0x01, 0x02}))
+	require.NoError(t, b.I2cWrite(0x00, []byte{0x01, 0x02}))
 }
 
 func TestI2cRead(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
-	assert.NoError(t, b.I2cRead(0x00, 10))
+	require.NoError(t, b.I2cRead(0x00, 10))
 }
 
 func TestWriteSysex(t *testing.T) {
 	b, _ := initTestFirmataWithReadWriteCloser(t.Name())
-	assert.NoError(t, b.WriteSysex([]byte{0x01, 0x02}))
+	require.NoError(t, b.WriteSysex([]byte{0x01, 0x02}))
 }
 
 func TestProcessI2cReply(t *testing.T) {
@@ -373,9 +374,9 @@ func TestConnect(t *testing.T) {
 		rwc.addTestReadData(testDataProtocolResponse)
 	})
 
-	assert.NoError(t, b.Connect(rwc))
+	require.NoError(t, b.Connect(rwc))
 	time.Sleep(150 * time.Millisecond)
-	assert.NoError(t, b.Disconnect())
+	require.NoError(t, b.Disconnect())
 }
 
 func TestServoConfig(t *testing.T) {

--- a/platforms/firmata/firmata_adaptor.go
+++ b/platforms/firmata/firmata_adaptor.go
@@ -16,18 +16,18 @@ import (
 )
 
 type firmataBoard interface {
-	Connect(io.ReadWriteCloser) error
+	Connect(conn io.ReadWriteCloser) error
 	Disconnect() error
 	Pins() []client.Pin
-	AnalogWrite(int, int) error
-	SetPinMode(int, int) error
-	ReportAnalog(int, int) error
-	ReportDigital(int, int) error
-	DigitalWrite(int, int) error
-	I2cRead(int, int) error
-	I2cWrite(int, []byte) error
-	I2cConfig(int) error
-	ServoConfig(int, int, int) error
+	AnalogWrite(pin int, value int) (err error)
+	SetPinMode(pin int, mode int) error
+	ReportAnalog(pin int, state int) error
+	ReportDigital(pin int, state int) error
+	DigitalWrite(pin int, value int) error
+	I2cRead(address int, numBytes int) error
+	I2cWrite(address int, data []byte) error
+	I2cConfig(delay int) error
+	ServoConfig(pin int, max int, min int) error
 	WriteSysex(data []byte) error
 	gobot.Eventer
 }

--- a/platforms/firmata/firmata_adaptor_test.go
+++ b/platforms/firmata/firmata_adaptor_test.go
@@ -6,12 +6,11 @@ package firmata
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/aio"
 	"gobot.io/x/gobot/v2/drivers/gpio"
@@ -114,11 +113,11 @@ func TestNewAdaptor(t *testing.T) {
 
 func TestAdaptorFinalize(t *testing.T) {
 	a := initTestAdaptor()
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 
 	a = initTestAdaptor()
 	a.Board.(*mockFirmataBoard).disconnectError = errors.New("close error")
-	assert.ErrorContains(t, a.Finalize(), "close error")
+	require.ErrorContains(t, a.Finalize(), "close error")
 }
 
 func TestAdaptorConnect(t *testing.T) {
@@ -128,94 +127,94 @@ func TestAdaptorConnect(t *testing.T) {
 	a := NewAdaptor("/dev/null")
 	a.PortOpener = openSP
 	a.Board = newMockFirmataBoard()
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 
 	a = NewAdaptor("/dev/null")
 	a.Board = newMockFirmataBoard()
 	a.PortOpener = func(port string) (io.ReadWriteCloser, error) {
 		return nil, errors.New("connect error")
 	}
-	assert.ErrorContains(t, a.Connect(), "connect error")
+	require.ErrorContains(t, a.Connect(), "connect error")
 
 	a = NewAdaptor(&readWriteCloser{})
 	a.Board = newMockFirmataBoard()
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 
 	a = NewAdaptor("/dev/null")
 	a.Board = nil
-	assert.NoError(t, a.Disconnect())
+	require.NoError(t, a.Disconnect())
 }
 
 func TestAdaptorServoWrite(t *testing.T) {
 	a := initTestAdaptor()
-	assert.NoError(t, a.ServoWrite("1", 50))
+	require.NoError(t, a.ServoWrite("1", 50))
 }
 
 func TestAdaptorServoWriteBadPin(t *testing.T) {
 	a := initTestAdaptor()
-	assert.NotNil(t, a.ServoWrite("xyz", 50))
+	require.Error(t, a.ServoWrite("xyz", 50))
 }
 
 func TestAdaptorPwmWrite(t *testing.T) {
 	a := initTestAdaptor()
-	assert.NoError(t, a.PwmWrite("1", 50))
+	require.NoError(t, a.PwmWrite("1", 50))
 }
 
 func TestAdaptorPwmWriteBadPin(t *testing.T) {
 	a := initTestAdaptor()
-	assert.NotNil(t, a.PwmWrite("xyz", 50))
+	require.Error(t, a.PwmWrite("xyz", 50))
 }
 
 func TestAdaptorDigitalWrite(t *testing.T) {
 	a := initTestAdaptor()
-	assert.NoError(t, a.DigitalWrite("1", 1))
+	require.NoError(t, a.DigitalWrite("1", 1))
 }
 
 func TestAdaptorDigitalWriteBadPin(t *testing.T) {
 	a := initTestAdaptor()
-	assert.NotNil(t, a.DigitalWrite("xyz", 50))
+	require.Error(t, a.DigitalWrite("xyz", 50))
 }
 
 func TestAdaptorDigitalRead(t *testing.T) {
 	a := initTestAdaptor()
 	val, err := a.DigitalRead("1")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, val)
 
 	val, err = a.DigitalRead("0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 0, val)
 }
 
 func TestAdaptorDigitalReadBadPin(t *testing.T) {
 	a := initTestAdaptor()
 	_, err := a.DigitalRead("xyz")
-	assert.NotNil(t, err)
+	require.Error(t, err)
 }
 
 func TestAdaptorAnalogRead(t *testing.T) {
 	a := initTestAdaptor()
 	val, err := a.AnalogRead("1")
 	assert.Equal(t, 133, val)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, err = a.AnalogRead("0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 0, val)
 }
 
 func TestAdaptorAnalogReadBadPin(t *testing.T) {
 	a := initTestAdaptor()
 	_, err := a.AnalogRead("xyz")
-	assert.NotNil(t, err)
+	require.Error(t, err)
 }
 
 func TestServoConfig(t *testing.T) {
 	a := initTestAdaptor()
 	err := a.ServoConfig("9", 0, 0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// test atoi error
 	err = a.ServoConfig("a", 0, 0)
-	assert.Equal(t, strings.Contains(fmt.Sprintf("%v", err), "invalid syntax"), true)
+	require.ErrorContains(t, err, "invalid syntax")
 }

--- a/platforms/firmata/firmata_i2c_test.go
+++ b/platforms/firmata/firmata_i2c_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/i2c"
 	"gobot.io/x/gobot/v2/platforms/firmata/client"
@@ -75,7 +76,7 @@ func initTestTestAdaptorWithI2cConnection() (i2c.Connection, *i2cMockFirmataBoar
 
 func TestClose(t *testing.T) {
 	i2c, _ := initTestTestAdaptorWithI2cConnection()
-	assert.NoError(t, i2c.Close())
+	require.NoError(t, i2c.Close())
 }
 
 func TestRead(t *testing.T) {
@@ -85,11 +86,11 @@ func TestRead(t *testing.T) {
 	buf := []byte{0}
 	// act
 	countRead, err := con.Read(buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, countRead)
 	assert.Equal(t, 1, brd.numBytesToRead)
 	assert.Equal(t, brd.i2cDataForRead, buf)
-	assert.Equal(t, 0, len(brd.i2cWritten))
+	assert.Empty(t, brd.i2cWritten)
 }
 
 func TestReadByte(t *testing.T) {
@@ -99,10 +100,10 @@ func TestReadByte(t *testing.T) {
 	// act
 	val, err := con.ReadByte()
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, brd.numBytesToRead)
 	assert.Equal(t, brd.i2cDataForRead[0], val)
-	assert.Equal(t, 0, len(brd.i2cWritten))
+	assert.Empty(t, brd.i2cWritten)
 }
 
 func TestReadByteData(t *testing.T) {
@@ -113,10 +114,10 @@ func TestReadByteData(t *testing.T) {
 	// act
 	val, err := con.ReadByteData(reg)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, brd.numBytesToRead)
 	assert.Equal(t, brd.i2cDataForRead[0], val)
-	assert.Equal(t, 1, len(brd.i2cWritten))
+	assert.Len(t, brd.i2cWritten, 1)
 	assert.Equal(t, reg, brd.i2cWritten[0])
 }
 
@@ -130,10 +131,10 @@ func TestReadWordData(t *testing.T) {
 	// act
 	val, err := con.ReadWordData(reg)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 2, brd.numBytesToRead)
 	assert.Equal(t, uint16(lsb)|uint16(msb)<<8, val)
-	assert.Equal(t, 1, len(brd.i2cWritten))
+	assert.Len(t, brd.i2cWritten, 1)
 	assert.Equal(t, reg, brd.i2cWritten[0])
 }
 
@@ -146,10 +147,10 @@ func TestReadBlockData(t *testing.T) {
 	// act
 	err := con.ReadBlockData(reg, buf)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 5, brd.numBytesToRead)
 	assert.Equal(t, brd.i2cDataForRead, buf)
-	assert.Equal(t, 1, len(brd.i2cWritten))
+	assert.Len(t, brd.i2cWritten, 1)
 	assert.Equal(t, reg, brd.i2cWritten[0])
 }
 
@@ -161,7 +162,7 @@ func TestWrite(t *testing.T) {
 	// act
 	written, err := con.Write(want)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, wantLen, written)
 	assert.Equal(t, want, brd.i2cWritten)
 }
@@ -174,7 +175,7 @@ func TestWrite20bytes(t *testing.T) {
 	// act
 	written, err := con.Write(want)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, wantLen, written)
 	assert.Equal(t, want, brd.i2cWritten)
 }
@@ -186,8 +187,8 @@ func TestWriteByte(t *testing.T) {
 	// act
 	err := con.WriteByte(want)
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(brd.i2cWritten))
+	require.NoError(t, err)
+	assert.Len(t, brd.i2cWritten, 1)
 	assert.Equal(t, want, brd.i2cWritten[0])
 }
 
@@ -199,8 +200,8 @@ func TestWriteByteData(t *testing.T) {
 	// act
 	err := con.WriteByteData(reg, val)
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(brd.i2cWritten))
+	require.NoError(t, err)
+	assert.Len(t, brd.i2cWritten, 2)
 	assert.Equal(t, reg, brd.i2cWritten[0])
 	assert.Equal(t, val, brd.i2cWritten[1])
 }
@@ -213,8 +214,8 @@ func TestWriteWordData(t *testing.T) {
 	// act
 	err := con.WriteWordData(reg, val)
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 3, len(brd.i2cWritten))
+	require.NoError(t, err)
+	assert.Len(t, brd.i2cWritten, 3)
 	assert.Equal(t, reg, brd.i2cWritten[0])
 	assert.Equal(t, uint8(val&0x00FF), brd.i2cWritten[1])
 	assert.Equal(t, uint8(val>>8), brd.i2cWritten[2])
@@ -232,8 +233,8 @@ func TestWriteBlockData(t *testing.T) {
 	// act
 	err := con.WriteBlockData(reg, val)
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 33, len(brd.i2cWritten))
+	require.NoError(t, err)
+	assert.Len(t, brd.i2cWritten, 33)
 	assert.Equal(t, reg, brd.i2cWritten[0])
 	assert.Equal(t, val[0:32], brd.i2cWritten[1:])
 }
@@ -246,5 +247,5 @@ func TestDefaultBus(t *testing.T) {
 func TestGetI2cConnectionInvalidBus(t *testing.T) {
 	a := NewAdaptor()
 	_, err := a.GetI2cConnection(0x01, 99)
-	assert.ErrorContains(t, err, "Invalid bus number 99, only 0 is supported")
+	require.ErrorContains(t, err, "Invalid bus number 99, only 0 is supported")
 }

--- a/platforms/intel-iot/curie/imu_driver_test.go
+++ b/platforms/intel-iot/curie/imu_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 
 	"gobot.io/x/gobot/v2/platforms/firmata"
@@ -91,12 +92,12 @@ func initTestIMUDriver() *IMUDriver {
 
 func TestIMUDriverStart(t *testing.T) {
 	d := initTestIMUDriver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestIMUDriverHalt(t *testing.T) {
 	d := initTestIMUDriver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestIMUDriverDefaultName(t *testing.T) {
@@ -118,105 +119,105 @@ func TestIMUDriverConnection(t *testing.T) {
 func TestIMUDriverReadAccelerometer(t *testing.T) {
 	d := initTestIMUDriver()
 	_ = d.Start()
-	assert.NoError(t, d.ReadAccelerometer())
+	require.NoError(t, d.ReadAccelerometer())
 }
 
 func TestIMUDriverReadAccelerometerData(t *testing.T) {
 	_, err := parseAccelerometerData([]byte{})
-	assert.ErrorContains(t, err, "Invalid data")
+	require.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseAccelerometerData([]byte{0xF0, 0x11, 0x00, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &AccelerometerData{X: 1920, Y: 1920, Z: 1920}, result)
 }
 
 func TestIMUDriverReadGyroscope(t *testing.T) {
 	d := initTestIMUDriver()
 	_ = d.Start()
-	assert.NoError(t, d.ReadGyroscope())
+	require.NoError(t, d.ReadGyroscope())
 }
 
 func TestIMUDriverReadGyroscopeData(t *testing.T) {
 	_, err := parseGyroscopeData([]byte{})
-	assert.ErrorContains(t, err, "Invalid data")
+	require.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseGyroscopeData([]byte{0xF0, 0x11, 0x01, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &GyroscopeData{X: 1920, Y: 1920, Z: 1920}, result)
 }
 
 func TestIMUDriverReadTemperature(t *testing.T) {
 	d := initTestIMUDriver()
 	_ = d.Start()
-	assert.NoError(t, d.ReadTemperature())
+	require.NoError(t, d.ReadTemperature())
 }
 
 func TestIMUDriverReadTemperatureData(t *testing.T) {
 	_, err := parseTemperatureData([]byte{})
-	assert.ErrorContains(t, err, "Invalid data")
+	require.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseTemperatureData([]byte{0xF0, 0x11, 0x02, 0x00, 0x02, 0x03, 0x04, 0xf7})
-	assert.NoError(t, err)
-	assert.Equal(t, float32(31.546875), result)
+	require.NoError(t, err)
+	assert.InDelta(t, float32(31.546875), result, 0.0)
 }
 
 func TestIMUDriverEnableShockDetection(t *testing.T) {
 	d := initTestIMUDriver()
 	_ = d.Start()
-	assert.NoError(t, d.EnableShockDetection(true))
+	require.NoError(t, d.EnableShockDetection(true))
 }
 
 func TestIMUDriverShockDetectData(t *testing.T) {
 	_, err := parseShockData([]byte{})
-	assert.ErrorContains(t, err, "Invalid data")
+	require.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseShockData([]byte{0xF0, 0x11, 0x03, 0x00, 0x02, 0xf7})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &ShockData{Axis: 0, Direction: 2}, result)
 }
 
 func TestIMUDriverEnableStepCounter(t *testing.T) {
 	d := initTestIMUDriver()
 	_ = d.Start()
-	assert.NoError(t, d.EnableStepCounter(true))
+	require.NoError(t, d.EnableStepCounter(true))
 }
 
 func TestIMUDriverStepCountData(t *testing.T) {
 	_, err := parseStepData([]byte{})
-	assert.ErrorContains(t, err, "Invalid data")
+	require.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseStepData([]byte{0xF0, 0x11, 0x04, 0x00, 0x02, 0xf7})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int16(256), result)
 }
 
 func TestIMUDriverEnableTapDetection(t *testing.T) {
 	d := initTestIMUDriver()
 	_ = d.Start()
-	assert.NoError(t, d.EnableTapDetection(true))
+	require.NoError(t, d.EnableTapDetection(true))
 }
 
 func TestIMUDriverTapDetectData(t *testing.T) {
 	_, err := parseTapData([]byte{})
-	assert.ErrorContains(t, err, "Invalid data")
+	require.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseTapData([]byte{0xF0, 0x11, 0x05, 0x00, 0x02, 0xf7})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &TapData{Axis: 0, Direction: 2}, result)
 }
 
 func TestIMUDriverEnableReadMotion(t *testing.T) {
 	d := initTestIMUDriver()
 	_ = d.Start()
-	assert.NoError(t, d.ReadMotion())
+	require.NoError(t, d.ReadMotion())
 }
 
 func TestIMUDriverReadMotionData(t *testing.T) {
 	_, err := parseMotionData([]byte{})
-	assert.ErrorContains(t, err, "Invalid data")
+	require.ErrorContains(t, err, "Invalid data")
 
 	result, err := parseMotionData([]byte{0xF0, 0x11, 0x06, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &MotionData{AX: 1920, AY: 1920, AZ: 1920, GX: 1920, GY: 1920, GZ: 1920}, result)
 }
 
@@ -224,11 +225,11 @@ func TestIMUDriverHandleEvents(t *testing.T) {
 	d := initTestIMUDriver()
 	_ = d.Start()
 
-	assert.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x00, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7}))
-	assert.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x01, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7}))
-	assert.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x02, 0x00, 0x02, 0x03, 0x04, 0xf7}))
-	assert.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x03, 0x00, 0x02, 0xf7}))
-	assert.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x04, 0x00, 0x02, 0xf7}))
-	assert.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x05, 0x00, 0x02, 0xf7}))
-	assert.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x06, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7}))
+	require.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x00, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7}))
+	require.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x01, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7}))
+	require.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x02, 0x00, 0x02, 0x03, 0x04, 0xf7}))
+	require.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x03, 0x00, 0x02, 0xf7}))
+	require.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x04, 0x00, 0x02, 0xf7}))
+	require.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x05, 0x00, 0x02, 0xf7}))
+	require.NoError(t, d.handleEvent([]byte{0xF0, 0x11, 0x06, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x0f, 0xf7}))
 }

--- a/platforms/intel-iot/edison/edison_adaptor_test.go
+++ b/platforms/intel-iot/edison/edison_adaptor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/aio"
 	"gobot.io/x/gobot/v2/drivers/gpio"
@@ -235,7 +236,7 @@ func TestConnect(t *testing.T) {
 
 	assert.Equal(t, 6, a.DefaultI2cBus())
 	assert.Equal(t, "arduino", a.board)
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 }
 
 func TestArduinoSetupFail263(t *testing.T) {
@@ -272,17 +273,17 @@ func TestArduinoSetupFail131(t *testing.T) {
 
 func TestArduinoI2CSetupFailTristate(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
-	assert.NoError(t, a.arduinoSetup())
+	require.NoError(t, a.arduinoSetup())
 
 	fs.WithWriteError = true
 	err := a.arduinoI2CSetup()
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 }
 
 func TestArduinoI2CSetupFail14(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 
-	assert.NoError(t, a.arduinoSetup())
+	require.NoError(t, a.arduinoSetup())
 	delete(fs.Files, "/sys/class/gpio/gpio14/direction")
 
 	err := a.arduinoI2CSetup()
@@ -292,7 +293,7 @@ func TestArduinoI2CSetupFail14(t *testing.T) {
 func TestArduinoI2CSetupUnexportFail(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 
-	assert.NoError(t, a.arduinoSetup())
+	require.NoError(t, a.arduinoSetup())
 	delete(fs.Files, "/sys/class/gpio/unexport")
 
 	err := a.arduinoI2CSetup()
@@ -302,7 +303,7 @@ func TestArduinoI2CSetupUnexportFail(t *testing.T) {
 func TestArduinoI2CSetupFail236(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 
-	assert.NoError(t, a.arduinoSetup())
+	require.NoError(t, a.arduinoSetup())
 	delete(fs.Files, "/sys/class/gpio/gpio236/direction")
 
 	err := a.arduinoI2CSetup()
@@ -312,7 +313,7 @@ func TestArduinoI2CSetupFail236(t *testing.T) {
 func TestArduinoI2CSetupFail28(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 
-	assert.NoError(t, a.arduinoSetup())
+	require.NoError(t, a.arduinoSetup())
 	delete(fs.Files, "/sys/kernel/debug/gpio_debug/gpio28/current_pinmux")
 
 	err := a.arduinoI2CSetup()
@@ -338,7 +339,7 @@ func TestConnectArduinoWriteError(t *testing.T) {
 func TestConnectSparkfun(t *testing.T) {
 	a, _ := initTestAdaptorWithMockedFilesystem("sparkfun")
 
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 	assert.Equal(t, 1, a.DefaultI2cBus())
 	assert.Equal(t, "sparkfun", a.board)
 }
@@ -346,7 +347,7 @@ func TestConnectSparkfun(t *testing.T) {
 func TestConnectMiniboard(t *testing.T) {
 	a, _ := initTestAdaptorWithMockedFilesystem("miniboard")
 
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 	assert.Equal(t, 1, a.DefaultI2cBus())
 	assert.Equal(t, "miniboard", a.board)
 }
@@ -365,10 +366,10 @@ func TestFinalize(t *testing.T) {
 	_ = a.PwmWrite("5", 100)
 
 	_, _ = a.GetI2cConnection(0xff, 6)
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 
 	// assert that finalize after finalize is working
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 
 	// assert that re-connect is working
 	_ = a.Connect()
@@ -400,7 +401,7 @@ func TestDigitalIO(t *testing.T) {
 
 	_ = a.DigitalWrite("2", 0)
 	i, err := a.DigitalRead("2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 0, i)
 }
 
@@ -453,7 +454,7 @@ func TestDigitalWriteError(t *testing.T) {
 	fs.WithWriteError = true
 
 	err := a.DigitalWrite("13", 1)
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 }
 
 func TestDigitalReadWriteError(t *testing.T) {
@@ -461,18 +462,18 @@ func TestDigitalReadWriteError(t *testing.T) {
 	fs.WithWriteError = true
 
 	_, err := a.DigitalRead("13")
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 }
 
 func TestPwm(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem("arduino")
 
 	err := a.PwmWrite("5", 100)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "1960", fs.Files["/sys/class/pwm/pwmchip0/pwm1/duty_cycle"].Contents)
 
 	err = a.PwmWrite("7", 100)
-	assert.ErrorContains(t, err, "'7' is not a valid id for a PWM pin")
+	require.ErrorContains(t, err, "'7' is not a valid id for a PWM pin")
 }
 
 func TestPwmExportError(t *testing.T) {
@@ -480,7 +481,7 @@ func TestPwmExportError(t *testing.T) {
 	fs := a.sys.UseMockFilesystem(pwmMockPathsMux13Arduino)
 	delete(fs.Files, "/sys/class/pwm/pwmchip0/export")
 	err := a.Connect()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = a.PwmWrite("5", 100)
 	assert.Contains(t, err.Error(), "/sys/class/pwm/pwmchip0/export: no such file")
@@ -501,7 +502,7 @@ func TestPwmWritePinError(t *testing.T) {
 	fs.WithWriteError = true
 
 	err := a.PwmWrite("5", 100)
-	assert.ErrorContains(t, err, "write error")
+	require.ErrorContains(t, err, "write error")
 }
 
 func TestPwmWriteError(t *testing.T) {
@@ -533,7 +534,7 @@ func TestAnalogError(t *testing.T) {
 	fs.WithReadError = true
 
 	_, err := a.AnalogRead("0")
-	assert.ErrorContains(t, err, "read error")
+	require.ErrorContains(t, err, "read error")
 }
 
 func TestI2cWorkflow(t *testing.T) {
@@ -541,17 +542,17 @@ func TestI2cWorkflow(t *testing.T) {
 	a.sys.UseMockSyscall()
 
 	con, err := a.GetI2cConnection(0xff, 6)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = con.Write([]byte{0x00, 0x01})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	data := []byte{42, 42}
 	_, err = con.Read(data)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []byte{0x00, 0x01}, data)
 
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 }
 
 func TestI2cFinalizeWithErrors(t *testing.T) {
@@ -559,16 +560,16 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a := NewAdaptor()
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem(pwmMockPathsMux13ArduinoI2c)
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 	con, err := a.GetI2cConnection(0xff, 6)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = con.Write([]byte{0x0A})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()
 	// assert
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "close error")
 }
 

--- a/platforms/intel-iot/joule/joule_adaptor_test.go
+++ b/platforms/intel-iot/joule/joule_adaptor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/gpio"
 	"gobot.io/x/gobot/v2/drivers/i2c"
@@ -111,13 +112,13 @@ func TestFinalize(t *testing.T) {
 	_ = a.DigitalWrite("J12_1", 1)
 	_ = a.PwmWrite("J12_26", 100)
 
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 
 	// assert finalize after finalize is working
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 
 	// assert re-connect is working
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 }
 
 func TestDigitalIO(t *testing.T) {
@@ -129,25 +130,25 @@ func TestDigitalIO(t *testing.T) {
 	_ = a.DigitalWrite("J12_1", 0)
 
 	i, err := a.DigitalRead("J12_1")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 0, i)
 
 	_, err = a.DigitalRead("P9_99")
-	assert.ErrorContains(t, err, "'P9_99' is not a valid id for a digital pin")
+	require.ErrorContains(t, err, "'P9_99' is not a valid id for a digital pin")
 }
 
 func TestPwm(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem()
 
 	err := a.PwmWrite("J12_26", 100)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "3921568", fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents)
 
 	err = a.PwmWrite("4", 100)
-	assert.ErrorContains(t, err, "'4' is not a valid id for a pin")
+	require.ErrorContains(t, err, "'4' is not a valid id for a pin")
 
 	err = a.PwmWrite("J12_1", 100)
-	assert.ErrorContains(t, err, "'J12_1' is not a valid id for a PWM pin")
+	require.ErrorContains(t, err, "'J12_1' is not a valid id for a PWM pin")
 }
 
 func TestPwmPinExportError(t *testing.T) {
@@ -176,11 +177,11 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a := NewAdaptor()
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-2"})
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 	con, err := a.GetI2cConnection(0xff, 2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = con.Write([]byte{0xbf})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/jetson/jetson_adaptor_test.go
+++ b/platforms/jetson/jetson_adaptor_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/gpio"
 	"gobot.io/x/gobot/v2/drivers/i2c"
@@ -59,7 +60,7 @@ func TestFinalize(t *testing.T) {
 	_ = a.DigitalWrite("3", 1)
 
 	_, _ = a.GetI2cConnection(0xff, 0)
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 }
 
 func TestPWMPinsConnect(t *testing.T) {
@@ -67,12 +68,12 @@ func TestPWMPinsConnect(t *testing.T) {
 	assert.Equal(t, (map[string]gobot.PWMPinner)(nil), a.pwmPins)
 
 	err := a.PwmWrite("33", 1)
-	assert.ErrorContains(t, err, "not connected")
+	require.ErrorContains(t, err, "not connected")
 
 	err = a.Connect()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEqual(t, (map[string]gobot.PWMPinner)(nil), a.pwmPins)
-	assert.Equal(t, 0, len(a.pwmPins))
+	assert.Empty(t, a.pwmPins)
 }
 
 func TestPWMPinsReConnect(t *testing.T) {
@@ -85,15 +86,15 @@ func TestPWMPinsReConnect(t *testing.T) {
 		"/sys/class/pwm/pwmchip0/pwm2/enable",
 	}
 	a, _ := initTestAdaptorWithMockedFilesystem(mockPaths)
-	assert.Equal(t, 0, len(a.pwmPins))
-	assert.NoError(t, a.PwmWrite("33", 1))
-	assert.Equal(t, 1, len(a.pwmPins))
-	assert.NoError(t, a.Finalize())
+	assert.Empty(t, a.pwmPins)
+	require.NoError(t, a.PwmWrite("33", 1))
+	assert.Len(t, a.pwmPins, 1)
+	require.NoError(t, a.Finalize())
 	// act
 	err := a.Connect()
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, 0, len(a.pwmPins))
+	require.NoError(t, err)
+	assert.Empty(t, a.pwmPins)
 }
 
 func TestDigitalIO(t *testing.T) {
@@ -108,17 +109,17 @@ func TestDigitalIO(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem(mockPaths)
 
 	err := a.DigitalWrite("7", 1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "1", fs.Files["/sys/class/gpio/gpio216/value"].Contents)
 
 	err = a.DigitalWrite("13", 1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	i, err := a.DigitalRead("13")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, i)
 
-	assert.ErrorContains(t, a.DigitalWrite("notexist", 1), "'notexist' is not a valid id for a digital pin")
-	assert.NoError(t, a.Finalize())
+	require.ErrorContains(t, a.DigitalWrite("notexist", 1), "'notexist' is not a valid id for a digital pin")
+	require.NoError(t, a.Finalize())
 }
 
 func TestDigitalPinConcurrency(t *testing.T) {
@@ -163,11 +164,11 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a := NewAdaptor()
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-1"})
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 	con, err := a.GetI2cConnection(0xff, 1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = con.Write([]byte{0xbf})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/jetson/pwm_pin.go
+++ b/platforms/jetson/pwm_pin.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strconv"
 
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/system"
@@ -54,7 +55,7 @@ func (p *PWMPin) Enabled() (bool, error) {
 
 // SetEnabled enables/disables the PWM pin
 func (p *PWMPin) SetEnabled(e bool) error {
-	if err := p.writeFile(fmt.Sprintf("pwm%s/enable", p.fn), fmt.Sprintf("%v", bool2int(e))); err != nil {
+	if err := p.writeFile(fmt.Sprintf("pwm%s/enable", p.fn), strconv.Itoa(bool2int(e))); err != nil {
 		return err
 	}
 	p.enabled = e
@@ -89,6 +90,7 @@ func (p *PWMPin) SetPeriod(period uint32) error {
 	if period < minimumPeriod {
 		return errors.New("Cannot set the period more then minimum")
 	}
+	//nolint:perfsprint // ok here
 	if err := p.writeFile(fmt.Sprintf("pwm%s/period", p.fn), fmt.Sprintf("%v", period)); err != nil {
 		return err
 	}
@@ -116,6 +118,7 @@ func (p *PWMPin) SetDutyCycle(duty uint32) error {
 	if rate < minimumRate {
 		duty = uint32(minimumRate * float64(p.period) / 100)
 	}
+	//nolint:perfsprint // ok here
 	if err := p.writeFile(fmt.Sprintf("pwm%s/duty_cycle", p.fn), fmt.Sprintf("%v", duty)); err != nil {
 		return err
 	}

--- a/platforms/jetson/pwm_pin_test.go
+++ b/platforms/jetson/pwm_pin_test.go
@@ -37,43 +37,43 @@ func TestPwmPin(t *testing.T) {
 	require.Equal(t, "", fs.Files[periodPath].Contents)
 	require.Equal(t, "", fs.Files[dutyCyclePath].Contents)
 
-	assert.NoError(t, pin.Export())
+	require.NoError(t, pin.Export())
 	assert.Equal(t, "3", fs.Files[exportPath].Contents)
 
-	assert.NoError(t, pin.SetEnabled(true))
+	require.NoError(t, pin.SetEnabled(true))
 	assert.Equal(t, "1", fs.Files[enablePath].Contents)
 
 	val, _ := pin.Polarity()
 	assert.True(t, val)
-	assert.NoError(t, pin.SetPolarity(false))
+	require.NoError(t, pin.SetPolarity(false))
 	val, _ = pin.Polarity()
 	assert.True(t, val)
 
 	_, err := pin.Period()
-	assert.ErrorContains(t, err, "Jetson PWM pin period not set")
-	assert.ErrorContains(t, pin.SetDutyCycle(10000), "Jetson PWM pin period not set")
+	require.ErrorContains(t, err, "Jetson PWM pin period not set")
+	require.ErrorContains(t, pin.SetDutyCycle(10000), "Jetson PWM pin period not set")
 	assert.Equal(t, "", fs.Files[dutyCyclePath].Contents)
 
-	assert.NoError(t, pin.SetPeriod(20000000))
+	require.NoError(t, pin.SetPeriod(20000000))
 	assert.Equal(t, "20000000", fs.Files[periodPath].Contents)
 	period, _ := pin.Period()
 	assert.Equal(t, uint32(20000000), period)
-	assert.ErrorContains(t, pin.SetPeriod(10000000), "Cannot set the period of individual PWM pins on Jetson")
+	require.ErrorContains(t, pin.SetPeriod(10000000), "Cannot set the period of individual PWM pins on Jetson")
 	assert.Equal(t, "20000000", fs.Files[periodPath].Contents)
 
 	dc, _ := pin.DutyCycle()
 	assert.Equal(t, uint32(0), dc)
 
-	assert.NoError(t, pin.SetDutyCycle(10000))
+	require.NoError(t, pin.SetDutyCycle(10000))
 	assert.Equal(t, "10000", fs.Files[dutyCyclePath].Contents)
 	dc, _ = pin.DutyCycle()
 	assert.Equal(t, uint32(10000), dc)
 
-	assert.ErrorContains(t, pin.SetDutyCycle(999999999), "Duty cycle exceeds period")
+	require.ErrorContains(t, pin.SetDutyCycle(999999999), "Duty cycle exceeds period")
 	dc, _ = pin.DutyCycle()
 	assert.Equal(t, "10000", fs.Files[dutyCyclePath].Contents)
 	assert.Equal(t, uint32(10000), dc)
 
-	assert.NoError(t, pin.Unexport())
+	require.NoError(t, pin.Unexport())
 	assert.Equal(t, "3", fs.Files[unexportPath].Contents)
 }

--- a/platforms/joystick/bin/scanner.go
+++ b/platforms/joystick/bin/scanner.go
@@ -50,8 +50,6 @@ func readJoystick(js joystick.Joystick) {
 	for axis := 0; axis < js.AxisCount(); axis++ {
 		printAt(1, axis+8, fmt.Sprintf("Axis %2d Value: %7d", axis, jinfo.AxisData[axis]))
 	}
-
-	return
 }
 
 func main() {

--- a/platforms/joystick/joystick_adaptor_test.go
+++ b/platforms/joystick/joystick_adaptor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"gobot.io/x/gobot/v2"
 )
@@ -24,12 +25,12 @@ func TestJoystickAdaptorName(t *testing.T) {
 	a := initTestAdaptor()
 	assert.True(t, strings.HasPrefix(a.Name(), "Joystick"))
 	a.SetName("NewName")
-	assert.Equal(t, a.Name(), "NewName")
+	assert.Equal(t, "NewName", a.Name())
 }
 
 func TestAdaptorConnect(t *testing.T) {
 	a := initTestAdaptor()
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 
 	a = NewAdaptor("6")
 	err := a.Connect()
@@ -39,5 +40,5 @@ func TestAdaptorConnect(t *testing.T) {
 func TestAdaptorFinalize(t *testing.T) {
 	a := initTestAdaptor()
 	_ = a.Connect()
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 }

--- a/platforms/joystick/joystick_driver_test.go
+++ b/platforms/joystick/joystick_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"gobot.io/x/gobot/v2"
 
@@ -30,13 +31,13 @@ func TestJoystickDriverName(t *testing.T) {
 	d, _ := initTestDriver("./configs/dualshock3.json")
 	assert.True(t, strings.HasPrefix(d.Name(), "Joystick"))
 	d.SetName("NewName")
-	assert.Equal(t, d.Name(), "NewName")
+	assert.Equal(t, "NewName", d.Name())
 }
 
 func TestDriverStart(t *testing.T) {
 	d, _ := initTestDriver("./configs/dualshock3.json")
 	d.interval = 1 * time.Millisecond
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 	time.Sleep(2 * time.Millisecond)
 }
 
@@ -45,7 +46,7 @@ func TestDriverHalt(t *testing.T) {
 	go func() {
 		<-d.halt
 	}()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestDriverHandleEventDS3(t *testing.T) {

--- a/platforms/keyboard/keyboard_driver_test.go
+++ b/platforms/keyboard/keyboard_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -35,10 +36,10 @@ func TestKeyboardDriverName(t *testing.T) {
 
 func TestKeyboardDriverStart(t *testing.T) {
 	d := initTestKeyboardDriver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestKeyboardDriverHalt(t *testing.T) {
 	d := initTestKeyboardDriver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }

--- a/platforms/leap/leap_motion_adaptor_test.go
+++ b/platforms/leap/leap_motion_adaptor_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -32,15 +33,15 @@ func TestLeapMotionAdaptorName(t *testing.T) {
 
 func TestLeapMotionAdaptorConnect(t *testing.T) {
 	a := initTestLeapMotionAdaptor()
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 
 	a.connect = func(port string) (io.ReadWriteCloser, error) {
 		return nil, errors.New("connection error")
 	}
-	assert.ErrorContains(t, a.Connect(), "connection error")
+	require.ErrorContains(t, a.Connect(), "connection error")
 }
 
 func TestLeapMotionAdaptorFinalize(t *testing.T) {
 	a := initTestLeapMotionAdaptor()
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 }

--- a/platforms/leap/leap_motion_driver_test.go
+++ b/platforms/leap/leap_motion_driver_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -69,7 +70,7 @@ func TestLeapMotionDriverName(t *testing.T) {
 
 func TestLeapMotionDriverStart(t *testing.T) {
 	d, _ := initTestLeapMotionDriver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 
 	d2, rwc := initTestLeapMotionDriver()
 	e := errors.New("write error")
@@ -79,7 +80,7 @@ func TestLeapMotionDriverStart(t *testing.T) {
 
 func TestLeapMotionDriverHalt(t *testing.T) {
 	d, _ := initTestLeapMotionDriver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestLeapMotionDriverParser(t *testing.T) {
@@ -92,17 +93,17 @@ func TestLeapMotionDriverParser(t *testing.T) {
 	}
 
 	assert.Equal(t, uint64(134211791358), parsedFrame.Timestamp)
-	assert.Equal(t, 247.410, parsedFrame.Hands[0].X())
-	assert.Equal(t, 275.868, parsedFrame.Hands[0].Y())
-	assert.Equal(t, 132.843, parsedFrame.Hands[0].Z())
+	assert.InDelta(t, 247.410, parsedFrame.Hands[0].X(), 0.0)
+	assert.InDelta(t, 275.868, parsedFrame.Hands[0].Y(), 0.0)
+	assert.InDelta(t, 132.843, parsedFrame.Hands[0].Z(), 0.0)
 
-	assert.Equal(t, 214.293, parsedFrame.Pointables[0].BTipPosition[0])
-	assert.Equal(t, 213.865, parsedFrame.Pointables[0].BTipPosition[1])
-	assert.Equal(t, 95.0224, parsedFrame.Pointables[0].BTipPosition[2])
+	assert.InDelta(t, 214.293, parsedFrame.Pointables[0].BTipPosition[0], 0.0)
+	assert.InDelta(t, 213.865, parsedFrame.Pointables[0].BTipPosition[1], 0.0)
+	assert.InDelta(t, 95.0224, parsedFrame.Pointables[0].BTipPosition[2], 0.0)
 
-	assert.Equal(t, -0.468069, parsedFrame.Pointables[0].Bases[0][0][0])
-	assert.Equal(t, 0.807844, parsedFrame.Pointables[0].Bases[0][0][1])
-	assert.Equal(t, -0.358190, parsedFrame.Pointables[0].Bases[0][0][2])
+	assert.InDelta(t, -0.468069, parsedFrame.Pointables[0].Bases[0][0][0], 0.0)
+	assert.InDelta(t, 0.807844, parsedFrame.Pointables[0].Bases[0][0][1], 0.0)
+	assert.InDelta(t, -0.358190, parsedFrame.Pointables[0].Bases[0][0][2], 0.0)
 
-	assert.Equal(t, 19.7871, parsedFrame.Pointables[0].Width)
+	assert.InDelta(t, 19.7871, parsedFrame.Pointables[0].Width, 0.0)
 }

--- a/platforms/mavlink/common/mavlink.go
+++ b/platforms/mavlink/common/mavlink.go
@@ -37,7 +37,7 @@ type MAVLinkMessage interface {
 	Len() uint8
 	Crc() uint8
 	Pack() []byte
-	Decode([]byte)
+	Decode(buf []byte)
 }
 
 // A MAVLinkPacket represents a raw packet received from a micro air vehicle

--- a/platforms/mavlink/mavlink_adaptor_test.go
+++ b/platforms/mavlink/mavlink_adaptor_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -66,18 +67,18 @@ func TestMavlinkAdaptorName(t *testing.T) {
 
 func TestMavlinkAdaptorConnect(t *testing.T) {
 	a := initTestMavlinkAdaptor()
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 
 	a.connect = func(port string) (io.ReadWriteCloser, error) { return nil, errors.New("connect error") }
-	assert.ErrorContains(t, a.Connect(), "connect error")
+	require.ErrorContains(t, a.Connect(), "connect error")
 }
 
 func TestMavlinkAdaptorFinalize(t *testing.T) {
 	a := initTestMavlinkAdaptor()
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 
 	testAdaptorClose = func() error {
 		return errors.New("close error")
 	}
-	assert.ErrorContains(t, a.Finalize(), "close error")
+	require.ErrorContains(t, a.Finalize(), "close error")
 }

--- a/platforms/mavlink/mavlink_driver_test.go
+++ b/platforms/mavlink/mavlink_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	common "gobot.io/x/gobot/v2/platforms/mavlink/common"
 )
@@ -59,11 +60,11 @@ func TestMavlinkDriverStart(t *testing.T) {
 		err <- data.(error)
 	})
 
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 
 	select {
 	case p := <-packet:
-		assert.NoError(t, d.SendPacket(p))
+		require.NoError(t, d.SendPacket(p))
 
 	case <-time.After(100 * time.Millisecond):
 		t.Errorf("packet was not emitted")
@@ -82,5 +83,5 @@ func TestMavlinkDriverStart(t *testing.T) {
 
 func TestMavlinkDriverHalt(t *testing.T) {
 	d := initTestMavlinkDriver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }

--- a/platforms/mavlink/mavlink_udp_adaptor.go
+++ b/platforms/mavlink/mavlink_udp_adaptor.go
@@ -8,8 +8,8 @@ import (
 
 type UDPConnection interface {
 	Close() error
-	ReadFromUDP([]byte) (int, *net.UDPAddr, error)
-	WriteTo([]byte, net.Addr) (int, error)
+	ReadFromUDP(b []byte) (int, *net.UDPAddr, error)
+	WriteTo(b []byte, a net.Addr) (int, error)
 }
 
 type UDPAdaptor struct {

--- a/platforms/mavlink/mavlink_udp_adaptor_test.go
+++ b/platforms/mavlink/mavlink_udp_adaptor_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	mavlink "gobot.io/x/gobot/v2/platforms/mavlink/common"
 )
@@ -65,8 +66,8 @@ func TestMavlinkUDPAdaptorName(t *testing.T) {
 
 func TestMavlinkUDPAdaptorConnectAndFinalize(t *testing.T) {
 	a := initTestMavlinkUDPAdaptor()
-	assert.NoError(t, a.Connect())
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Connect())
+	require.NoError(t, a.Finalize())
 }
 
 func TestMavlinkUDPAdaptorWrite(t *testing.T) {
@@ -82,7 +83,7 @@ func TestMavlinkUDPAdaptorWrite(t *testing.T) {
 
 	i, err := a.Write([]byte{0x01, 0x02, 0x03})
 	assert.Equal(t, 3, i)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestMavlinkReadMAVLinkReadDefaultPacket(t *testing.T) {
@@ -136,5 +137,5 @@ func TestMavlinkReadMAVLinkPacketReadError(t *testing.T) {
 	a.sock = m
 
 	_, err := a.ReadMAVLinkPacket()
-	assert.ErrorContains(t, err, "read error")
+	require.ErrorContains(t, err, "read error")
 }

--- a/platforms/microbit/accelerometer_driver_test.go
+++ b/platforms/microbit/accelerometer_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -25,8 +26,8 @@ func TestAccelerometerDriver(t *testing.T) {
 
 func TestAccelerometerDriverStartAndHalt(t *testing.T) {
 	d := initTestAccelerometerDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
 }
 
 func TestAccelerometerDriverReadData(t *testing.T) {
@@ -35,9 +36,9 @@ func TestAccelerometerDriverReadData(t *testing.T) {
 	d := NewAccelerometerDriver(a)
 	_ = d.Start()
 	_ = d.On(Accelerometer, func(data interface{}) {
-		assert.Equal(t, float32(8.738), data.(*AccelerometerData).X)
-		assert.Equal(t, float32(8.995), data.(*AccelerometerData).Y)
-		assert.Equal(t, float32(9.252), data.(*AccelerometerData).Z)
+		assert.InDelta(t, float32(8.738), data.(*AccelerometerData).X, 0.0)
+		assert.InDelta(t, float32(8.995), data.(*AccelerometerData).Y, 0.0)
+		assert.InDelta(t, float32(9.252), data.(*AccelerometerData).Z, 0.0)
 		sem <- true
 	})
 

--- a/platforms/microbit/button_driver_test.go
+++ b/platforms/microbit/button_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -25,8 +26,8 @@ func TestButtonDriver(t *testing.T) {
 
 func TestButtonDriverStartAndHalt(t *testing.T) {
 	d := initTestButtonDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
 }
 
 func TestButtonDriverReadData(t *testing.T) {

--- a/platforms/microbit/io_pin_driver_test.go
+++ b/platforms/microbit/io_pin_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/aio"
 	"gobot.io/x/gobot/v2/drivers/gpio"
@@ -39,8 +40,8 @@ func TestIOPinDriverStartAndHalt(t *testing.T) {
 	a.TestReadCharacteristic(func(cUUID string) ([]byte, error) {
 		return []byte{0, 1, 1, 0}, nil
 	})
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
 }
 
 func TestIOPinDriverStartError(t *testing.T) {
@@ -49,7 +50,7 @@ func TestIOPinDriverStartError(t *testing.T) {
 	a.TestReadCharacteristic(func(cUUID string) ([]byte, error) {
 		return nil, errors.New("read error")
 	})
-	assert.ErrorContains(t, d.Start(), "read error")
+	require.ErrorContains(t, d.Start(), "read error")
 }
 
 func TestIOPinDriverDigitalRead(t *testing.T) {
@@ -71,10 +72,10 @@ func TestIOPinDriverDigitalReadInvalidPin(t *testing.T) {
 	d := NewIOPinDriver(a)
 
 	_, err := d.DigitalRead("A3")
-	assert.NotNil(t, err)
+	require.Error(t, err)
 
 	_, err = d.DigitalRead("6")
-	assert.ErrorContains(t, err, "Invalid pin.")
+	require.ErrorContains(t, err, "Invalid pin.")
 }
 
 func TestIOPinDriverDigitalWrite(t *testing.T) {
@@ -82,15 +83,15 @@ func TestIOPinDriverDigitalWrite(t *testing.T) {
 	d := NewIOPinDriver(a)
 
 	// TODO: a better test
-	assert.NoError(t, d.DigitalWrite("0", 1))
+	require.NoError(t, d.DigitalWrite("0", 1))
 }
 
 func TestIOPinDriverDigitalWriteInvalidPin(t *testing.T) {
 	a := NewBleTestAdaptor()
 	d := NewIOPinDriver(a)
 
-	assert.NotNil(t, d.DigitalWrite("A3", 1))
-	assert.ErrorContains(t, d.DigitalWrite("6", 1), "Invalid pin.")
+	require.Error(t, d.DigitalWrite("A3", 1))
+	require.ErrorContains(t, d.DigitalWrite("6", 1), "Invalid pin.")
 }
 
 func TestIOPinDriverAnalogRead(t *testing.T) {
@@ -112,10 +113,10 @@ func TestIOPinDriverAnalogReadInvalidPin(t *testing.T) {
 	d := NewIOPinDriver(a)
 
 	_, err := d.AnalogRead("A3")
-	assert.NotNil(t, err)
+	require.Error(t, err)
 
 	_, err = d.AnalogRead("6")
-	assert.ErrorContains(t, err, "Invalid pin.")
+	require.ErrorContains(t, err, "Invalid pin.")
 }
 
 func TestIOPinDriverDigitalAnalogRead(t *testing.T) {
@@ -139,7 +140,7 @@ func TestIOPinDriverDigitalWriteAnalogRead(t *testing.T) {
 		return []byte{0, 0, 1, 128, 2, 1}, nil
 	})
 
-	assert.NoError(t, d.DigitalWrite("1", 0))
+	require.NoError(t, d.DigitalWrite("1", 0))
 
 	val, _ := d.AnalogRead("1")
 	assert.Equal(t, 128, val)
@@ -155,5 +156,5 @@ func TestIOPinDriverAnalogReadDigitalWrite(t *testing.T) {
 	val, _ := d.AnalogRead("1")
 	assert.Equal(t, 128, val)
 
-	assert.NoError(t, d.DigitalWrite("1", 0))
+	require.NoError(t, d.DigitalWrite("1", 0))
 }

--- a/platforms/microbit/led_driver_test.go
+++ b/platforms/microbit/led_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -24,32 +25,32 @@ func TestLEDDriver(t *testing.T) {
 
 func TestLEDDriverStartAndHalt(t *testing.T) {
 	d := initTestLEDDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
 }
 
 func TestLEDDriverWriteMatrix(t *testing.T) {
 	d := initTestLEDDriver()
 	_ = d.Start()
-	assert.NoError(t, d.WriteMatrix([]byte{0x01, 0x02}))
+	require.NoError(t, d.WriteMatrix([]byte{0x01, 0x02}))
 }
 
 func TestLEDDriverWriteText(t *testing.T) {
 	d := initTestLEDDriver()
 	_ = d.Start()
-	assert.NoError(t, d.WriteText("Hello"))
+	require.NoError(t, d.WriteText("Hello"))
 }
 
 func TestLEDDriverCommands(t *testing.T) {
 	d := initTestLEDDriver()
 	_ = d.Start()
-	assert.NoError(t, d.Blank())
-	assert.NoError(t, d.Solid())
-	assert.NoError(t, d.UpRightArrow())
-	assert.NoError(t, d.UpLeftArrow())
-	assert.NoError(t, d.DownRightArrow())
-	assert.NoError(t, d.DownLeftArrow())
-	assert.NoError(t, d.Dimond())
-	assert.NoError(t, d.Smile())
-	assert.NoError(t, d.Wink())
+	require.NoError(t, d.Blank())
+	require.NoError(t, d.Solid())
+	require.NoError(t, d.UpRightArrow())
+	require.NoError(t, d.UpLeftArrow())
+	require.NoError(t, d.DownRightArrow())
+	require.NoError(t, d.DownLeftArrow())
+	require.NoError(t, d.Dimond())
+	require.NoError(t, d.Smile())
+	require.NoError(t, d.Wink())
 }

--- a/platforms/microbit/magnetometer_driver_test.go
+++ b/platforms/microbit/magnetometer_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -25,8 +26,8 @@ func TestMagnetometerDriver(t *testing.T) {
 
 func TestMagnetometerDriverStartAndHalt(t *testing.T) {
 	d := initTestMagnetometerDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
 }
 
 func TestMagnetometerDriverReadData(t *testing.T) {
@@ -35,9 +36,9 @@ func TestMagnetometerDriverReadData(t *testing.T) {
 	d := NewMagnetometerDriver(a)
 	_ = d.Start()
 	_ = d.On(Magnetometer, func(data interface{}) {
-		assert.Equal(t, float32(8.738), data.(*MagnetometerData).X)
-		assert.Equal(t, float32(8.995), data.(*MagnetometerData).Y)
-		assert.Equal(t, float32(9.252), data.(*MagnetometerData).Z)
+		assert.InDelta(t, float32(8.738), data.(*MagnetometerData).X, 0.0)
+		assert.InDelta(t, float32(8.995), data.(*MagnetometerData).Y, 0.0)
+		assert.InDelta(t, float32(9.252), data.(*MagnetometerData).Z, 0.0)
 		sem <- true
 	})
 

--- a/platforms/microbit/temperature_driver_test.go
+++ b/platforms/microbit/temperature_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -25,8 +26,8 @@ func TestTemperatureDriver(t *testing.T) {
 
 func TestTemperatureDriverStartAndHalt(t *testing.T) {
 	d := initTestTemperatureDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
 }
 
 func TestTemperatureDriverReadData(t *testing.T) {

--- a/platforms/mqtt/mqtt_adaptor_test.go
+++ b/platforms/mqtt/mqtt_adaptor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -85,12 +86,12 @@ func TestMqttAdaptorConnectSSLError(t *testing.T) {
 
 func TestMqttAdaptorConnectWithAuthError(t *testing.T) {
 	a := NewAdaptorWithAuth("xyz://localhost:1883", "client", "user", "pass")
-	assert.ErrorContains(t, a.Connect(), "network Error : unknown protocol")
+	require.ErrorContains(t, a.Connect(), "network Error : unknown protocol")
 }
 
 func TestMqttAdaptorFinalize(t *testing.T) {
 	a := initTestMqttAdaptor()
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 }
 
 func TestMqttAdaptorCannotPublishUnlessConnected(t *testing.T) {
@@ -124,5 +125,5 @@ func TestMqttAdaptorOnWhenConnected(t *testing.T) {
 func TestMqttAdaptorQoS(t *testing.T) {
 	a := initTestMqttAdaptor()
 	a.SetQoS(1)
-	assert.Equal(t, a.qos, 1)
+	assert.Equal(t, 1, a.qos)
 }

--- a/platforms/mqtt/mqtt_driver_test.go
+++ b/platforms/mqtt/mqtt_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -16,8 +17,8 @@ func TestMqttDriver(t *testing.T) {
 	assert.True(t, strings.HasPrefix(d.Name(), "MQTT"))
 	assert.True(t, strings.HasPrefix(d.Connection().Name(), "MQTT"))
 
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
 }
 
 func TestMqttDriverName(t *testing.T) {

--- a/platforms/nanopi/nanopi_adaptor_test.go
+++ b/platforms/nanopi/nanopi_adaptor_test.go
@@ -2,10 +2,12 @@ package nanopi
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/gpio"
 	"gobot.io/x/gobot/v2/drivers/i2c"
@@ -92,8 +94,8 @@ func TestDigitalIO(t *testing.T) {
 	i, _ := a.DigitalRead("10")
 	assert.Equal(t, 1, i)
 
-	assert.ErrorContains(t, a.DigitalWrite("99", 1), "'99' is not a valid id for a digital pin")
-	assert.NoError(t, a.Finalize())
+	require.ErrorContains(t, a.DigitalWrite("99", 1), "'99' is not a valid id for a digital pin")
+	require.NoError(t, a.Finalize())
 }
 
 func TestInvalidPWMPin(t *testing.T) {
@@ -101,16 +103,16 @@ func TestInvalidPWMPin(t *testing.T) {
 	preparePwmFs(fs)
 
 	err := a.PwmWrite("666", 42)
-	assert.ErrorContains(t, err, "'666' is not a valid id for a PWM pin")
+	require.ErrorContains(t, err, "'666' is not a valid id for a PWM pin")
 
 	err = a.ServoWrite("666", 120)
-	assert.ErrorContains(t, err, "'666' is not a valid id for a PWM pin")
+	require.ErrorContains(t, err, "'666' is not a valid id for a PWM pin")
 
 	err = a.PwmWrite("3", 42)
-	assert.ErrorContains(t, err, "'3' is not a valid id for a PWM pin")
+	require.ErrorContains(t, err, "'3' is not a valid id for a PWM pin")
 
 	err = a.ServoWrite("3", 120)
-	assert.ErrorContains(t, err, "'3' is not a valid id for a PWM pin")
+	require.ErrorContains(t, err, "'3' is not a valid id for a PWM pin")
 }
 
 func TestPwmWrite(t *testing.T) {
@@ -118,24 +120,24 @@ func TestPwmWrite(t *testing.T) {
 	preparePwmFs(fs)
 
 	err := a.PwmWrite("PWM", 100)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "0", fs.Files[pwmExportPath].Contents)
 	assert.Equal(t, "1", fs.Files[pwmEnablePath].Contents)
-	assert.Equal(t, fmt.Sprintf("%d", 10000000), fs.Files[pwmPeriodPath].Contents)
+	assert.Equal(t, strconv.Itoa(10000000), fs.Files[pwmPeriodPath].Contents)
 	assert.Equal(t, "3921568", fs.Files[pwmDutyCyclePath].Contents)
 	assert.Equal(t, "normal", fs.Files[pwmPolarityPath].Contents)
 
 	err = a.ServoWrite("PWM", 0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "500000", fs.Files[pwmDutyCyclePath].Contents)
 
 	err = a.ServoWrite("PWM", 180)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "2000000", fs.Files[pwmDutyCyclePath].Contents)
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 }
 
 func TestSetPeriod(t *testing.T) {
@@ -147,25 +149,25 @@ func TestSetPeriod(t *testing.T) {
 	// act
 	err := a.SetPeriod("PWM", newPeriod)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "0", fs.Files[pwmExportPath].Contents)
 	assert.Equal(t, "1", fs.Files[pwmEnablePath].Contents)
-	assert.Equal(t, fmt.Sprintf("%d", newPeriod), fs.Files[pwmPeriodPath].Contents)
+	assert.Equal(t, fmt.Sprintf("%d", newPeriod), fs.Files[pwmPeriodPath].Contents) //nolint:perfsprint // ok here
 	assert.Equal(t, "0", fs.Files[pwmDutyCyclePath].Contents)
 	assert.Equal(t, "normal", fs.Files[pwmPolarityPath].Contents)
 
 	// arrange test for automatic adjustment of duty cycle to lower value
 	err = a.PwmWrite("PWM", 127) // 127 is a little bit smaller than 50% of period
-	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%d", 1270000), fs.Files[pwmDutyCyclePath].Contents)
+	require.NoError(t, err)
+	assert.Equal(t, strconv.Itoa(1270000), fs.Files[pwmDutyCyclePath].Contents)
 	newPeriod = newPeriod / 10
 
 	// act
 	err = a.SetPeriod("PWM", newPeriod)
 
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%d", 127000), fs.Files[pwmDutyCyclePath].Contents)
+	require.NoError(t, err)
+	assert.Equal(t, strconv.Itoa(127000), fs.Files[pwmDutyCyclePath].Contents)
 
 	// arrange test for automatic adjustment of duty cycle to higher value
 	newPeriod = newPeriod * 20
@@ -174,14 +176,14 @@ func TestSetPeriod(t *testing.T) {
 	err = a.SetPeriod("PWM", newPeriod)
 
 	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%d", 2540000), fs.Files[pwmDutyCyclePath].Contents)
+	require.NoError(t, err)
+	assert.Equal(t, strconv.Itoa(2540000), fs.Files[pwmDutyCyclePath].Contents)
 }
 
 func TestFinalizeErrorAfterGPIO(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem(gpioMockPaths)
 
-	assert.NoError(t, a.DigitalWrite("7", 1))
+	require.NoError(t, a.DigitalWrite("7", 1))
 
 	fs.WithWriteError = true
 
@@ -193,7 +195,7 @@ func TestFinalizeErrorAfterPWM(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem(pwmMockPaths)
 	preparePwmFs(fs)
 
-	assert.NoError(t, a.PwmWrite("PWM", 1))
+	require.NoError(t, a.PwmWrite("PWM", 1))
 
 	fs.WithWriteError = true
 
@@ -221,11 +223,11 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a := NewNeoAdaptor()
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-1"})
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 	con, err := a.GetI2cConnection(0xff, 1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = con.Write([]byte{0xbf})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/platforms/nats/nats_adaptor_test.go
+++ b/platforms/nats/nats_adaptor_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -74,7 +75,7 @@ func TestNatsAdapterSetsRootCAs(t *testing.T) {
 	_ = a.Connect()
 	o := a.client.Opts
 	casPool, err := o.RootCAsCB()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, casPool)
 	assert.True(t, o.Secure)
 }
@@ -84,7 +85,7 @@ func TestNatsAdapterSetsClientCerts(t *testing.T) {
 	assert.Equal(t, "tls://localhost:4242", a.Host)
 	_ = a.Connect()
 	cert, err := a.client.Opts.TLSCertCB()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, cert)
 	assert.NotNil(t, cert.Leaf)
 	assert.True(t, a.client.Opts.Secure)
@@ -95,7 +96,7 @@ func TestNatsAdapterSetsClientCertsWithUserInfo(t *testing.T) {
 	assert.Equal(t, "tls://localhost:4242", a.Host)
 	_ = a.Connect()
 	cert, err := a.client.Opts.TLSCertCB()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, cert)
 	assert.NotNil(t, cert.Leaf)
 	assert.True(t, a.client.Opts.Secure)
@@ -148,12 +149,12 @@ func TestNatsAdaptorFailedConnect(t *testing.T) {
 	if err != nil && strings.Contains(err.Error(), "cannot assign requested address") {
 		t.Skip("FLAKY: Can not test, because IP or port is in use.")
 	}
-	assert.ErrorContains(t, err, "nats: no servers available for connection")
+	require.ErrorContains(t, err, "nats: no servers available for connection")
 }
 
 func TestNatsAdaptorFinalize(t *testing.T) {
 	a := NewAdaptor("localhost:9999", 79999)
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 }
 
 func TestNatsAdaptorCannotPublishUnlessConnected(t *testing.T) {

--- a/platforms/nats/nats_driver_test.go
+++ b/platforms/nats/nats_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -17,8 +18,8 @@ func TestNatsDriver(t *testing.T) {
 	assert.True(t, strings.HasPrefix(d.Connection().Name(), "NATS"))
 	assert.NotNil(t, d.adaptor())
 
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
 }
 
 func TestNatsDriverName(t *testing.T) {

--- a/platforms/neurosky/neurosky_adaptor_test.go
+++ b/platforms/neurosky/neurosky_adaptor_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -69,12 +70,12 @@ func TestNeuroskyAdaptorName(t *testing.T) {
 
 func TestNeuroskyAdaptorConnect(t *testing.T) {
 	a := initTestNeuroskyAdaptor()
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 
 	a.connect = func(n *Adaptor) (io.ReadWriteCloser, error) {
 		return nil, errors.New("connection error")
 	}
-	assert.ErrorContains(t, a.Connect(), "connection error")
+	require.ErrorContains(t, a.Connect(), "connection error")
 }
 
 func TestNeuroskyAdaptorFinalize(t *testing.T) {
@@ -84,9 +85,9 @@ func TestNeuroskyAdaptorFinalize(t *testing.T) {
 		return rwc, nil
 	}
 	_ = a.Connect()
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 
 	rwc.CloseError(errors.New("close error"))
 	_ = a.Connect()
-	assert.ErrorContains(t, a.Finalize(), "close error")
+	require.ErrorContains(t, a.Finalize(), "close error")
 }

--- a/platforms/neurosky/neurosky_driver_test.go
+++ b/platforms/neurosky/neurosky_driver_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -52,7 +53,7 @@ func TestNeuroskyDriverStart(t *testing.T) {
 		sem <- true
 	})
 
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 
 	time.Sleep(50 * time.Millisecond)
 	rwc.ReadError(e)
@@ -69,7 +70,7 @@ func TestNeuroskyDriverStart(t *testing.T) {
 
 func TestNeuroskyDriverHalt(t *testing.T) {
 	d := initTestNeuroskyDriver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestNeuroskyDriverParse(t *testing.T) {

--- a/platforms/opencv/camera_driver_test.go
+++ b/platforms/opencv/camera_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -36,7 +37,7 @@ func TestCameraDriverName(t *testing.T) {
 func TestCameraDriverStart(t *testing.T) {
 	sem := make(chan bool)
 	d := initTestCameraDriver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 	d.On(d.Event("frame"), func(data interface{}) {
 		sem <- true
 	})
@@ -47,7 +48,7 @@ func TestCameraDriverStart(t *testing.T) {
 	}
 
 	d = NewCameraDriver("")
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 
 	d = NewCameraDriver(true)
 	assert.NotNil(t, d.Start())
@@ -55,5 +56,5 @@ func TestCameraDriverStart(t *testing.T) {
 
 func TestCameraDriverHalt(t *testing.T) {
 	d := initTestCameraDriver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }

--- a/platforms/opencv/window_driver_test.go
+++ b/platforms/opencv/window_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gocv.io/x/gocv"
 )
@@ -33,12 +34,12 @@ func TestWindowDriverName(t *testing.T) {
 
 func TestWindowDriverStart(t *testing.T) {
 	d := initTestWindowDriver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestWindowDriverHalt(t *testing.T) {
 	d := initTestWindowDriver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestWindowDriverShowImage(t *testing.T) {

--- a/platforms/parrot/ardrone/ardrone_adaptor_test.go
+++ b/platforms/parrot/ardrone/ardrone_adaptor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -29,12 +30,12 @@ func TestArdroneAdaptor(t *testing.T) {
 
 func TestArdroneAdaptorConnect(t *testing.T) {
 	a := initTestArdroneAdaptor()
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 
 	a.connect = func(a *Adaptor) (drone, error) {
 		return nil, errors.New("connection error")
 	}
-	assert.ErrorContains(t, a.Connect(), "connection error")
+	require.ErrorContains(t, a.Connect(), "connection error")
 }
 
 func TestArdroneAdaptorName(t *testing.T) {
@@ -46,5 +47,5 @@ func TestArdroneAdaptorName(t *testing.T) {
 
 func TestArdroneAdaptorFinalize(t *testing.T) {
 	a := initTestArdroneAdaptor()
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 }

--- a/platforms/parrot/ardrone/ardrone_driver_test.go
+++ b/platforms/parrot/ardrone/ardrone_driver_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -34,12 +35,12 @@ func TestArdroneDriverName(t *testing.T) {
 
 func TestArdroneDriverStart(t *testing.T) {
 	d := initTestArdroneDriver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestArdroneDriverHalt(t *testing.T) {
 	d := initTestArdroneDriver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestArdroneDriverTakeOff(t *testing.T) {

--- a/platforms/parrot/ardrone/pitch_test.go
+++ b/platforms/parrot/ardrone/pitch_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 func TestArdroneValidatePitchWhenEqualOffset(t *testing.T) {
-	assert.Equal(t, 1.0, ValidatePitch(32767.0, 32767.0))
+	assert.InDelta(t, 1.0, ValidatePitch(32767.0, 32767.0), 0.0)
 }
 
 func TestArdroneValidatePitchWhenTiny(t *testing.T) {
-	assert.Equal(t, 0.0, ValidatePitch(1.1, 32767.0))
+	assert.InDelta(t, 0.0, ValidatePitch(1.1, 32767.0), 0.0)
 }
 
 func TestArdroneValidatePitchWhenCentered(t *testing.T) {
-	assert.Equal(t, 0.5, ValidatePitch(16383.5, 32767.0))
+	assert.InDelta(t, 0.5, ValidatePitch(16383.5, 32767.0), 0.0)
 }

--- a/platforms/parrot/bebop/bebop_adaptor_test.go
+++ b/platforms/parrot/bebop/bebop_adaptor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -29,16 +30,16 @@ func TestBebopAdaptorName(t *testing.T) {
 
 func TestBebopAdaptorConnect(t *testing.T) {
 	a := initTestBebopAdaptor()
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 
 	a.connect = func(a *Adaptor) error {
 		return errors.New("connection error")
 	}
-	assert.ErrorContains(t, a.Connect(), "connection error")
+	require.ErrorContains(t, a.Connect(), "connection error")
 }
 
 func TestBebopAdaptorFinalize(t *testing.T) {
 	a := initTestBebopAdaptor()
 	_ = a.Connect()
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 }

--- a/platforms/parrot/minidrone/minidrone_driver_test.go
+++ b/platforms/parrot/minidrone/minidrone_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -24,133 +25,133 @@ func TestMinidroneDriver(t *testing.T) {
 
 func TestMinidroneDriverStartAndHalt(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
 }
 
 func TestMinidroneTakeoff(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.TakeOff())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.TakeOff())
 }
 
 func TestMinidroneEmergency(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Emergency())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Emergency())
 }
 
 func TestMinidroneTakePicture(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.TakePicture())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.TakePicture())
 }
 
 func TestMinidroneUp(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Up(25))
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Up(25))
 }
 
 func TestMinidroneUpTooFar(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Up(125))
-	assert.NoError(t, d.Up(-50))
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Up(125))
+	require.NoError(t, d.Up(-50))
 }
 
 func TestMinidroneDown(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Down(25))
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Down(25))
 }
 
 func TestMinidroneForward(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Forward(25))
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Forward(25))
 }
 
 func TestMinidroneBackward(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Backward(25))
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Backward(25))
 }
 
 func TestMinidroneRight(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Right(25))
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Right(25))
 }
 
 func TestMinidroneLeft(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Left(25))
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Left(25))
 }
 
 func TestMinidroneClockwise(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Clockwise(25))
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Clockwise(25))
 }
 
 func TestMinidroneCounterClockwise(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.CounterClockwise(25))
+	require.NoError(t, d.Start())
+	require.NoError(t, d.CounterClockwise(25))
 }
 
 func TestMinidroneStop(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Stop())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Stop())
 }
 
 func TestMinidroneStartStopRecording(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.StartRecording())
-	assert.NoError(t, d.StopRecording())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.StartRecording())
+	require.NoError(t, d.StopRecording())
 }
 
 func TestMinidroneHullProtectionOutdoor(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.HullProtection(true))
-	assert.NoError(t, d.Outdoor(true))
+	require.NoError(t, d.Start())
+	require.NoError(t, d.HullProtection(true))
+	require.NoError(t, d.Outdoor(true))
 }
 
 func TestMinidroneHullFlips(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.FrontFlip())
-	assert.NoError(t, d.BackFlip())
-	assert.NoError(t, d.RightFlip())
-	assert.NoError(t, d.LeftFlip())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.FrontFlip())
+	require.NoError(t, d.BackFlip())
+	require.NoError(t, d.RightFlip())
+	require.NoError(t, d.LeftFlip())
 }
 
 func TestMinidroneLightControl(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.LightControl(0, LightBlinked, 25))
+	require.NoError(t, d.Start())
+	require.NoError(t, d.LightControl(0, LightBlinked, 25))
 }
 
 func TestMinidroneClawControl(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.ClawControl(0, ClawOpen))
+	require.NoError(t, d.Start())
+	require.NoError(t, d.ClawControl(0, ClawOpen))
 }
 
 func TestMinidroneGunControl(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.GunControl(0))
+	require.NoError(t, d.Start())
+	require.NoError(t, d.GunControl(0))
 }
 
 func TestMinidroneProcessFlightData(t *testing.T) {
 	d := initTestMinidroneDriver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 
 	d.processFlightStatus([]byte{0x00, 0x00, 0x00})
 	d.processFlightStatus([]byte{0x00, 0x00, 0x00, 0x00, 0x00})
@@ -166,5 +167,5 @@ func TestMinidroneProcessFlightData(t *testing.T) {
 	d.processFlightStatus([]byte{0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x05})
 	d.processFlightStatus([]byte{0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x06})
 
-	assert.NoError(t, d.Stop())
+	require.NoError(t, d.Stop())
 }

--- a/platforms/particle/adaptor.go
+++ b/platforms/particle/adaptor.go
@@ -273,7 +273,7 @@ func (s *Adaptor) request(method string, url string, params url.Values) (m map[s
 
 func (s *Adaptor) servoPinOpen(pin string) error {
 	params := url.Values{
-		"params":       {fmt.Sprintf("%v", pin)},
+		"params":       {pin},
 		"access_token": {s.AccessToken},
 	}
 	url := fmt.Sprintf("%v/servoOpen", s.deviceURL())

--- a/platforms/particle/adaptor_test.go
+++ b/platforms/particle/adaptor_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/donovanhide/eventsource"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -88,13 +89,13 @@ func TestNewAdaptor(t *testing.T) {
 
 func TestAdaptorConnect(t *testing.T) {
 	a := initTestAdaptor()
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 }
 
 func TestAdaptorFinalize(t *testing.T) {
 	a := initTestAdaptor()
 	_ = a.Connect()
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 }
 
 func TestAdaptorAnalogRead(t *testing.T) {
@@ -254,7 +255,7 @@ func TestAdaptorFunction(t *testing.T) {
 	a.setAPIServer(testServer.URL)
 
 	_, err := a.Function("hello", "")
-	assert.ErrorContains(t, err, "timeout")
+	require.ErrorContains(t, err, "timeout")
 
 	testServer.Close()
 }
@@ -309,7 +310,7 @@ func TestAdaptorVariable(t *testing.T) {
 	a.setAPIServer(testServer.URL)
 
 	_, err := a.Variable("not_existent")
-	assert.ErrorContains(t, err, "Variable not found")
+	require.ErrorContains(t, err, "Variable not found")
 
 	testServer.Close()
 }
@@ -386,14 +387,14 @@ func TestAdaptorEventStream(t *testing.T) {
 	assert.Equal(t, "https://api.particle.io/v1/devices/myDevice/events/ping?access_token=token", url)
 
 	_, err := a.EventStream("nothing", "ping")
-	assert.ErrorContains(t, err, "source param should be: all, devices or device")
+	require.ErrorContains(t, err, "source param should be: all, devices or device")
 
 	eventSource = func(u string) (chan eventsource.Event, chan error, error) {
 		return nil, nil, errors.New("error connecting sse")
 	}
 
 	_, err = a.EventStream("devices", "")
-	assert.ErrorContains(t, err, "error connecting sse")
+	require.ErrorContains(t, err, "error connecting sse")
 
 	eventChan := make(chan eventsource.Event)
 	errorChan := make(chan error)
@@ -403,5 +404,5 @@ func TestAdaptorEventStream(t *testing.T) {
 	}
 
 	_, err = a.EventStream("devices", "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/platforms/pebble/pebble_adaptor_test.go
+++ b/platforms/pebble/pebble_adaptor_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -20,10 +21,10 @@ func TestAdaptor(t *testing.T) {
 
 func TestAdaptorConnect(t *testing.T) {
 	a := initTestAdaptor()
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 }
 
 func TestAdaptorFinalize(t *testing.T) {
 	a := initTestAdaptor()
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 }

--- a/platforms/pebble/pebble_driver_test.go
+++ b/platforms/pebble/pebble_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -16,12 +17,12 @@ func initTestDriver() *Driver {
 
 func TestDriverStart(t *testing.T) {
 	d := initTestDriver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestDriverHalt(t *testing.T) {
 	d := initTestDriver()
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestDriver(t *testing.T) {

--- a/platforms/raspi/pwm_pin_test.go
+++ b/platforms/raspi/pwm_pin_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/system"
 )
@@ -17,37 +18,37 @@ func TestPwmPin(t *testing.T) {
 
 	pin := NewPWMPin(a, path, "1")
 
-	assert.NoError(t, pin.Export())
-	assert.NoError(t, pin.SetEnabled(true))
+	require.NoError(t, pin.Export())
+	require.NoError(t, pin.SetEnabled(true))
 
 	val, _ := pin.Polarity()
 	assert.True(t, val)
 
-	assert.NoError(t, pin.SetPolarity(false))
+	require.NoError(t, pin.SetPolarity(false))
 
 	val, _ = pin.Polarity()
 	assert.True(t, val)
 
 	_, err := pin.Period()
-	assert.ErrorContains(t, err, "Raspi PWM pin period not set")
-	assert.ErrorContains(t, pin.SetDutyCycle(10000), "Raspi PWM pin period not set")
+	require.ErrorContains(t, err, "Raspi PWM pin period not set")
+	require.ErrorContains(t, pin.SetDutyCycle(10000), "Raspi PWM pin period not set")
 
-	assert.NoError(t, pin.SetPeriod(20000000))
+	require.NoError(t, pin.SetPeriod(20000000))
 	period, _ := pin.Period()
 	assert.Equal(t, uint32(20000000), period)
-	assert.ErrorContains(t, pin.SetPeriod(10000000), "Cannot set the period of individual PWM pins on Raspi")
+	require.ErrorContains(t, pin.SetPeriod(10000000), "Cannot set the period of individual PWM pins on Raspi")
 
 	dc, _ := pin.DutyCycle()
 	assert.Equal(t, uint32(0), dc)
 
-	assert.NoError(t, pin.SetDutyCycle(10000))
+	require.NoError(t, pin.SetDutyCycle(10000))
 
 	dc, _ = pin.DutyCycle()
 	assert.Equal(t, uint32(10000), dc)
 
-	assert.ErrorContains(t, pin.SetDutyCycle(999999999), "Duty cycle exceeds period")
+	require.ErrorContains(t, pin.SetDutyCycle(999999999), "Duty cycle exceeds period")
 	dc, _ = pin.DutyCycle()
 	assert.Equal(t, uint32(10000), dc)
 
-	assert.NoError(t, pin.Unexport())
+	require.NoError(t, pin.Unexport())
 }

--- a/platforms/sphero/bb8/bb8_driver_test.go
+++ b/platforms/sphero/bb8/bb8_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -24,6 +25,6 @@ func TestBB8Driver(t *testing.T) {
 
 func TestBB8DriverStartAndHalt(t *testing.T) {
 	d := initTestBB8Driver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
 }

--- a/platforms/sphero/ollie/ollie_driver_test.go
+++ b/platforms/sphero/ollie/ollie_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/platforms/sphero"
 )
@@ -26,8 +27,8 @@ func TestOllieDriver(t *testing.T) {
 
 func TestOllieDriverStartAndHalt(t *testing.T) {
 	d := initTestOllieDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
 }
 
 func TestLocatorData(t *testing.T) {

--- a/platforms/sphero/sphero_adaptor_test.go
+++ b/platforms/sphero/sphero_adaptor_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -82,23 +83,23 @@ func TestSpheroAdaptorReconnect(t *testing.T) {
 func TestSpheroAdaptorFinalize(t *testing.T) {
 	a, rwc := initTestSpheroAdaptor()
 	_ = a.Connect()
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 
 	rwc.testAdaptorClose = func() error {
 		return errors.New("close error")
 	}
 
 	a.connected = true
-	assert.ErrorContains(t, a.Finalize(), "close error")
+	require.ErrorContains(t, a.Finalize(), "close error")
 }
 
 func TestSpheroAdaptorConnect(t *testing.T) {
 	a, _ := initTestSpheroAdaptor()
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 
 	a.connect = func(string) (io.ReadWriteCloser, error) {
 		return nil, errors.New("connect error")
 	}
 
-	assert.ErrorContains(t, a.Connect(), "connect error")
+	require.ErrorContains(t, a.Connect(), "connect error")
 }

--- a/platforms/sphero/sphero_driver_test.go
+++ b/platforms/sphero/sphero_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -84,13 +85,13 @@ func TestSpheroDriver(t *testing.T) {
 
 func TestSpheroDriverStart(t *testing.T) {
 	d := initTestSpheroDriver()
-	assert.NoError(t, d.Start())
+	require.NoError(t, d.Start())
 }
 
 func TestSpheroDriverHalt(t *testing.T) {
 	d := initTestSpheroDriver()
 	d.adaptor().connected = true
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Halt())
 }
 
 func TestSpheroDriverSetDataStreaming(t *testing.T) {

--- a/platforms/sphero/sprkplus/sprkplus_driver_test.go
+++ b/platforms/sphero/sprkplus/sprkplus_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -24,6 +25,6 @@ func TestSPRKPlusDriver(t *testing.T) {
 
 func TestSPRKPlusDriverStartAndHalt(t *testing.T) {
 	d := initTestSPRKPlusDriver()
-	assert.NoError(t, d.Start())
-	assert.NoError(t, d.Halt())
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
 }

--- a/platforms/upboard/up2/adaptor_test.go
+++ b/platforms/upboard/up2/adaptor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 	"gobot.io/x/gobot/v2/drivers/gpio"
 	"gobot.io/x/gobot/v2/drivers/i2c"
@@ -77,8 +78,8 @@ func TestDigitalIO(t *testing.T) {
 		fs.Files["/sys/class/leds/upboard:green:/brightness"].Contents,
 	)
 
-	assert.ErrorContains(t, a.DigitalWrite("99", 1), "'99' is not a valid id for a digital pin")
-	assert.NoError(t, a.Finalize())
+	require.ErrorContains(t, a.DigitalWrite("99", 1), "'99' is not a valid id for a digital pin")
+	require.NoError(t, a.Finalize())
 }
 
 func TestPWM(t *testing.T) {
@@ -87,7 +88,7 @@ func TestPWM(t *testing.T) {
 	fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents = "0"
 
 	err := a.PwmWrite("32", 100)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "0", fs.Files["/sys/class/pwm/pwmchip0/export"].Contents)
 	assert.Equal(t, "1", fs.Files["/sys/class/pwm/pwmchip0/pwm0/enable"].Contents)
@@ -96,24 +97,24 @@ func TestPWM(t *testing.T) {
 	assert.Equal(t, "normal", fs.Files["/sys/class/pwm/pwmchip0/pwm0/polarity"].Contents)
 
 	err = a.ServoWrite("32", 0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "500000", fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents)
 	assert.Equal(t, "10000000", fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents)
 
 	err = a.ServoWrite("32", 180)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "2000000", fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents)
 	assert.Equal(t, "10000000", fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents)
 
-	assert.NoError(t, a.Finalize())
+	require.NoError(t, a.Finalize())
 }
 
 func TestFinalizeErrorAfterGPIO(t *testing.T) {
 	a, fs := initTestAdaptorWithMockedFilesystem(gpioMockPaths)
 
-	assert.NoError(t, a.DigitalWrite("7", 1))
+	require.NoError(t, a.DigitalWrite("7", 1))
 
 	fs.WithWriteError = true
 
@@ -126,7 +127,7 @@ func TestFinalizeErrorAfterPWM(t *testing.T) {
 	fs.Files["/sys/class/pwm/pwmchip0/pwm0/duty_cycle"].Contents = "0"
 	fs.Files["/sys/class/pwm/pwmchip0/pwm0/period"].Contents = "0"
 
-	assert.NoError(t, a.PwmWrite("32", 1))
+	require.NoError(t, a.PwmWrite("32", 1))
 
 	fs.WithWriteError = true
 
@@ -184,11 +185,11 @@ func TestI2cFinalizeWithErrors(t *testing.T) {
 	a := NewAdaptor()
 	a.sys.UseMockSyscall()
 	fs := a.sys.UseMockFilesystem([]string{"/dev/i2c-5"})
-	assert.NoError(t, a.Connect())
+	require.NoError(t, a.Connect())
 	con, err := a.GetI2cConnection(0xff, 5)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = con.Write([]byte{0xbf})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	fs.WithCloseError = true
 	// act
 	err = a.Finalize()

--- a/robot_test.go
+++ b/robot_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRobotConnectionEach(t *testing.T) {
@@ -23,24 +24,24 @@ func TestRobotToJSON(t *testing.T) {
 		return nil
 	})
 	json := NewJSONRobot(r)
-	assert.Equal(t, r.Devices().Len(), len(json.Devices))
-	assert.Equal(t, len(r.Commands()), len(json.Commands))
+	assert.Len(t, json.Devices, r.Devices().Len())
+	assert.Len(t, json.Commands, len(r.Commands()))
 }
 
 func TestRobotDevicesToJSON(t *testing.T) {
 	r := newTestRobot("Robot99")
 	json := NewJSONRobot(r)
-	assert.Equal(t, r.Devices().Len(), len(json.Devices))
+	assert.Len(t, json.Devices, r.Devices().Len())
 	assert.Equal(t, "Device1", json.Devices[0].Name)
 	assert.Equal(t, "*gobot.testDriver", json.Devices[0].Driver)
 	assert.Equal(t, "Connection1", json.Devices[0].Connection)
-	assert.Equal(t, 1, len(json.Devices[0].Commands))
+	assert.Len(t, json.Devices[0].Commands, 1)
 }
 
 func TestRobotStart(t *testing.T) {
 	r := newTestRobot("Robot99")
-	assert.NoError(t, r.Start())
-	assert.NoError(t, r.Stop())
+	require.NoError(t, r.Start())
+	require.NoError(t, r.Stop())
 	assert.False(t, r.Running())
 }
 
@@ -55,13 +56,13 @@ func TestRobotStartAutoRun(t *testing.T) {
 	)
 
 	go func() {
-		assert.NoError(t, r.Start())
+		require.NoError(t, r.Start())
 	}()
 
 	time.Sleep(10 * time.Millisecond)
 	assert.True(t, r.Running())
 
 	// stop it
-	assert.NoError(t, r.Stop())
+	require.NoError(t, r.Stop())
 	assert.False(t, r.Running())
 }

--- a/system/digitalpin_gpiod_test.go
+++ b/system/digitalpin_gpiod_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -259,7 +260,7 @@ func TestWriteGpiod(t *testing.T) {
 					assert.Contains(t, err.Error(), want)
 				}
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tc.want, lm.lastVal)
 		})
@@ -294,7 +295,7 @@ func TestReadGpiod(t *testing.T) {
 					assert.Contains(t, err.Error(), want)
 				}
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, got, tc.simVal)
 		})

--- a/system/digitalpin_poll_test.go
+++ b/system/digitalpin_poll_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_startEdgePolling(t *testing.T) {
@@ -164,11 +165,11 @@ func Test_startEdgePolling(t *testing.T) {
 			wg.Wait()
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
-			assert.Equal(t, len(tc.simulateReadValues), numCallsRead)
+			assert.Len(t, tc.simulateReadValues, numCallsRead)
 			assert.Equal(t, tc.wantEdgeTypes, edgeTypes)
 		})
 	}

--- a/system/digitalpin_sysfs_test.go
+++ b/system/digitalpin_sysfs_test.go
@@ -92,9 +92,9 @@ func TestApplyOptionsSysfs(t *testing.T) {
 			err := pin.ApplyOptions(optionFunction1, optionFunction2)
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, OUT, pin.digitalPinConfig.direction)
 			assert.Equal(t, 15, pin.digitalPinConfig.drive)
@@ -321,9 +321,9 @@ func TestDigitalPinExportSysfs(t *testing.T) {
 			err := pin.Export()
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, pin.valFile)
 				assert.NotNil(t, pin.dirFile)
 				assert.Equal(t, tc.wantDirection, fs.Files[dirPath].Contents)
@@ -351,28 +351,28 @@ func TestDigitalPinSysfs(t *testing.T) {
 	assert.Nil(t, pin.valFile)
 
 	err := pin.Unexport()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "10", fs.Files["/sys/class/gpio/unexport"].Contents)
 
 	require.NoError(t, pin.Export())
 
 	err = pin.Write(1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "1", fs.Files["/sys/class/gpio/gpio10/value"].Contents)
 
 	err = pin.ApplyOptions(WithPinDirectionInput())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "in", fs.Files["/sys/class/gpio/gpio10/direction"].Contents)
 
 	data, _ := pin.Read()
-	assert.Equal(t, data, 1)
+	assert.Equal(t, 1, data)
 
 	pin2 := newDigitalPinSysfs(fs, "30")
 	err = pin2.Write(1)
-	assert.ErrorContains(t, err, "pin has not been exported")
+	require.ErrorContains(t, err, "pin has not been exported")
 
 	data, err = pin2.Read()
-	assert.ErrorContains(t, err, "pin has not been exported")
+	require.ErrorContains(t, err, "pin has not been exported")
 	assert.Equal(t, 0, data)
 
 	writeFile = func(File, []byte) error {
@@ -380,14 +380,14 @@ func TestDigitalPinSysfs(t *testing.T) {
 	}
 
 	err = pin.Unexport()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	writeFile = func(File, []byte) error {
 		return &os.PathError{Err: errors.New("write error")}
 	}
 
 	err = pin.Unexport()
-	assert.ErrorContains(t, err.(*os.PathError).Err, "write error")
+	require.ErrorContains(t, err.(*os.PathError).Err, "write error")
 }
 
 func TestDigitalPinUnexportErrorSysfs(t *testing.T) {
@@ -401,5 +401,5 @@ func TestDigitalPinUnexportErrorSysfs(t *testing.T) {
 	}
 
 	err := pin.Unexport()
-	assert.ErrorContains(t, err, " : device or resource busy")
+	require.ErrorContains(t, err, " : device or resource busy")
 }

--- a/system/fs_mock_test.go
+++ b/system/fs_mock_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMockFilesystemOpen(t *testing.T) {
@@ -14,13 +15,13 @@ func TestMockFilesystemOpen(t *testing.T) {
 	assert.False(t, f1.Opened)
 	f2, err := fs.openFile("foo", 0, 0o666)
 	assert.Equal(t, f2, f1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = f2.Sync()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = fs.openFile("bar", 0, 0o666)
-	assert.ErrorContains(t, err, " : bar: no such file")
+	require.ErrorContains(t, err, " : bar: no such file")
 
 	fs.Add("bar")
 	f4, _ := fs.openFile("bar", 0, 0o666)
@@ -31,15 +32,15 @@ func TestMockFilesystemStat(t *testing.T) {
 	fs := newMockFilesystem([]string{"foo", "bar/baz"})
 
 	fileStat, err := fs.stat("foo")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, fileStat.IsDir())
 
 	dirStat, err := fs.stat("bar")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, dirStat.IsDir())
 
 	_, err = fs.stat("plonk")
-	assert.ErrorContains(t, err, " : plonk: no such file")
+	require.ErrorContains(t, err, " : plonk: no such file")
 }
 
 func TestMockFilesystemFind(t *testing.T) {
@@ -61,7 +62,7 @@ func TestMockFilesystemFind(t *testing.T) {
 			// act
 			dirs, err := fs.find(tt.baseDir, tt.pattern)
 			// assert
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			sort.Strings(dirs)
 			assert.Equal(t, tt.want, dirs)
 		})
@@ -73,13 +74,13 @@ func TestMockFilesystemWrite(t *testing.T) {
 	f1 := fs.Files["bar"]
 
 	f2, err := fs.openFile("bar", 0, 0o666)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// Never been read or written.
-	assert.True(t, f1.Seq <= 0)
+	assert.LessOrEqual(t, f1.Seq, 0)
 
 	_, _ = f2.WriteString("testing")
 	// Was written.
-	assert.True(t, f1.Seq > 0)
+	assert.Greater(t, f1.Seq, 0)
 	assert.Equal(t, "testing", f1.Contents)
 }
 
@@ -89,15 +90,15 @@ func TestMockFilesystemRead(t *testing.T) {
 	f1.Contents = "Yip"
 
 	f2, err := fs.openFile("bar", 0, 0o666)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// Never been read or written.
-	assert.True(t, f1.Seq <= 0)
+	assert.LessOrEqual(t, f1.Seq, 0)
 
 	buffer := make([]byte, 20)
 	n, _ := f2.Read(buffer)
 
 	// Was read.
-	assert.True(t, f1.Seq > 0)
+	assert.Greater(t, f1.Seq, 0)
 	assert.Equal(t, 3, n)
 	assert.Equal(t, "Yip", string(buffer[:3]))
 

--- a/system/fs_test.go
+++ b/system/fs_test.go
@@ -5,18 +5,19 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFilesystemOpen(t *testing.T) {
 	fs := &nativeFilesystem{}
 	file, err := fs.openFile(os.DevNull, os.O_RDONLY, 0o666)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var _ File = file
 }
 
 func TestFilesystemStat(t *testing.T) {
 	fs := &nativeFilesystem{}
 	fileInfo, err := fs.stat(os.DevNull)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, fileInfo)
 }

--- a/system/i2c_device_test.go
+++ b/system/i2c_device_test.go
@@ -6,6 +6,7 @@ import (
 	"unsafe"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -81,11 +82,11 @@ func TestNewI2cDevice(t *testing.T) {
 			d, err := a.NewI2cDevice(tc.dev)
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 				assert.Equal(t, (*i2cDevice)(nil), d)
 			} else {
 				var _ gobot.I2cSystemDevicer = d
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -95,7 +96,7 @@ func TestClose(t *testing.T) {
 	// arrange
 	d, _ := initTestI2cDeviceWithMockedSys()
 	// act & assert
-	assert.NoError(t, d.Close())
+	require.NoError(t, d.Close())
 }
 
 func TestWriteRead(t *testing.T) {
@@ -107,10 +108,10 @@ func TestWriteRead(t *testing.T) {
 	wn, werr := d.Write(1, wbuf)
 	rn, rerr := d.Read(1, rbuf)
 	// assert
-	assert.NoError(t, werr)
-	assert.NoError(t, rerr)
-	assert.Equal(t, len(wbuf), wn)
-	assert.Equal(t, len(wbuf), rn) // will read only the written values
+	require.NoError(t, werr)
+	require.NoError(t, rerr)
+	assert.Len(t, wbuf, wn)
+	assert.Len(t, wbuf, rn) // will read only the written values
 	assert.Equal(t, rbuf[:len(wbuf)], wbuf)
 }
 
@@ -145,9 +146,9 @@ func TestReadByte(t *testing.T) {
 			got, err := d.ReadByte(2)
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, want, got)
 				assert.Equal(t, d.file, msc.lastFile)
 				assert.Equal(t, uintptr(I2C_SMBUS), msc.lastSignal)
@@ -193,9 +194,9 @@ func TestReadByteData(t *testing.T) {
 			got, err := d.ReadByteData(3, reg)
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, want, got)
 				assert.Equal(t, d.file, msc.lastFile)
 				assert.Equal(t, uintptr(I2C_SMBUS), msc.lastSignal)
@@ -244,9 +245,9 @@ func TestReadWordData(t *testing.T) {
 			got, err := d.ReadWordData(4, reg)
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, want, got)
 				assert.Equal(t, d.file, msc.lastFile)
 				assert.Equal(t, uintptr(I2C_SMBUS), msc.lastSignal)
@@ -303,9 +304,9 @@ func TestReadBlockData(t *testing.T) {
 			err := d.ReadBlockData(5, reg, buf)
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, msc.dataSlice, buf)
 				assert.Equal(t, d.file, msc.lastFile)
 				assert.Equal(t, uintptr(I2C_SMBUS), msc.lastSignal)
@@ -348,9 +349,9 @@ func TestWriteByte(t *testing.T) {
 			err := d.WriteByte(6, val)
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, d.file, msc.lastFile)
 				assert.Equal(t, uintptr(I2C_SMBUS), msc.lastSignal)
 				assert.Equal(t, byte(I2C_SMBUS_WRITE), msc.smbus.readWrite)
@@ -394,15 +395,15 @@ func TestWriteByteData(t *testing.T) {
 			err := d.WriteByteData(7, reg, val)
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, d.file, msc.lastFile)
 				assert.Equal(t, uintptr(I2C_SMBUS), msc.lastSignal)
 				assert.Equal(t, byte(I2C_SMBUS_WRITE), msc.smbus.readWrite)
 				assert.Equal(t, reg, msc.smbus.command)
 				assert.Equal(t, uint32(I2C_SMBUS_BYTE_DATA), msc.smbus.protocol)
-				assert.Equal(t, 1, len(msc.dataSlice))
+				assert.Len(t, msc.dataSlice, 1)
 				assert.Equal(t, val, msc.dataSlice[0])
 			}
 		})
@@ -444,15 +445,15 @@ func TestWriteWordData(t *testing.T) {
 			err := d.WriteWordData(8, reg, val)
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, d.file, msc.lastFile)
 				assert.Equal(t, uintptr(I2C_SMBUS), msc.lastSignal)
 				assert.Equal(t, byte(I2C_SMBUS_WRITE), msc.smbus.readWrite)
 				assert.Equal(t, reg, msc.smbus.command)
 				assert.Equal(t, uint32(I2C_SMBUS_WORD_DATA), msc.smbus.protocol)
-				assert.Equal(t, 2, len(msc.dataSlice))
+				assert.Len(t, msc.dataSlice, 2)
 				// all common drivers write LSByte first
 				assert.Equal(t, wantLSByte, msc.dataSlice[0])
 				assert.Equal(t, wantMSByte, msc.dataSlice[1])
@@ -502,9 +503,9 @@ func TestWriteBlockData(t *testing.T) {
 			err := d.WriteBlockData(9, reg, data)
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, d.file, msc.lastFile)
 				assert.Equal(t, uintptr(I2C_SMBUS), msc.lastSignal)
 				assert.Equal(t, uint8(len(data)+1), msc.sliceSize) // including size element
@@ -524,7 +525,7 @@ func TestWriteBlockDataTooMuch(t *testing.T) {
 	// act
 	err := d.WriteBlockData(10, 0x01, make([]byte, 33))
 	// assert
-	assert.ErrorContains(t, err, "Writing blocks larger than 32 bytes (33) not supported")
+	require.ErrorContains(t, err, "Writing blocks larger than 32 bytes (33) not supported")
 }
 
 func Test_setAddress(t *testing.T) {
@@ -533,7 +534,7 @@ func Test_setAddress(t *testing.T) {
 	// act
 	err := d.setAddress(0xff)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, uintptr(0xff), msc.devAddress)
 }
 
@@ -575,9 +576,9 @@ func Test_queryFunctionality(t *testing.T) {
 			err := d.queryFunctionality(tc.requested, "test"+name)
 			// assert
 			if tc.wantErr != "" {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			if tc.wantFile {
 				assert.NotNil(t, d.file)

--- a/system/pwmpin_sysfs.go
+++ b/system/pwmpin_sysfs.go
@@ -91,7 +91,7 @@ func (p *pwmPinSysFs) SetEnabled(enable bool) error {
 	if enable {
 		enableVal = 1
 	}
-	if _, err := p.write(p.fs, p.pwmEnablePath(), []byte(fmt.Sprintf("%v", enableVal))); err != nil {
+	if _, err := p.write(p.fs, p.pwmEnablePath(), []byte(strconv.Itoa(enableVal))); err != nil {
 		if pwmDebug {
 			p.printState()
 		}
@@ -158,6 +158,7 @@ func (p *pwmPinSysFs) Period() (uint32, error) {
 
 // SetPeriod writes the current period in nanoseconds
 func (p *pwmPinSysFs) SetPeriod(period uint32) error {
+	//nolint:perfsprint // ok here
 	if _, err := p.write(p.fs, p.pwmPeriodPath(), []byte(fmt.Sprintf("%v", period))); err != nil {
 
 		if pwmDebug {
@@ -181,6 +182,7 @@ func (p *pwmPinSysFs) DutyCycle() (uint32, error) {
 
 // SetDutyCycle writes the duty cycle in nanoseconds
 func (p *pwmPinSysFs) SetDutyCycle(duty uint32) error {
+	//nolint:perfsprint // ok here
 	if _, err := p.write(p.fs, p.pwmDutyCyclePath(), []byte(fmt.Sprintf("%v", duty))); err != nil {
 		if pwmDebug {
 			p.printState()

--- a/system/pwmpin_sysfs_test.go
+++ b/system/pwmpin_sysfs_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gobot.io/x/gobot/v2"
 )
 
@@ -35,39 +36,39 @@ func TestPwmPin(t *testing.T) {
 	assert.Equal(t, "10", pin.pin)
 
 	err := pin.Unexport()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "10", fs.Files["/sys/class/pwm/pwmchip0/unexport"].Contents)
 
 	err = pin.Export()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "10", fs.Files["/sys/class/pwm/pwmchip0/export"].Contents)
 
-	assert.NoError(t, pin.SetPolarity(false))
+	require.NoError(t, pin.SetPolarity(false))
 	assert.Equal(t, inverted, fs.Files["/sys/class/pwm/pwmchip0/pwm10/polarity"].Contents)
 	pol, _ := pin.Polarity()
 	assert.False(t, pol)
-	assert.NoError(t, pin.SetPolarity(true))
+	require.NoError(t, pin.SetPolarity(true))
 	assert.Equal(t, normal, fs.Files["/sys/class/pwm/pwmchip0/pwm10/polarity"].Contents)
 	pol, _ = pin.Polarity()
 	assert.True(t, pol)
 
 	assert.NotEqual(t, "1", fs.Files["/sys/class/pwm/pwmchip0/pwm10/enable"].Contents)
 	err = pin.SetEnabled(true)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "1", fs.Files["/sys/class/pwm/pwmchip0/pwm10/enable"].Contents)
 	err = pin.SetPolarity(true)
-	assert.ErrorContains(t, err, "Cannot set PWM polarity when enabled")
+	require.ErrorContains(t, err, "Cannot set PWM polarity when enabled")
 
 	fs.Files["/sys/class/pwm/pwmchip0/pwm10/period"].Contents = "6"
 	data, _ := pin.Period()
 	assert.Equal(t, uint32(6), data)
-	assert.NoError(t, pin.SetPeriod(100000))
+	require.NoError(t, pin.SetPeriod(100000))
 	data, _ = pin.Period()
 	assert.Equal(t, uint32(100000), data)
 
 	assert.NotEqual(t, "1", fs.Files["/sys/class/pwm/pwmchip0/pwm10/duty_cycle"].Contents)
 	err = pin.SetDutyCycle(100)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "100", fs.Files["/sys/class/pwm/pwmchip0/pwm10/duty_cycle"].Contents)
 	data, _ = pin.DutyCycle()
 	assert.Equal(t, uint32(100), data)
@@ -88,7 +89,7 @@ func TestPwmPinAlreadyExported(t *testing.T) {
 	}
 
 	// no error indicates that the pin was already exported
-	assert.NoError(t, pin.Export())
+	require.NoError(t, pin.Export())
 }
 
 func TestPwmPinExportError(t *testing.T) {
@@ -107,7 +108,7 @@ func TestPwmPinExportError(t *testing.T) {
 
 	// no error indicates that the pin was already exported
 	err := pin.Export()
-	assert.ErrorContains(t, err, "Export() failed for id 10 with  : bad address")
+	require.ErrorContains(t, err, "Export() failed for id 10 with  : bad address")
 }
 
 func TestPwmPinUnxportError(t *testing.T) {
@@ -125,7 +126,7 @@ func TestPwmPinUnxportError(t *testing.T) {
 	}
 
 	err := pin.Unexport()
-	assert.ErrorContains(t, err, "Unexport() failed for id 10 with  : device or resource busy")
+	require.ErrorContains(t, err, "Unexport() failed for id 10 with  : device or resource busy")
 }
 
 func TestPwmPinPeriodError(t *testing.T) {
@@ -143,7 +144,7 @@ func TestPwmPinPeriodError(t *testing.T) {
 	}
 
 	_, err := pin.Period()
-	assert.ErrorContains(t, err, "Period() failed for id 10 with  : device or resource busy")
+	require.ErrorContains(t, err, "Period() failed for id 10 with  : device or resource busy")
 }
 
 func TestPwmPinPolarityError(t *testing.T) {
@@ -161,7 +162,7 @@ func TestPwmPinPolarityError(t *testing.T) {
 	}
 
 	_, err := pin.Polarity()
-	assert.ErrorContains(t, err, "Polarity() failed for id 10 with  : device or resource busy")
+	require.ErrorContains(t, err, "Polarity() failed for id 10 with  : device or resource busy")
 }
 
 func TestPwmPinDutyCycleError(t *testing.T) {
@@ -179,5 +180,5 @@ func TestPwmPinDutyCycleError(t *testing.T) {
 	}
 
 	_, err := pin.DutyCycle()
-	assert.ErrorContains(t, err, "DutyCycle() failed for id 10 with  : device or resource busy")
+	require.ErrorContains(t, err, "DutyCycle() failed for id 10 with  : device or resource busy")
 }

--- a/system/system_test.go
+++ b/system/system_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewAccesser(t *testing.T) {
@@ -34,7 +35,7 @@ func TestNewAccesser_NewSpiDevice(t *testing.T) {
 	// act
 	con, err := a.NewSpiDevice(busNum, chipNum, mode, bits, maxSpeed)
 	// assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, con)
 	assert.Equal(t, busNum, spi.busNum)
 	assert.Equal(t, chipNum, spi.chipNum)

--- a/utils_test.go
+++ b/utils_test.go
@@ -64,18 +64,18 @@ func TestAfter(t *testing.T) {
 }
 
 func TestFromScale(t *testing.T) {
-	assert.Equal(t, 0.5, FromScale(5, 0, 10))
+	assert.InDelta(t, 0.5, FromScale(5, 0, 10), 0.0)
 }
 
 func TestToScale(t *testing.T) {
-	assert.Equal(t, 10.0, ToScale(500, 0, 10))
-	assert.Equal(t, 0.0, ToScale(-1, 0, 10))
-	assert.Equal(t, 5.0, ToScale(0.5, 0, 10))
+	assert.InDelta(t, 10.0, ToScale(500, 0, 10), 0.0)
+	assert.InDelta(t, 0.0, ToScale(-1, 0, 10), 0.0)
+	assert.InDelta(t, 5.0, ToScale(0.5, 0, 10), 0.0)
 }
 
 func TestRescale(t *testing.T) {
-	assert.Equal(t, 5.0, Rescale(500, 0, 1000, 0, 10))
-	assert.Equal(t, 490.0, Rescale(-1.0, -1, 0, 490, 350))
+	assert.InDelta(t, 5.0, Rescale(500, 0, 1000, 0, 10), 0.0)
+	assert.InDelta(t, 490.0, Rescale(-1.0, -1, 0, 490, 350), 0.0)
 }
 
 func TestRand(t *testing.T) {


### PR DESCRIPTION
## Solved issues and/or description of the change

solves #1031 

## Manual test

none

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code
