### PR TITLE
platforms(adaptors): add a generic analog pin adaptor

### DIFF
--- a/adaptor.go
+++ b/adaptor.go
@@ -99,6 +99,14 @@ type PWMPinnerProvider interface {
 	PWMPin(id string) (PWMPinner, error)
 }
 
+// AnalogPinner is the interface for system analog io interactions
+type AnalogPinner interface {
+	// Read reads the current value of the pin
+	Read() (int, error)
+	// Write writes to the pin
+	Write(val int) error
+}
+
 // I2cSystemDevicer is the interface to a i2c bus at system level, according to I2C/SMBus specification.
 // Some functions are not in the interface yet:
 // * Process Call (WriteWordDataReadWordData)

--- a/platforms/adaptors/analogpinsadaptor.go
+++ b/platforms/adaptors/analogpinsadaptor.go
@@ -1,0 +1,95 @@
+package adaptors
+
+import (
+	"fmt"
+	"sync"
+
+	"gobot.io/x/gobot/v2"
+	"gobot.io/x/gobot/v2/system"
+)
+
+type analogPinTranslator func(pin string) (path string, r, w bool, bufLen uint16, err error)
+
+// AnalogPinsAdaptor is a adaptor for analog pins, normally used for composition in platforms.
+// It is also usable for general sysfs access.
+type AnalogPinsAdaptor struct {
+	sys       *system.Accesser
+	translate analogPinTranslator
+	pins      map[string]gobot.AnalogPinner
+	mutex     sync.Mutex
+}
+
+// NewAnalogPinsAdaptor provides the access to analog pins of the board. Usually sysfs system drivers are used.
+// The translator is used to adapt the pin header naming, which is given by user, to the internal file name
+// nomenclature. This varies by each platform.
+func NewAnalogPinsAdaptor(sys *system.Accesser, t analogPinTranslator) *AnalogPinsAdaptor {
+	a := AnalogPinsAdaptor{
+		sys:       sys,
+		translate: t,
+	}
+	return &a
+}
+
+// Connect prepare new connection to analog pins.
+func (a *AnalogPinsAdaptor) Connect() error {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
+	a.pins = make(map[string]gobot.AnalogPinner)
+	return nil
+}
+
+// Finalize closes connection to analog pins
+func (a *AnalogPinsAdaptor) Finalize() error {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
+	a.pins = nil
+	return nil
+}
+
+// AnalogRead returns an analog value from specified pin or identifier, defined by the translation function.
+func (a *AnalogPinsAdaptor) AnalogRead(id string) (int, error) {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
+	pin, err := a.analogPin(id)
+	if err != nil {
+		return 0, err
+	}
+
+	return pin.Read()
+}
+
+// AnalogWrite writes an analog value to the specified pin or identifier, defined by the translation function.
+func (a *AnalogPinsAdaptor) AnalogWrite(id string, val int) error {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
+	pin, err := a.analogPin(id)
+	if err != nil {
+		return err
+	}
+
+	return pin.Write(val)
+}
+
+// analogPin initializes the pin for analog access and returns matched pin for specified identifier.
+func (a *AnalogPinsAdaptor) analogPin(id string) (gobot.AnalogPinner, error) {
+	if a.pins == nil {
+		return nil, fmt.Errorf("not connected for pin %s", id)
+	}
+
+	pin := a.pins[id]
+
+	if pin == nil {
+		path, r, w, bufLen, err := a.translate(id)
+		if err != nil {
+			return nil, err
+		}
+		pin = a.sys.NewAnalogPin(path, r, w, bufLen)
+		a.pins[id] = pin
+	}
+
+	return pin, nil
+}

