### PR TITLE
aio(thermalzone): add driver for read a thermalzone from system

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,12 +298,15 @@ Support for many devices that use Analog Input/Output (AIO) have
 a shared set of drivers provided using the `gobot/drivers/aio` package:
 
 - [AIO](https://en.wikipedia.org/wiki/Analog-to-digital_converter) <=> [Drivers](https://github.com/hybridgroup/gobot/tree/master/drivers/aio)
+  - Analog Actuator
   - Analog Sensor
   - Grove Light Sensor
   - Grove Piezo Vibration Sensor
   - Grove Rotary Dial
   - Grove Sound Sensor
   - Grove Temperature Sensor
+  - Temperature Sensor (supports linear and NTC thermistor in normal and inverse mode)
+  - Thermal Zone Temperature Sensor
 
 Support for devices that use Inter-Integrated Circuit (I2C) have a shared set of
 drivers provided using the `gobot/drivers/i2c` package:

--- a/drivers/aio/README.md
+++ b/drivers/aio/README.md
@@ -12,12 +12,12 @@ Please refer to the main [README.md](https://github.com/hybridgroup/gobot/blob/r
 
 Gobot has a extensible system for connecting to hardware devices. The following AIO devices are currently supported:
 
-- Analog Sensor
 - Analog Actuator
+- Analog Sensor
 - Grove Light Sensor
+- Grove Piezo Vibration Sensor
 - Grove Rotary Dial
 - Grove Sound Sensor
 - Grove Temperature Sensor
 - Temperature Sensor (supports linear and NTC thermistor in normal and inverse mode)
-
-More drivers are coming soon...
+- Thermal Zone Temperature Sensor

--- a/drivers/aio/temperature_sensor_driver_test.go
+++ b/drivers/aio/temperature_sensor_driver_test.go
@@ -128,7 +128,7 @@ func TestTemperatureSensorDriver_LinearScaler(t *testing.T) {
 	}
 }
 
-func TestTemperatureSensorPublishesTemperatureInCelsius(t *testing.T) {
+func TestTemperatureSensorWithSensorCyclicRead_PublishesTemperatureInCelsius(t *testing.T) {
 	// arrange
 	sem := make(chan bool)
 	a := newAioTestAdaptor()
@@ -155,7 +155,7 @@ func TestTemperatureSensorPublishesTemperatureInCelsius(t *testing.T) {
 	assert.InDelta(t, 31.61532462352477, d.Value(), 0.0)
 }
 
-func TestTemperatureSensorWithSensorCyclicReadPublishesError(t *testing.T) {
+func TestTemperatureSensorWithSensorCyclicRead_PublishesError(t *testing.T) {
 	// arrange
 	sem := make(chan bool)
 	a := newAioTestAdaptor()

--- a/drivers/aio/thermalzone_driver.go
+++ b/drivers/aio/thermalzone_driver.go
@@ -1,0 +1,83 @@
+package aio
+
+import (
+	"fmt"
+
+	"gobot.io/x/gobot/v2"
+)
+
+// thermalZoneOptionApplier needs to be implemented by each configurable option type
+type thermalZoneOptionApplier interface {
+	apply(cfg *thermalZoneConfiguration)
+}
+
+// thermalZoneConfiguration contains all changeable attributes of the driver.
+type thermalZoneConfiguration struct {
+	scaleUnit func(float64) float64
+}
+
+// thermalZoneUnitscalerOption is the type for applying another unit scaler to the configuration
+type thermalZoneUnitscalerOption struct {
+	unitscaler func(float64) float64
+}
+
+// ThermalZoneDriver represents an driver for reading the system thermal zone temperature
+type ThermalZoneDriver struct {
+	*AnalogSensorDriver
+	thermalZoneCfg *thermalZoneConfiguration
+}
+
+// NewThermalZoneDriver is a driver for reading the system thermal zone temperature, given an AnalogReader and zone id.
+//
+// Supported options: see also [aio.NewAnalogSensorDriver]
+//
+//	"WithFahrenheit()"
+//
+// Adds the following API Commands: see [aio.NewAnalogSensorDriver]
+func NewThermalZoneDriver(a AnalogReader, zoneID string, opts ...interface{}) *ThermalZoneDriver {
+	degreeScaler := func(input int) float64 { return float64(input) / 1000 }
+	d := ThermalZoneDriver{
+		AnalogSensorDriver: NewAnalogSensorDriver(a, zoneID, WithSensorScaler(degreeScaler)),
+		thermalZoneCfg: &thermalZoneConfiguration{
+			scaleUnit: func(input float64) float64 { return input }, // 1:1 in °C
+		},
+	}
+	d.driverCfg.name = gobot.DefaultName("ThermalZone")
+	d.analogRead = d.thermalZoneRead
+
+	for _, opt := range opts {
+		switch o := opt.(type) {
+		case optionApplier:
+			o.apply(d.driverCfg)
+		case sensorOptionApplier:
+			o.apply(d.sensorCfg)
+		case thermalZoneOptionApplier:
+			o.apply(d.thermalZoneCfg)
+		default:
+			panic(fmt.Sprintf("'%s' can not be applied on '%s'", opt, d.driverCfg.name))
+		}
+	}
+
+	return &d
+}
+
+// WithFahrenheit substitute the default 1:1 °C scaler by a scaler for °F
+func WithFahrenheit() thermalZoneOptionApplier {
+	// (1°C × 9/5) + 32 = 33,8°F
+	unitscaler := func(input float64) float64 { return input*9.0/5.0 + 32.0 }
+	return thermalZoneUnitscalerOption{unitscaler: unitscaler}
+}
+
+// thermalZoneRead overrides and extends the analogSensorRead() function to add the unit scaler
+func (d *ThermalZoneDriver) thermalZoneRead() (int, float64, error) {
+	if _, _, err := d.analogSensorRead(); err != nil {
+		return 0, 0, err
+	}
+	// apply unit scaler on value
+	d.lastValue = d.thermalZoneCfg.scaleUnit(d.lastValue)
+	return d.lastRawValue, d.lastValue, nil
+}
+
+func (o thermalZoneUnitscalerOption) apply(cfg *thermalZoneConfiguration) {
+	cfg.scaleUnit = o.unitscaler
+}

--- a/drivers/aio/thermalzone_driver_test.go
+++ b/drivers/aio/thermalzone_driver_test.go
@@ -1,0 +1,91 @@
+package aio
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewThermalZoneDriver(t *testing.T) {
+	// arrange
+	const pin = "thermal_zone0"
+	a := newAioTestAdaptor()
+	// act
+	d := NewThermalZoneDriver(a, pin)
+	// assert: driver attributes
+	assert.IsType(t, &ThermalZoneDriver{}, d)
+	assert.NotNil(t, d.driverCfg)
+	assert.True(t, strings.HasPrefix(d.Name(), "ThermalZone"))
+	assert.Equal(t, a, d.Connection())
+	require.NoError(t, d.afterStart())
+	require.NoError(t, d.beforeHalt())
+	assert.NotNil(t, d.Commander)
+	assert.NotNil(t, d.mutex)
+	// assert: sensor attributes
+	assert.Equal(t, pin, d.Pin())
+	assert.InDelta(t, 0.0, d.lastValue, 0, 0)
+	assert.Equal(t, 0, d.lastRawValue)
+	assert.Nil(t, d.halt) // will be created on initialize, if cyclic reading is on
+	assert.NotNil(t, d.Eventer)
+	require.NotNil(t, d.sensorCfg)
+	assert.Equal(t, time.Duration(0), d.sensorCfg.readInterval)
+	assert.NotNil(t, d.sensorCfg.scale)
+	// assert: thermal zone attributes
+	require.NotNil(t, d.thermalZoneCfg)
+	require.NotNil(t, d.thermalZoneCfg.scaleUnit)
+	assert.InDelta(t, 1.0, d.thermalZoneCfg.scaleUnit(1), 0.0)
+}
+
+func TestNewThermalZoneDriver_options(t *testing.T) {
+	// This is a general test, that options are applied in constructor by using the common WithName() option, least one
+	// option of this driver and one of another driver (which should lead to panic). Further tests for options can also
+	// be done by call of "WithOption(val).apply(cfg)".
+	// arrange
+	const (
+		myName     = "outlet temperature"
+		cycReadDur = 10 * time.Millisecond
+	)
+	panicFunc := func() {
+		NewThermalZoneDriver(newAioTestAdaptor(), "1", WithName("crazy"),
+			WithActuatorScaler(func(float64) int { return 0 }))
+	}
+	// act
+	d := NewThermalZoneDriver(newAioTestAdaptor(), "1",
+		WithName(myName),
+		WithSensorCyclicRead(cycReadDur),
+		WithFahrenheit())
+	// assert
+	assert.Equal(t, cycReadDur, d.sensorCfg.readInterval)
+	assert.InDelta(t, 33.8, d.thermalZoneCfg.scaleUnit(1), 0.0) // (1°C × 9/5) + 32 = 33,8°F
+	assert.Equal(t, myName, d.Name())
+	assert.PanicsWithValue(t, "'scaler option for analog actuators' can not be applied on 'crazy'", panicFunc)
+}
+
+func TestThermalZoneWithSensorCyclicRead_PublishesTemperatureInFahrenheit(t *testing.T) {
+	// arrange
+	sem := make(chan bool)
+	a := newAioTestAdaptor()
+	d := NewThermalZoneDriver(a, "1", WithSensorCyclicRead(10*time.Millisecond), WithFahrenheit())
+	a.analogReadFunc = func() (int, error) {
+		return -100000, nil // -100.000 °C
+	}
+	// act: start cyclic reading
+	require.NoError(t, d.Start())
+	// assert
+	_ = d.Once(d.Event(Value), func(data interface{}) {
+		//nolint:forcetypeassert // ok here
+		assert.InDelta(t, -148.0, data.(float64), 0.0)
+		sem <- true
+	})
+
+	select {
+	case <-sem:
+	case <-time.After(1 * time.Second):
+		t.Errorf(" Temperature Sensor Event \"Data\" was not published")
+	}
+
+	assert.InDelta(t, -148.0, d.Value(), 0.0)
+}

--- a/examples/raspi_thermalzone.go
+++ b/examples/raspi_thermalzone.go
@@ -1,0 +1,50 @@
+//go:build example
+// +build example
+
+//
+// Do not build by default.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"gobot.io/x/gobot/v2"
+	"gobot.io/x/gobot/v2/drivers/aio"
+	"gobot.io/x/gobot/v2/platforms/raspi"
+)
+
+// Wiring: no wiring needed
+func main() {
+	adaptor := raspi.NewAdaptor()
+	therm0C := aio.NewThermalZoneDriver(adaptor, "thermal_zone0")
+	therm0F := aio.NewThermalZoneDriver(adaptor, "thermal_zone0", aio.WithFahrenheit())
+
+	work := func() {
+		gobot.Every(500*time.Millisecond, func() {
+			t0C, err := therm0C.Read()
+			if err != nil {
+				log.Println(err)
+			}
+
+			t0F, err := therm0F.Read()
+			if err != nil {
+				log.Println(err)
+			}
+
+			fmt.Printf("Zone 0: %2.3f °C, %2.3f °F\n", t0C, t0F)
+		})
+	}
+
+	robot := gobot.NewRobot("thermalBot",
+		[]gobot.Connection{adaptor},
+		[]gobot.Device{therm0C, therm0F},
+		work,
+	)
+
+	if err := robot.Start(); err != nil {
+		panic(err)
+	}
+}

--- a/examples/tinkerboard_thermalzone.go
+++ b/examples/tinkerboard_thermalzone.go
@@ -1,0 +1,50 @@
+//go:build example
+// +build example
+
+//
+// Do not build by default.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"gobot.io/x/gobot/v2"
+	"gobot.io/x/gobot/v2/drivers/aio"
+	"gobot.io/x/gobot/v2/platforms/tinkerboard"
+)
+
+// Wiring: no wiring needed
+func main() {
+	adaptor := tinkerboard.NewAdaptor()
+	therm0 := aio.NewThermalZoneDriver(adaptor, "thermal_zone0")
+	therm1 := aio.NewThermalZoneDriver(adaptor, "thermal_zone1", aio.WithFahrenheit())
+
+	work := func() {
+		gobot.Every(500*time.Millisecond, func() {
+			t0, err := therm0.Read()
+			if err != nil {
+				log.Println(err)
+			}
+
+			t1, err := therm1.Read()
+			if err != nil {
+				log.Println(err)
+			}
+
+			fmt.Printf("Zone 0: %2.3f °C, Zone 1: %2.3f °F\n", t0, t1)
+		})
+	}
+
+	robot := gobot.NewRobot("thermalBot",
+		[]gobot.Connection{adaptor},
+		[]gobot.Device{therm0, therm1},
+		work,
+	)
+
+	if err := robot.Start(); err != nil {
+		panic(err)
+	}
+}

--- a/platforms/nanopi/nanopineo_pin_map.go
+++ b/platforms/nanopi/nanopineo_pin_map.go
@@ -23,3 +23,8 @@ var neoPwmPins = map[string]pwmPinDefinition{
 	// UART_RXD0, GPIOA5, PWM
 	"PWM": {dir: "/sys/devices/platform/soc/1c21400.pwm/pwm/", dirRegexp: "pwmchip[0]$", channel: 0},
 }
+
+var analogPinDefinitions = map[string]analogPinDefinition{
+	// +/-273.200 °C need >=7 characters to read: +/-273200 millidegree Celsius
+	"thermal_zone0": {path: "/sys/class/thermal/thermal_zone0/temp", r: true, w: false, bufLen: 7},
+}

--- a/platforms/raspi/raspi_pin_map.go
+++ b/platforms/raspi/raspi_pin_map.go
@@ -86,3 +86,8 @@ var pins = map[string]map[string]int{
 		"3": 21,
 	},
 }
+
+var analogPinDefinitions = map[string]analogPinDefinition{
+	// +/-273.200 °C need >=7 characters to read: +/-273200 millidegree Celsius
+	"thermal_zone0": {path: "/sys/class/thermal/thermal_zone0/temp", r: true, w: false, bufLen: 7},
+}

--- a/platforms/tinkerboard/adaptor_test.go
+++ b/platforms/tinkerboard/adaptor_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"gobot.io/x/gobot/v2"
+	"gobot.io/x/gobot/v2/drivers/aio"
 	"gobot.io/x/gobot/v2/drivers/gpio"
 	"gobot.io/x/gobot/v2/drivers/i2c"
 	"gobot.io/x/gobot/v2/system"
@@ -58,6 +59,7 @@ var (
 	_ gpio.DigitalWriter          = (*Adaptor)(nil)
 	_ gpio.PwmWriter              = (*Adaptor)(nil)
 	_ gpio.ServoWriter            = (*Adaptor)(nil)
+	_ aio.AnalogReader            = (*Adaptor)(nil)
 	_ i2c.Connector               = (*Adaptor)(nil)
 )
 
@@ -96,6 +98,29 @@ func TestDigitalIO(t *testing.T) {
 	assert.Equal(t, 1, i)
 
 	require.ErrorContains(t, a.DigitalWrite("99", 1), "'99' is not a valid id for a digital pin")
+	require.NoError(t, a.Finalize())
+}
+
+func TestAnalog(t *testing.T) {
+	mockPaths := []string{
+		"/sys/class/thermal/thermal_zone0/temp",
+	}
+
+	a, fs := initTestAdaptorWithMockedFilesystem(mockPaths)
+
+	fs.Files["/sys/class/thermal/thermal_zone0/temp"].Contents = "567\n"
+	got, err := a.AnalogRead("thermal_zone0")
+	require.NoError(t, err)
+	assert.Equal(t, 567, got)
+
+	_, err = a.AnalogRead("thermal_zone10")
+	require.ErrorContains(t, err, "'thermal_zone10' is not a valid id for a analog pin")
+
+	fs.WithReadError = true
+	_, err = a.AnalogRead("thermal_zone0")
+	require.ErrorContains(t, err, "read error")
+	fs.WithReadError = false
+
 	require.NoError(t, a.Finalize())
 }
 
@@ -351,6 +376,55 @@ func Test_translateDigitalPin(t *testing.T) {
 			assert.Equal(t, tc.wantErr, err)
 			assert.Equal(t, tc.wantChip, chip)
 			assert.Equal(t, tc.wantLine, line)
+		})
+	}
+}
+
+func Test_translateAnalogPin(t *testing.T) {
+	mockedPaths := []string{
+		"/sys/class/thermal/thermal_zone0/temp",
+		"/sys/class/thermal/thermal_zone1/temp",
+	}
+	tests := map[string]struct {
+		id           string
+		wantPath     string
+		wantReadable bool
+		wantBufLen   uint16
+		wantErr      string
+	}{
+		"translate_thermal_zone0": {
+			id:           "thermal_zone0",
+			wantPath:     "/sys/class/thermal/thermal_zone0/temp",
+			wantReadable: true,
+			wantBufLen:   7,
+		},
+		"translate_thermal_zone1": {
+			id:           "thermal_zone1",
+			wantPath:     "/sys/class/thermal/thermal_zone1/temp",
+			wantReadable: true,
+			wantBufLen:   7,
+		},
+		"unknown_id": {
+			id:      "99",
+			wantErr: "'99' is not a valid id for a analog pin",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			a, _ := initTestAdaptorWithMockedFilesystem(mockedPaths)
+			// act
+			path, r, w, buf, err := a.translateAnalogPin(tc.id)
+			// assert
+			if tc.wantErr != "" {
+				require.EqualError(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantPath, path)
+			assert.Equal(t, tc.wantReadable, r)
+			assert.False(t, w)
+			assert.Equal(t, tc.wantBufLen, buf)
 		})
 	}
 }