--- a/platforms/adaptors/analogpinsadaptor_test.go
+++ b/platforms/adaptors/analogpinsadaptor_test.go
@@ -1,0 +1,249 @@
+//nolint:nonamedreturns // ok for tests
+package adaptors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"gobot.io/x/gobot/v2"
+	"gobot.io/x/gobot/v2/system"
+)
+
+const (
+	analogReadPath            = "/sys/bus/iio/devices/iio:device0/in_voltage0_raw"
+	analogWritePath           = "/sys/devices/platform/ff680020.pwm/pwm/pwmchip3/export"
+	analogReadWritePath       = "/sys/devices/platform/ff680020.pwm/pwm/pwmchip3/pwm44/period"
+	analogReadWriteStringPath = "/sys/devices/platform/ff680020.pwm/pwm/pwmchip3/pwm44/polarity"
+)
+
+var analogMockPaths = []string{
+	analogReadPath,
+	analogWritePath,
+	analogReadWritePath,
+	analogReadWriteStringPath,
+}
+
+func initTestAnalogPinsAdaptorWithMockedFilesystem(mockPaths []string) (*AnalogPinsAdaptor, *system.MockFilesystem) {
+	sys := system.NewAccesser()
+	fs := sys.UseMockFilesystem(mockPaths)
+	a := NewAnalogPinsAdaptor(sys, testAnalogPinTranslator)
+	fs.Files[analogReadPath].Contents = "54321"
+	fs.Files[analogWritePath].Contents = "0"
+	fs.Files[analogReadWritePath].Contents = "30000"
+	fs.Files[analogReadWriteStringPath].Contents = "inverted"
+	if err := a.Connect(); err != nil {
+		panic(err)
+	}
+	return a, fs
+}
+
+func testAnalogPinTranslator(id string) (string, bool, bool, uint16, error) {
+	switch id {
+	case "read":
+		return analogReadPath, true, false, 10, nil
+	case "write":
+		return analogWritePath, false, true, 11, nil
+	case "read/write":
+		return analogReadWritePath, true, true, 12, nil
+	case "read/write_string":
+		return analogReadWriteStringPath, true, true, 13, nil
+	}
+
+	return "", false, false, 0, fmt.Errorf("'%s' is not a valid id of a analog pin", id)
+}
+
+func TestAnalogPinsConnect(t *testing.T) {
+	translate := func(id string) (path string, r, w bool, bufLen uint16, err error) { return }
+	a := NewAnalogPinsAdaptor(system.NewAccesser(), translate)
+	assert.Equal(t, (map[string]gobot.AnalogPinner)(nil), a.pins)
+
+	err := a.AnalogWrite("write", 1)
+	require.ErrorContains(t, err, "not connected")
+
+	err = a.Connect()
+	require.NoError(t, err)
+	assert.NotEqual(t, (map[string]gobot.AnalogPinner)(nil), a.pins)
+	assert.Empty(t, a.pins)
+}
+
+func TestAnalogPinsFinalize(t *testing.T) {
+	// arrange
+	sys := system.NewAccesser()
+	fs := sys.UseMockFilesystem(analogMockPaths)
+	a := NewAnalogPinsAdaptor(sys, testAnalogPinTranslator)
+	fs.Files[analogReadPath].Contents = "0"
+	// assert that finalize before connect is working
+	require.NoError(t, a.Finalize())
+	// arrange
+	require.NoError(t, a.Connect())
+	require.NoError(t, a.AnalogWrite("write", 1))
+	assert.Len(t, a.pins, 1)
+	// act
+	err := a.Finalize()
+	// assert
+	require.NoError(t, err)
+	assert.Empty(t, a.pins)
+	// assert that finalize after finalize is working
+	require.NoError(t, a.Finalize())
+	// arrange missing file
+	require.NoError(t, a.Connect())
+	require.NoError(t, a.AnalogWrite("write", 2))
+	delete(fs.Files, analogWritePath)
+	err = a.Finalize()
+	require.NoError(t, err) // because there is currently no access on finalize
+	// arrange write error
+	require.NoError(t, a.Connect())
+	require.NoError(t, a.AnalogWrite("read/write_string", 5))
+	fs.WithWriteError = true
+	err = a.Finalize()
+	require.NoError(t, err) // because there is currently no access on finalize
+}
+
+func TestAnalogPinsReConnect(t *testing.T) {
+	// arrange
+	a, _ := initTestAnalogPinsAdaptorWithMockedFilesystem(analogMockPaths)
+	require.NoError(t, a.AnalogWrite("read/write_string", 1))
+	assert.Len(t, a.pins, 1)
+	require.NoError(t, a.Finalize())
+	// act
+	err := a.Connect()
+	// assert
+	require.NoError(t, err)
+	assert.NotNil(t, a.pins)
+	assert.Empty(t, a.pins)
+}
+
+func TestAnalogWrite(t *testing.T) {
+	tests := map[string]struct {
+		pin              string
+		simulateWriteErr bool
+		simulateReadErr  bool
+		wantValW         string
+		wantValRW        string
+		wantValRWS       string
+		wantErr          string
+	}{
+		"write_w_pin": {
+			pin:        "write",
+			wantValW:   "100",
+			wantValRW:  "30000",
+			wantValRWS: "inverted",
+		},
+		"write_rw_pin": {
+			pin:        "read/write_string",
+			wantValW:   "0",
+			wantValRW:  "30000",
+			wantValRWS: "100",
+		},
+		"ok_on_read_error": {
+			pin:             "read/write_string",
+			simulateReadErr: true,
+			wantValW:        "0",
+			wantValRW:       "30000",
+			wantValRWS:      "100",
+		},
+		"error_write_error": {
+			pin:              "read/write_string",
+			simulateWriteErr: true,
+			wantValW:         "0",
+			wantValRW:        "30000",
+			wantValRWS:       "inverted",
+			wantErr:          "write error",
+		},
+		"error_notexist": {
+			pin:        "notexist",
+			wantValW:   "0",
+			wantValRW:  "30000",
+			wantValRWS: "inverted",
+			wantErr:    "'notexist' is not a valid id of a analog pin",
+		},
+		"error_write_not_allowed": {
+			pin:        "read",
+			wantValW:   "0",
+			wantValRW:  "30000",
+			wantValRWS: "inverted",
+			wantErr:    "the pin '/sys/bus/iio/devices/iio:device0/in_voltage0_raw' is not allowed to write (val: 100)",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			a, fs := initTestAnalogPinsAdaptorWithMockedFilesystem(analogMockPaths)
+			fs.WithWriteError = tc.simulateWriteErr
+			fs.WithReadError = tc.simulateReadErr
+			// act
+			err := a.AnalogWrite(tc.pin, 100)
+			// assert
+			if tc.wantErr != "" {
+				require.EqualError(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, "54321", fs.Files[analogReadPath].Contents)
+			assert.Equal(t, tc.wantValW, fs.Files[analogWritePath].Contents)
+			assert.Equal(t, tc.wantValRW, fs.Files[analogReadWritePath].Contents)
+			assert.Equal(t, tc.wantValRWS, fs.Files[analogReadWriteStringPath].Contents)
+		})
+	}
+}
+
+func TestAnalogRead(t *testing.T) {
+	tests := map[string]struct {
+		pin              string
+		simulateReadErr  bool
+		simulateWriteErr bool
+		wantVal          int
+		wantErr          string
+	}{
+		"read_r_pin": {
+			pin:     "read",
+			wantVal: 54321,
+		},
+		"read_rw_pin": {
+			pin:     "read/write",
+			wantVal: 30000,
+		},
+		"ok_on_write_error": {
+			pin:              "read",
+			simulateWriteErr: true,
+			wantVal:          54321,
+		},
+		"error_read_error": {
+			pin:             "read",
+			simulateReadErr: true,
+			wantErr:         "read error",
+		},
+		"error_notexist": {
+			pin:     "notexist",
+			wantErr: "'notexist' is not a valid id of a analog pin",
+		},
+		"error_invalid_syntax": {
+			pin:     "read/write_string",
+			wantErr: "strconv.Atoi: parsing \"inverted\": invalid syntax",
+		},
+		"error_read_not_allowed": {
+			pin:     "write",
+			wantErr: "the pin '/sys/devices/platform/ff680020.pwm/pwm/pwmchip3/export' is not allowed to read",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			a, fs := initTestAnalogPinsAdaptorWithMockedFilesystem(analogMockPaths)
+			fs.WithReadError = tc.simulateReadErr
+			fs.WithWriteError = tc.simulateWriteErr
+			// act
+			got, err := a.AnalogRead(tc.pin)
+			// assert
+			if tc.wantErr != "" {
+				require.EqualError(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantVal, got)
+		})
+	}
+}