--- a/platforms/tinkerboard/pin_map.go
+++ b/platforms/tinkerboard/pin_map.go
@@ -1,15 +1,5 @@
 package tinkerboard
 
-type cdevPin struct {
-	chip uint8
-	line uint8
-}
-
-type gpioPinDefinition struct {
-	sysfs int
-	cdev  cdevPin
-}
-
 // notes for character device
 // pins: A=0+Nr, B=8+Nr, C=16+Nr
 // tested: armbian Linux, OK: work as input and output, IN: work only as input
@@ -49,4 +39,10 @@ var pwmPinDefinitions = map[string]pwmPinDefinition{
 	"33": {dir: "/sys/devices/platform/ff680020.pwm/pwm/", dirRegexp: "pwmchip[0|1|2]$", channel: 0},
 	// GPIO7_C7_UART2TX_PWM3
 	"32": {dir: "/sys/devices/platform/ff680030.pwm/pwm/", dirRegexp: "pwmchip[0|1|2|3]$", channel: 0},
+}
+
+var analogPinDefinitions = map[string]analogPinDefinition{
+	// +/-273.200 °C need >=7 characters to read: +/-273200 millidegree Celsius
+	"thermal_zone0": {path: "/sys/class/thermal/thermal_zone0/temp", r: true, w: false, bufLen: 7},
+	"thermal_zone1": {path: "/sys/class/thermal/thermal_zone1/temp", r: true, w: false, bufLen: 7},
 }


### PR DESCRIPTION
## Solved issues and/or description of the change

introduce a analog reader for reading the thermalzone temperature from the systems sysfs

see: https://www.kernel.org/doc/Documentation/thermal/sysfs-api.txt

add this new ability to platforms:
* [x] tinkerboard
* [x] raspi
* [x] nanopi neo

## Manual test

- OS and Version (Win/Mac/Linux): Linux
- Adaptor(s) and/or driver(s): tinkerboard, raspi

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code
- [x] depends on #1041 

If this is a new driver or adaptor:

- [x] I have added the name to the corresponding README.md
- [x] I have added an example to see how to setup and use it
- [x] I have checked or build at least my new example (e.g. by run `make examples_check`)