--- a/platforms/beaglebone/black_pins.go
+++ b/platforms/beaglebone/black_pins.go
@@ -49,7 +49,7 @@ var bbbPinMap = map[string]int{
 	"P9_31": 110,
 }
 
-var bbbPwmPinMap = map[string]pwmPinData{
+var bbbPwmPinMap = map[string]pwmPinDefinition{
 	"P8_13": {
 		dir: "/sys/devices/platform/ocp/48304000.epwmss/48304200.pwm/pwm/", dirRegexp: "pwmchip[0-9]+$", channel: 1,
 	},
@@ -73,12 +73,12 @@ var bbbPwmPinMap = map[string]pwmPinData{
 	},
 }
 
-var bbbAnalogPinMap = map[string]string{
-	"P9_39": "in_voltage0_raw",
-	"P9_40": "in_voltage1_raw",
-	"P9_37": "in_voltage2_raw",
-	"P9_38": "in_voltage3_raw",
-	"P9_33": "in_voltage4_raw",
-	"P9_36": "in_voltage5_raw",
-	"P9_35": "in_voltage6_raw",
+var bbbAnalogPinMap = map[string]analogPinDefinition{
+	"P9_39": {path: "/sys/bus/iio/devices/iio:device0/in_voltage0_raw", r: true, w: false, bufLen: 1024},
+	"P9_40": {path: "/sys/bus/iio/devices/iio:device0/in_voltage1_raw", r: true, w: false, bufLen: 1024},
+	"P9_37": {path: "/sys/bus/iio/devices/iio:device0/in_voltage2_raw", r: true, w: false, bufLen: 1024},
+	"P9_38": {path: "/sys/bus/iio/devices/iio:device0/in_voltage3_raw", r: true, w: false, bufLen: 1024},
+	"P9_33": {path: "/sys/bus/iio/devices/iio:device0/in_voltage4_raw", r: true, w: false, bufLen: 1024},
+	"P9_36": {path: "/sys/bus/iio/devices/iio:device0/in_voltage5_raw", r: true, w: false, bufLen: 1024},
+	"P9_35": {path: "/sys/bus/iio/devices/iio:device0/in_voltage6_raw", r: true, w: false, bufLen: 1024},
 }

--- a/platforms/beaglebone/pocketbeagle_pins.go
+++ b/platforms/beaglebone/pocketbeagle_pins.go
@@ -76,7 +76,7 @@ var pocketBeaglePinMap = map[string]int{
 	// P2_36 - AIO7
 }
 
-var pocketBeaglePwmPinMap = map[string]pwmPinData{
+var pocketBeaglePwmPinMap = map[string]pwmPinDefinition{
 	"P1_33": {dir: "/sys/devices/platform/ocp/48300000.epwmss/48300200.pwm/pwm/", dirRegexp: "pwmchip[0-9]+$", channel: 1},
 	"P1_36": {dir: "/sys/devices/platform/ocp/48300000.epwmss/48300200.pwm/pwm/", dirRegexp: "pwmchip[0-9]+$", channel: 0},
 
@@ -84,11 +84,11 @@ var pocketBeaglePwmPinMap = map[string]pwmPinData{
 	"P2_3": {dir: "/sys/devices/platform/ocp/48304000.epwmss/48304200.pwm/pwm/", dirRegexp: "pwmchip[0-9]+$", channel: 1},
 }
 
-var pocketBeagleAnalogPinMap = map[string]string{
-	"P1_19": "in_voltage0_raw",
-	"P1_21": "in_voltage1_raw",
-	"P1_23": "in_voltage2_raw",
-	"P1_25": "in_voltage3_raw",
-	"P1_27": "in_voltage4_raw",
-	"P2_36": "in_voltage7_raw",
+var pocketBeagleAnalogPinMap = map[string]analogPinDefinition{
+	"P1_19": {path: "/sys/bus/iio/devices/iio:device0/in_voltage0_raw", r: true, w: false, bufLen: 1024},
+	"P1_21": {path: "/sys/bus/iio/devices/iio:device0/in_voltage1_raw", r: true, w: false, bufLen: 1024},
+	"P1_23": {path: "/sys/bus/iio/devices/iio:device0/in_voltage2_raw", r: true, w: false, bufLen: 1024},
+	"P1_25": {path: "/sys/bus/iio/devices/iio:device0/in_voltage3_raw", r: true, w: false, bufLen: 1024},
+	"P1_27": {path: "/sys/bus/iio/devices/iio:device0/in_voltage4_raw", r: true, w: false, bufLen: 1024},
+	"P2_36": {path: "/sys/bus/iio/devices/iio:device0/in_voltage7_raw", r: true, w: false, bufLen: 1024},
 }

--- a/system/PWM.md
+++ b/system/PWM.md
@@ -93,3 +93,5 @@ Now we should measure a value of around 2.3V with the meter, which is the differ
 If we have attached an oscilloscope we can play around with the values for period and duty_cycle and see what happen.
 
 ## Links
+
+* <https://docs.kernel.org/driver-api/pwm.html>

--- a/system/analogpin_sysfs.go
+++ b/system/analogpin_sysfs.go
@@ -1,0 +1,37 @@
+package system
+
+import "fmt"
+
+type analogPinSysFs struct {
+	sysfsPath string
+	r, w      bool
+	sfa       *sysfsFileAccess
+}
+
+func newAnalogPinSysfs(sfa *sysfsFileAccess, path string, r, w bool) *analogPinSysFs {
+	p := &analogPinSysFs{
+		sysfsPath: path,
+		sfa:       sfa,
+		r:         r,
+		w:         w,
+	}
+	return p
+}
+
+// Read reads a value from sysf path
+func (p *analogPinSysFs) Read() (int, error) {
+	if !p.r {
+		return 0, fmt.Errorf("the pin '%s' is not allowed to read", p.sysfsPath)
+	}
+
+	return p.sfa.readInteger(p.sysfsPath)
+}
+
+// Write writes a value to sysf path
+func (p *analogPinSysFs) Write(val int) error {
+	if !p.w {
+		return fmt.Errorf("the pin '%s' is not allowed to write (val: %v)", p.sysfsPath, val)
+	}
+
+	return p.sfa.writeInteger(p.sysfsPath, val)
+}

--- a/system/analogpin_sysfs_test.go
+++ b/system/analogpin_sysfs_test.go
@@ -1,0 +1,121 @@
+package system
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_newAnalogPinSysfs(t *testing.T) {
+	// arrange
+	m := &MockFilesystem{}
+	sfa := sysfsFileAccess{fs: m, readBufLen: 2}
+	const path = "/sys/whatever"
+	// act
+	pin := newAnalogPinSysfs(&sfa, path, true, false)
+	// assert
+	assert.Equal(t, path, pin.sysfsPath)
+	assert.Equal(t, &sfa, pin.sfa)
+	assert.True(t, pin.r)
+	assert.False(t, pin.w)
+}
+
+func TestRead(t *testing.T) {
+	const (
+		sysfsPath = "/sys/testread"
+		value     = "32"
+	)
+	tests := map[string]struct {
+		readable bool
+		simErr   bool
+		wantVal  int
+		wantErr  string
+	}{
+		"read_ok": {
+			readable: true,
+			wantVal:  32,
+		},
+		"error_not_readable": {
+			readable: false,
+			wantErr:  "the pin '/sys/testread' is not allowed to read",
+		},
+		"error_on_read": {
+			readable: true,
+			simErr:   true,
+			wantErr:  "read error",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			fs := newMockFilesystem([]string{sysfsPath})
+			sfa := sysfsFileAccess{fs: fs, readBufLen: 2}
+			pin := newAnalogPinSysfs(&sfa, sysfsPath, tc.readable, false)
+			fs.Files[sysfsPath].Contents = value
+			if tc.simErr {
+				fs.Files[sysfsPath].simulateReadError = fmt.Errorf("read error")
+			}
+			// act
+			got, err := pin.Read()
+			// assert
+			if tc.wantErr != "" {
+				require.EqualError(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantVal, got)
+		})
+	}
+}
+
+func TestWrite(t *testing.T) {
+	const (
+		sysfsPath = "/sys/testwrite"
+		oldVal    = "old_value"
+	)
+	tests := map[string]struct {
+		writeable bool
+		simErr    bool
+		wantVal   string
+		wantErr   string
+	}{
+		"write_ok": {
+			writeable: true,
+			wantVal:   "23",
+		},
+		"error_not_writeable": {
+			writeable: false,
+			wantErr:   "the pin '/sys/testwrite' is not allowed to write (val: 23)",
+			wantVal:   oldVal,
+		},
+		"error_on_write": {
+			writeable: true,
+			simErr:    true,
+			wantErr:   "write error",
+			wantVal:   "23", // the mock is implemented in this way
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			fs := newMockFilesystem([]string{sysfsPath})
+			sfa := sysfsFileAccess{fs: fs, readBufLen: 10}
+			pin := newAnalogPinSysfs(&sfa, sysfsPath, false, tc.writeable)
+			fs.Files[sysfsPath].Contents = oldVal
+			if tc.simErr {
+				fs.Files[sysfsPath].simulateWriteError = fmt.Errorf("write error")
+			}
+			// act
+			err := pin.Write(23)
+			// assert
+			if tc.wantErr != "" {
+				require.EqualError(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantVal, fs.Files[sysfsPath].Contents)
+		})
+	}
+}

--- a/system/digitalpin_access.go
+++ b/system/digitalpin_access.go
@@ -8,7 +8,7 @@ import (
 
 // sysfsDitalPinHandler represents the sysfs implementation
 type sysfsDigitalPinAccess struct {
-	fs filesystem
+	sfa *sysfsFileAccess
 }
 
 // gpiodDigitalPinAccess represents the character device implementation
@@ -25,11 +25,11 @@ func (h *sysfsDigitalPinAccess) isSupported() bool {
 func (h *sysfsDigitalPinAccess) createPin(chip string, pin int,
 	o ...func(gobot.DigitalPinOptioner) bool,
 ) gobot.DigitalPinner {
-	return newDigitalPinSysfs(h.fs, strconv.Itoa(pin), o...)
+	return newDigitalPinSysfs(h.sfa, strconv.Itoa(pin), o...)
 }
 
 func (h *sysfsDigitalPinAccess) setFs(fs filesystem) {
-	h.fs = fs
+	h.sfa = &sysfsFileAccess{fs: fs, readBufLen: 2}
 }
 
 func (h *gpiodDigitalPinAccess) isSupported() bool {

--- a/system/digitalpin_sysfs_test.go
+++ b/system/digitalpin_sysfs_test.go
@@ -21,19 +21,21 @@ var (
 
 func initTestDigitalPinSysfsWithMockedFilesystem(mockPaths []string) (*digitalPinSysfs, *MockFilesystem) {
 	fs := newMockFilesystem(mockPaths)
-	pin := newDigitalPinSysfs(fs, "10")
+	sfa := sysfsFileAccess{fs: fs, readBufLen: 2}
+	pin := newDigitalPinSysfs(&sfa, "10")
 	return pin, fs
 }
 
 func Test_newDigitalPinSysfs(t *testing.T) {
 	// arrange
 	m := &MockFilesystem{}
+	sfa := sysfsFileAccess{fs: m, readBufLen: 2}
 	const pinID = "1"
 	// act
-	pin := newDigitalPinSysfs(m, pinID, WithPinOpenDrain())
+	pin := newDigitalPinSysfs(&sfa, pinID, WithPinOpenDrain())
 	// assert
 	assert.Equal(t, pinID, pin.pin)
-	assert.Equal(t, m, pin.fs)
+	assert.Equal(t, &sfa, pin.sfa)
 	assert.Equal(t, "gpio"+pinID, pin.label)
 	assert.Equal(t, "in", pin.direction)
 	assert.Equal(t, 1, pin.drive)
@@ -134,7 +136,7 @@ func TestDigitalPinExportSysfs(t *testing.T) {
 		changeDebouncePeriod  time.Duration
 		changeEdge            int
 		changePollInterval    time.Duration
-		simEbusyOnWrite       int
+		simEbusyOnPath        string
 		wantWrites            int
 		wantExport            string
 		wantUnexport          string
@@ -225,11 +227,11 @@ func TestDigitalPinExportSysfs(t *testing.T) {
 			wantValue:       "0",
 		},
 		"ok_already_exported": {
-			mockPaths:       allMockPaths,
-			wantWrites:      2,
-			wantExport:      "10",
-			wantDirection:   "in",
-			simEbusyOnWrite: 1, // just means "already exported"
+			mockPaths:      allMockPaths,
+			wantWrites:     2,
+			wantExport:     "10",
+			wantDirection:  "in",
+			simEbusyOnPath: exportPath, // just means "already exported"
 		},
 		"error_no_eventhandler_for_polling": { // this only tests the call of function, all other is tested separately
 			mockPaths:          allMockPaths,
@@ -250,11 +252,11 @@ func TestDigitalPinExportSysfs(t *testing.T) {
 			wantErr:      "gpio10/direction: no such file",
 		},
 		"error_write_direction_file": {
-			mockPaths:       allMockPaths,
-			wantWrites:      3,
-			wantUnexport:    "10",
-			simEbusyOnWrite: 2,
-			wantErr:         "device or resource busy",
+			mockPaths:      allMockPaths,
+			wantWrites:     3,
+			wantUnexport:   "10",
+			simEbusyOnPath: dirPath,
+			wantErr:        "device or resource busy",
 		},
 		"error_no_value_file": {
 			mockPaths:    []string{exportPath, dirPath, unexportPath},
@@ -281,7 +283,8 @@ func TestDigitalPinExportSysfs(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// arrange
 			fs := newMockFilesystem(tc.mockPaths)
-			pin := newDigitalPinSysfs(fs, "10")
+			sfa := sysfsFileAccess{fs: fs, readBufLen: 2}
+			pin := newDigitalPinSysfs(&sfa, "10")
 			if tc.changeDirection != "" {
 				pin.direction = tc.changeDirection
 			}
@@ -307,17 +310,9 @@ func TestDigitalPinExportSysfs(t *testing.T) {
 				pin.pollInterval = tc.changePollInterval
 			}
 			// arrange write function
-			oldWriteFunc := writeFile
-			numCallsWrite := 0
-			writeFile = func(f File, data []byte) error {
-				numCallsWrite++
-				require.NoError(t, oldWriteFunc(f, data))
-				if numCallsWrite == tc.simEbusyOnWrite {
-					return &os.PathError{Err: Syscall_EBUSY}
-				}
-				return nil
+			if tc.simEbusyOnPath != "" {
+				fs.Files[tc.simEbusyOnPath].simulateWriteError = &os.PathError{Err: Syscall_EBUSY}
 			}
-			defer func() { writeFile = oldWriteFunc }()
 			// act
 			err := pin.Export()
 			// assert
@@ -333,7 +328,7 @@ func TestDigitalPinExportSysfs(t *testing.T) {
 				assert.Equal(t, tc.wantInverse, fs.Files[inversePath].Contents)
 			}
 			assert.Equal(t, tc.wantUnexport, fs.Files[unexportPath].Contents)
-			assert.Equal(t, tc.wantWrites, numCallsWrite)
+			assert.Equal(t, tc.wantWrites, fs.numCallsWrite)
 		})
 	}
 }
@@ -368,7 +363,8 @@ func TestDigitalPinSysfs(t *testing.T) {
 	data, _ := pin.Read()
 	assert.Equal(t, 1, data)
 
-	pin2 := newDigitalPinSysfs(fs, "30")
+	sfa := sysfsFileAccess{fs: fs, readBufLen: 2}
+	pin2 := newDigitalPinSysfs(&sfa, "30")
 	err = pin2.Write(1)
 	require.ErrorContains(t, err, "pin has not been exported")
 
@@ -376,33 +372,47 @@ func TestDigitalPinSysfs(t *testing.T) {
 	require.ErrorContains(t, err, "pin has not been exported")
 	assert.Equal(t, 0, data)
 
-	writeFile = func(File, []byte) error {
-		return &os.PathError{Err: Syscall_EINVAL}
-	}
-
+	// arrange: unexport general write error, the error is not suppressed
+	fs.Files["/sys/class/gpio/unexport"].simulateWriteError = &os.PathError{Err: errors.New("write error")}
+	// act: unexport
 	err = pin.Unexport()
-	require.NoError(t, err)
-
-	writeFile = func(File, []byte) error {
-		return &os.PathError{Err: errors.New("write error")}
-	}
-
-	err = pin.Unexport()
+	// assert: the error is not suppressed
 	var pathError *os.PathError
 	require.ErrorAs(t, err, &pathError)
 	require.ErrorContains(t, err, "write error")
 }
 
 func TestDigitalPinUnexportErrorSysfs(t *testing.T) {
-	mockPaths := []string{
-		"/sys/class/gpio/unexport",
+	tests := map[string]struct {
+		simulateError error
+		wantErr       string
+	}{
+		"reserved_pin": {
+			// simulation of reserved pin, the internal error is suppressed
+			simulateError: &os.PathError{Err: Syscall_EINVAL},
+			wantErr:       "",
+		},
+		"error_busy": {
+			simulateError: &os.PathError{Err: Syscall_EBUSY},
+			wantErr:       " : device or resource busy",
+		},
 	}
-	pin, _ := initTestDigitalPinSysfsWithMockedFilesystem(mockPaths)
-
-	writeFile = func(File, []byte) error {
-		return &os.PathError{Err: Syscall_EBUSY}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			mockPaths := []string{
+				"/sys/class/gpio/unexport",
+			}
+			pin, fs := initTestDigitalPinSysfsWithMockedFilesystem(mockPaths)
+			fs.Files["/sys/class/gpio/unexport"].simulateWriteError = tc.simulateError
+			// act
+			err := pin.Unexport()
+			// assert
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
-
-	err := pin.Unexport()
-	require.ErrorContains(t, err, " : device or resource busy")
 }

--- a/system/sysfsfile_access.go
+++ b/system/sysfsfile_access.go
@@ -1,0 +1,146 @@
+package system
+
+import (
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type sysfsFileAccess struct {
+	fs         filesystem
+	readBufLen uint16
+}
+
+// Linux sysfs / GPIO specific sysfs docs.
+//
+//	https://www.kernel.org/doc/Documentation/filesystems/sysfs.txt
+//	https://www.kernel.org/doc/Documentation/gpio/sysfs.txt
+//	https://www.kernel.org/doc/Documentation/thermal/sysfs-api.txt
+//	see also PWM.md
+type sysfsFile struct {
+	sfa       sysfsFileAccess
+	file      File
+	sysfsPath string
+}
+
+func (sfa sysfsFileAccess) readInteger(path string) (int, error) {
+	sf, err := sfa.openRead(path)
+	defer func() { _ = sf.close() }()
+	if err != nil {
+		return 0, err
+	}
+
+	return sf.readInteger()
+}
+
+func (sfa sysfsFileAccess) read(path string) ([]byte, error) {
+	sf, err := sfa.openRead(path)
+	defer func() { _ = sf.close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	return sf.read()
+}
+
+func (sfa sysfsFileAccess) writeInteger(path string, val int) error {
+	sf, err := sfa.openWrite(path)
+	defer func() { _ = sf.close() }()
+	if err != nil {
+		return err
+	}
+
+	return sf.writeInteger(val)
+}
+
+func (sfa sysfsFileAccess) write(path string, data []byte) error {
+	sf, err := sfa.openWrite(path)
+	defer func() { _ = sf.close() }()
+	if err != nil {
+		return err
+	}
+
+	return sf.write(data)
+}
+
+func (sfa sysfsFileAccess) openRead(path string) (*sysfsFile, error) {
+	f, err := sfa.fs.openFile(path, os.O_RDONLY, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	return &sysfsFile{sfa: sfa, file: f, sysfsPath: path}, nil
+}
+
+func (sfa sysfsFileAccess) openWrite(path string) (*sysfsFile, error) {
+	f, err := sfa.fs.openFile(path, os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	return &sysfsFile{sfa: sfa, file: f, sysfsPath: path}, nil
+}
+
+func (sfa sysfsFileAccess) openReadWrite(path string) (*sysfsFile, error) {
+	f, err := sfa.fs.openFile(path, os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	return &sysfsFile{sfa: sfa, file: f, sysfsPath: path}, nil
+}
+
+func (sf *sysfsFile) close() error {
+	if sf == nil || sf.file == nil {
+		return nil
+	}
+	return sf.file.Close()
+}
+
+func (sf *sysfsFile) readInteger() (int, error) {
+	buf, err := sf.read()
+	if err != nil {
+		return 0, err
+	}
+
+	if len(buf) == 0 {
+		return 0, nil
+	}
+
+	return strconv.Atoi(strings.Split(string(buf), "\n")[0])
+}
+
+func (sf *sysfsFile) read() ([]byte, error) {
+	// sysfs docs say:
+	// > If userspace seeks back to zero or does a pread(2) with an offset of '0' the [..] method will
+	// > be called again, rearmed, to fill the buffer.
+	// > The buffer will always be PAGE_SIZE bytes in length. On i386, this is 4096.
+
+	// TODO: Examine if seek is needed if full buffer is read from sysfs file.
+
+	buf := make([]byte, sf.sfa.readBufLen)
+	if _, err := sf.file.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	i, err := sf.file.Read(buf)
+	if i == 0 {
+		return []byte{}, err
+	}
+
+	return buf[:i], err
+}
+
+func (sf *sysfsFile) writeInteger(val int) error {
+	return sf.write([]byte(strconv.Itoa(val)))
+}
+
+func (sf *sysfsFile) write(data []byte) error {
+	// sysfs docs say:
+	// > When writing sysfs files, userspace processes should first read the
+	// > entire file, modify the values it wishes to change, then write the
+	// > entire buffer back.
+	// however, this seems outdated/inaccurate (docs are from back in the Kernel BitKeeper days).
+
+	// Write() returns already a non-nil error when n != len(b).
+	_, err := sf.file.Write(data)
+	return err
+}

--- a/system/system_test.go
+++ b/system/system_test.go
@@ -82,7 +82,7 @@ func TestNewAccesser_IsSysfsDigitalPinAccess(t *testing.T) {
 				assert.True(t, got)
 				dpaSys := a.digitalPinAccess.(*sysfsDigitalPinAccess)
 				assert.NotNil(t, dpaSys)
-				assert.Equal(t, a.fs.(*nativeFilesystem), dpaSys.fs)
+				assert.Equal(t, a.fs.(*nativeFilesystem), dpaSys.sfa.fs)
 			} else {
 				assert.False(t, got)
 				dpaGpiod := a.digitalPinAccess.(*gpiodDigitalPinAccess)


### PR DESCRIPTION
## Solved issues and/or description of the change

Introduce a library at system level for sysfs access. The library is used now for the sysfs digitalpin access, pwm pin access, and a new sysfs analog pin system library.

Based on the library - at adaptor level a new generic adaptor was introduced to access e.g. sysfs in a generic way and be able to implement drivers. Beaglebone and Edison are already converted to use the new base adaptor for its AnalogRead() capability.

## Manual test

none

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code
- [x] depends on #1042 

If this is a new driver or adaptor:

- [x] I have checked or build at least my new example (e.g. by run `make examples_check`)