### PR TITLE
test: try to stabilize eventer tests

### DIFF
--- a/drivers/aio/analog_sensor_driver_test.go
+++ b/drivers/aio/analog_sensor_driver_test.go
@@ -193,7 +193,7 @@ func TestAnalogSensor_WithSensorCyclicRead(t *testing.T) {
 	select {
 	case <-semDone:
 	case <-time.After(readTimeout):
-		t.Errorf("AnalogSensor Event \"Data\" was not published")
+		require.Fail(t, "AnalogSensor Event \"Data\" was not published")
 	}
 
 	// arrange: for error to be received
@@ -206,7 +206,7 @@ func TestAnalogSensor_WithSensorCyclicRead(t *testing.T) {
 	select {
 	case <-semDone:
 	case <-time.After(readTimeout):
-		t.Errorf("AnalogSensor Event \"Error\" was not published")
+		require.Fail(t, "AnalogSensor Event \"Error\" was not published")
 	}
 
 	// arrange: for halt message
@@ -224,9 +224,9 @@ func TestAnalogSensor_WithSensorCyclicRead(t *testing.T) {
 	// assert: no event
 	select {
 	case <-semData:
-		t.Errorf("AnalogSensor Event for data should not published")
+		require.Fail(t, "AnalogSensor Event for data should not published")
 	case <-semDone:
-		t.Errorf("AnalogSensor Event for value should not published")
+		require.Fail(t, "AnalogSensor Event for value should not published")
 	case <-time.After(readTimeout):
 	}
 }

--- a/drivers/aio/grove_drivers_test.go
+++ b/drivers/aio/grove_drivers_test.go
@@ -153,7 +153,7 @@ func TestGroveDriverHalt_WithSensorCyclicRead(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 		// note: if a reading is already in progress, it will be finished before halt have an impact
 		if atomic.LoadInt32(&callCount) > lastCallCount+1 {
-			t.Errorf("AnalogRead was called more than once after driver was halted")
+			require.Fail(t, "AnalogRead was called more than once after driver was halted")
 		}
 	}
 }
@@ -188,7 +188,7 @@ func TestGroveDriverWithSensorCyclicReadPublishesError(t *testing.T) {
 		select {
 		case <-sem:
 		case <-time.After(time.Second):
-			t.Errorf("%s Event \"Error\" was not published", groveGetType(driver))
+			require.Fail(t, "%s Event \"Error\" was not published", groveGetType(driver))
 		}
 
 		// Cleanup

--- a/drivers/aio/grove_temperature_sensor_driver_test.go
+++ b/drivers/aio/grove_temperature_sensor_driver_test.go
@@ -116,7 +116,7 @@ func TestGroveTemperatureSensor_publishesTemperatureInCelsius(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(1 * time.Second):
-		t.Errorf("Grove Temperature Sensor Event \"Value\" was not published")
+		require.Fail(t, "Grove Temperature Sensor Event \"Value\" was not published")
 	}
 
 	assert.InDelta(t, 31.61532462352477, d.Temperature(), 0.0)

--- a/drivers/aio/temperature_sensor_driver_test.go
+++ b/drivers/aio/temperature_sensor_driver_test.go
@@ -149,7 +149,7 @@ func TestTemperatureSensorWithSensorCyclicRead_PublishesTemperatureInCelsius(t *
 	select {
 	case <-sem:
 	case <-time.After(1 * time.Second):
-		t.Errorf(" Temperature Sensor Event \"Data\" was not published")
+		require.Fail(t, " Temperature Sensor Event \"Data\" was not published")
 	}
 
 	assert.InDelta(t, 31.61532462352477, d.Value(), 0.0)
@@ -177,7 +177,7 @@ func TestTemperatureSensorWithSensorCyclicRead_PublishesError(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(1 * time.Second):
-		t.Errorf(" Temperature Sensor Event \"Error\" was not published")
+		require.Fail(t, " Temperature Sensor Event \"Error\" was not published")
 	}
 }
 
@@ -195,7 +195,7 @@ func TestTemperatureSensorHalt_WithSensorCyclicRead(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(100 * time.Millisecond):
-		t.Errorf("Temperature Sensor was not halted")
+		require.Fail(t, "Temperature Sensor was not halted")
 	}
 }
 

--- a/drivers/aio/thermalzone_driver_test.go
+++ b/drivers/aio/thermalzone_driver_test.go
@@ -84,7 +84,7 @@ func TestThermalZoneWithSensorCyclicRead_PublishesTemperatureInFahrenheit(t *tes
 	select {
 	case <-sem:
 	case <-time.After(1 * time.Second):
-		t.Errorf(" Temperature Sensor Event \"Data\" was not published")
+		require.Fail(t, " Temperature Sensor Event \"Data\" was not published")
 	}
 
 	assert.InDelta(t, -148.0, d.Value(), 0.0)

--- a/drivers/ble/microbit/accelerometer_driver_test.go
+++ b/drivers/ble/microbit/accelerometer_driver_test.go
@@ -61,6 +61,6 @@ func TestAccelerometerReadData(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(100 * time.Millisecond):
-		t.Errorf("Microbit Event \"Accelerometer\" was not published")
+		require.Fail(t, "Microbit Event \"Accelerometer\" was not published")
 	}
 }

--- a/drivers/ble/microbit/button_driver_test.go
+++ b/drivers/ble/microbit/button_driver_test.go
@@ -56,6 +56,6 @@ func TestButtonReadData(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(100 * time.Millisecond):
-		t.Errorf("Microbit Event \"ButtonB\" was not published")
+		require.Fail(t, "Microbit Event \"ButtonB\" was not published")
 	}
 }

--- a/drivers/ble/microbit/magnetometer_driver_test.go
+++ b/drivers/ble/microbit/magnetometer_driver_test.go
@@ -64,6 +64,6 @@ func TestMagnetometerReadData(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(100 * time.Millisecond):
-		t.Errorf("Microbit Event \"Magnetometer\" was not published")
+		require.Fail(t, "Microbit Event \"Magnetometer\" was not published")
 	}
 }

--- a/drivers/ble/microbit/temperature_driver_test.go
+++ b/drivers/ble/microbit/temperature_driver_test.go
@@ -61,6 +61,6 @@ func TestTemperatureReadData(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(100 * time.Millisecond):
-		t.Errorf("Microbit Event \"Temperature\" was not published")
+		require.Fail(t, "Microbit Event \"Temperature\" was not published")
 	}
 }

--- a/drivers/common/spherocommon/spherocommon_test.go
+++ b/drivers/common/spherocommon/spherocommon_test.go
@@ -1,6 +1,10 @@
 package spherocommon
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestCalculateChecksum(t *testing.T) {
 	tests := []struct {
@@ -14,7 +18,7 @@ func TestCalculateChecksum(t *testing.T) {
 	for _, tt := range tests {
 		actual := CalculateChecksum(tt.data)
 		if actual != tt.checksum {
-			t.Errorf("Expected %x, got %x for data %x.", tt.checksum, actual, tt.data)
+			require.Fail(t, "Expected %x, got %x for data %x.", tt.checksum, actual, tt.data)
 		}
 	}
 }

--- a/drivers/gpio/grove_drivers_test.go
+++ b/drivers/gpio/grove_drivers_test.go
@@ -71,7 +71,7 @@ func TestDigitalDriverHalt(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 		// note: if a reading is already in progress, it will be finished before halt have an impact
 		if atomic.LoadInt32(&callCount) > lastCallCount+1 {
-			t.Errorf("DigitalRead was called more than once after driver was halted")
+			require.Fail(t, "DigitalRead was called more than once after driver was halted")
 		}
 	}
 }
@@ -105,7 +105,7 @@ func TestDriverPublishesError(t *testing.T) {
 		select {
 		case <-sem:
 		case <-time.After(time.Second):
-			t.Errorf("%s Event \"Error\" was not published", getType(driver))
+			require.Fail(t, "%s Event \"Error\" was not published", getType(driver))
 		}
 
 		// Cleanup

--- a/drivers/gpio/pir_motion_driver_test.go
+++ b/drivers/gpio/pir_motion_driver_test.go
@@ -104,7 +104,7 @@ func TestPIRMotionStart(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(motionTestDelay * time.Millisecond):
-		t.Errorf("PIRMotionDriver Event \"MotionDetected\" was not published")
+		require.Fail(t, "PIRMotionDriver Event \"MotionDetected\" was not published")
 	}
 
 	_ = d.Once(MotionStopped, func(data interface{}) {
@@ -116,7 +116,7 @@ func TestPIRMotionStart(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(motionTestDelay * time.Millisecond):
-		t.Errorf("PIRMotionDriver Event \"MotionStopped\" was not published")
+		require.Fail(t, "PIRMotionDriver Event \"MotionStopped\" was not published")
 	}
 
 	_ = d.Once(Error, func(data interface{}) {
@@ -126,7 +126,7 @@ func TestPIRMotionStart(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(motionTestDelay * time.Millisecond):
-		t.Errorf("PIRMotionDriver Event \"Error\" was not published")
+		require.Fail(t, "PIRMotionDriver Event \"Error\" was not published")
 	}
 
 	_ = d.Once(MotionDetected, func(data interface{}) {
@@ -138,7 +138,7 @@ func TestPIRMotionStart(t *testing.T) {
 
 	select {
 	case <-sem:
-		t.Errorf("PIRMotion Event \"MotionDetected\" should not published")
+		require.Fail(t, "PIRMotion Event \"MotionDetected\" should not published")
 	case <-time.After(motionTestDelay * time.Millisecond):
 	}
 }

--- a/drivers/i2c/adafruit1109_driver_test.go
+++ b/drivers/i2c/adafruit1109_driver_test.go
@@ -23,7 +23,7 @@ func TestNewAdafruit1109Driver(t *testing.T) {
 	var di interface{} = NewAdafruit1109Driver(newI2cTestAdaptor())
 	d, ok := di.(*Adafruit1109Driver)
 	if !ok {
-		t.Errorf("NewAdafruit1109Driver() should have returned a *Adafruit1109Driver")
+		require.Fail(t, "NewAdafruit1109Driver() should have returned a *Adafruit1109Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.NotNil(t, d.Connection())

--- a/drivers/i2c/ads1x15_driver_1015_test.go
+++ b/drivers/i2c/ads1x15_driver_1015_test.go
@@ -22,7 +22,7 @@ func TestNewADS1015Driver(t *testing.T) {
 	var di interface{} = NewADS1015Driver(newI2cTestAdaptor())
 	d, ok := di.(*ADS1x15Driver)
 	if !ok {
-		t.Errorf("NewADS1015Driver() should have returned a *ADS1x15Driver")
+		require.Fail(t, "NewADS1015Driver() should have returned a *ADS1x15Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "ADS1015"))

--- a/drivers/i2c/ads1x15_driver_1115_test.go
+++ b/drivers/i2c/ads1x15_driver_1115_test.go
@@ -22,7 +22,7 @@ func TestNewADS1115Driver(t *testing.T) {
 	var di interface{} = NewADS1115Driver(newI2cTestAdaptor())
 	d, ok := di.(*ADS1x15Driver)
 	if !ok {
-		t.Errorf("NewADS1115Driver() should have returned a *ADS1x15Driver")
+		require.Fail(t, "NewADS1115Driver() should have returned a *ADS1x15Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "ADS1115"))

--- a/drivers/i2c/adxl345_driver_test.go
+++ b/drivers/i2c/adxl345_driver_test.go
@@ -25,7 +25,7 @@ func TestNewADXL345Driver(t *testing.T) {
 	var di interface{} = NewADXL345Driver(newI2cTestAdaptor())
 	d, ok := di.(*ADXL345Driver)
 	if !ok {
-		t.Errorf("NewADXL345Driver() should have returned a *ADXL345Driver")
+		require.Fail(t, "NewADXL345Driver() should have returned a *ADXL345Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "ADXL345"))

--- a/drivers/i2c/bh1750_driver_test.go
+++ b/drivers/i2c/bh1750_driver_test.go
@@ -29,7 +29,7 @@ func TestNewBH1750Driver(t *testing.T) {
 	var di interface{} = NewBH1750Driver(newI2cTestAdaptor())
 	d, ok := di.(*BH1750Driver)
 	if !ok {
-		t.Errorf("NewBH1750Driver() should have returned a *BH1750Driver")
+		require.Fail(t, "NewBH1750Driver() should have returned a *BH1750Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "BH1750"))

--- a/drivers/i2c/blinkm_driver_test.go
+++ b/drivers/i2c/blinkm_driver_test.go
@@ -29,7 +29,7 @@ func TestNewBlinkMDriver(t *testing.T) {
 	var di interface{} = NewBlinkMDriver(newI2cTestAdaptor())
 	d, ok := di.(*BlinkMDriver)
 	if !ok {
-		t.Errorf("NewBlinkMDriver() should have returned a *BlinkMDriver")
+		require.Fail(t, "NewBlinkMDriver() should have returned a *BlinkMDriver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "BlinkM"))

--- a/drivers/i2c/bme280_driver_test.go
+++ b/drivers/i2c/bme280_driver_test.go
@@ -25,7 +25,7 @@ func TestNewBME280Driver(t *testing.T) {
 	var di interface{} = NewBME280Driver(newI2cTestAdaptor())
 	d, ok := di.(*BME280Driver)
 	if !ok {
-		t.Errorf("NewBME280Driver() should have returned a *BME280Driver")
+		require.Fail(t, "NewBME280Driver() should have returned a *BME280Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "BMP280"))

--- a/drivers/i2c/bmp180_driver_test.go
+++ b/drivers/i2c/bmp180_driver_test.go
@@ -28,7 +28,7 @@ func TestNewBMP180Driver(t *testing.T) {
 	var di interface{} = NewBMP180Driver(newI2cTestAdaptor())
 	d, ok := di.(*BMP180Driver)
 	if !ok {
-		t.Errorf("NewBMP180Driver() should have returned a *BMP180Driver")
+		require.Fail(t, "NewBMP180Driver() should have returned a *BMP180Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "BMP180"))

--- a/drivers/i2c/bmp280_driver_test.go
+++ b/drivers/i2c/bmp280_driver_test.go
@@ -25,7 +25,7 @@ func TestNewBMP280Driver(t *testing.T) {
 	var di interface{} = NewBMP280Driver(newI2cTestAdaptor())
 	d, ok := di.(*BMP280Driver)
 	if !ok {
-		t.Errorf("NewBMP280Driver() should have returned a *BMP280Driver")
+		require.Fail(t, "NewBMP280Driver() should have returned a *BMP280Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "BMP280"))

--- a/drivers/i2c/bmp388_driver_test.go
+++ b/drivers/i2c/bmp388_driver_test.go
@@ -44,7 +44,7 @@ func TestNewBMP388Driver(t *testing.T) {
 	var di interface{} = NewBMP388Driver(newI2cTestAdaptor())
 	d, ok := di.(*BMP388Driver)
 	if !ok {
-		t.Errorf("NewBMP388Driver() should have returned a *BMP388Driver")
+		require.Fail(t, "NewBMP388Driver() should have returned a *BMP388Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "BMP388"))

--- a/drivers/i2c/ccs811_driver_test.go
+++ b/drivers/i2c/ccs811_driver_test.go
@@ -24,7 +24,7 @@ func TestNewCCS811Driver(t *testing.T) {
 	var di interface{} = NewCCS811Driver(newI2cTestAdaptor())
 	d, ok := di.(*CCS811Driver)
 	if !ok {
-		t.Errorf("NewCCS811Driver() should have returned a *CCS811Driver")
+		require.Fail(t, "NewCCS811Driver() should have returned a *CCS811Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "CCS811"))

--- a/drivers/i2c/drv2605l_driver_test.go
+++ b/drivers/i2c/drv2605l_driver_test.go
@@ -37,7 +37,7 @@ func TestNewDRV2605LDriver(t *testing.T) {
 	var di interface{} = NewDRV2605LDriver(newI2cTestAdaptor())
 	d, ok := di.(*DRV2605LDriver)
 	if !ok {
-		t.Errorf("NewDRV2605LDriver() should have returned a *DRV2605LDriver")
+		require.Fail(t, "NewDRV2605LDriver() should have returned a *DRV2605LDriver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "DRV2605L"))

--- a/drivers/i2c/generic_driver_test.go
+++ b/drivers/i2c/generic_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"gobot.io/x/gobot/v2"
 )
@@ -19,7 +20,7 @@ func TestNewGenericDriver(t *testing.T) {
 	// assert
 	d, ok := di.(*GenericDriver)
 	if !ok {
-		t.Errorf("NewGenericDriver() should have returned a *GenericDriver")
+		require.Fail(t, "NewGenericDriver() should have returned a *GenericDriver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "GenericI2C"))

--- a/drivers/i2c/grovepi_driver_test.go
+++ b/drivers/i2c/grovepi_driver_test.go
@@ -42,7 +42,7 @@ func TestNewGrovePiDriver(t *testing.T) {
 	var di interface{} = NewGrovePiDriver(newI2cTestAdaptor())
 	d, ok := di.(*GrovePiDriver)
 	if !ok {
-		t.Errorf("NewGrovePiDriver() should have returned a *GrovePiDriver")
+		require.Fail(t, "NewGrovePiDriver() should have returned a *GrovePiDriver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "GrovePi"))
@@ -165,7 +165,7 @@ func TestGrovePiSomeRead(t *testing.T) {
 			case strings.Contains(name, "DHTRead"):
 				gotF1, gotF2, err = g.DHTRead(strconv.Itoa(tc.usedPin), 1, 2)
 			default:
-				t.Errorf("unknown command %s", name)
+				require.Fail(t, "unknown command %s", name)
 				return
 			}
 			// assert
@@ -218,7 +218,7 @@ func TestGrovePiSomeWrite(t *testing.T) {
 			case "AnalogWrite":
 				err = g.AnalogWrite(strconv.Itoa(tc.usedPin), tc.usedValue)
 			default:
-				t.Errorf("unknown command %s", name)
+				require.Fail(t, "unknown command %s", name)
 				return
 			}
 			// assert

--- a/drivers/i2c/hmc5883l_driver_test.go
+++ b/drivers/i2c/hmc5883l_driver_test.go
@@ -23,7 +23,7 @@ func TestNewHMC5883LDriver(t *testing.T) {
 	var di interface{} = NewHMC5883LDriver(newI2cTestAdaptor())
 	d, ok := di.(*HMC5883LDriver)
 	if !ok {
-		t.Errorf("NewHMC5883LDriver() should have returned a *HMC5883LDriver")
+		require.Fail(t, "NewHMC5883LDriver() should have returned a *HMC5883LDriver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.name, "HMC5883L"))

--- a/drivers/i2c/hmc6352_driver_test.go
+++ b/drivers/i2c/hmc6352_driver_test.go
@@ -28,7 +28,7 @@ func TestNewHMC6352Driver(t *testing.T) {
 	var di interface{} = NewHMC6352Driver(newI2cTestAdaptor())
 	d, ok := di.(*HMC6352Driver)
 	if !ok {
-		t.Errorf("NewHMC6352Driver() should have returned a *HMC6352Driver")
+		require.Fail(t, "NewHMC6352Driver() should have returned a *HMC6352Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "HMC6352"))

--- a/drivers/i2c/i2c_config_test.go
+++ b/drivers/i2c/i2c_config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewConfig(t *testing.T) {
@@ -13,7 +14,7 @@ func TestNewConfig(t *testing.T) {
 	// assert
 	c, ok := ci.(*i2cConfig)
 	if !ok {
-		t.Errorf("NewConfig() should have returned a *i2cConfig")
+		require.Fail(t, "NewConfig() should have returned a *i2cConfig")
 	}
 	assert.Equal(t, BusNotInitialized, c.bus)
 	assert.Equal(t, AddressNotInitialized, c.address)

--- a/drivers/i2c/i2c_driver_test.go
+++ b/drivers/i2c/i2c_driver_test.go
@@ -30,7 +30,7 @@ func TestNewDriver(t *testing.T) {
 	// assert
 	d, ok := di.(*Driver)
 	if !ok {
-		t.Errorf("NewDriver() should have returned a *Driver")
+		require.Fail(t, "NewDriver() should have returned a *Driver")
 	}
 	assert.Contains(t, d.name, "I2C_BASIC")
 	assert.Equal(t, 0x15, d.defaultAddress)

--- a/drivers/i2c/jhd1313m1_driver_test.go
+++ b/drivers/i2c/jhd1313m1_driver_test.go
@@ -31,7 +31,7 @@ func TestNewJHD1313M1Driver(t *testing.T) {
 	var mpl interface{} = NewJHD1313M1Driver(newI2cTestAdaptor())
 	_, ok := mpl.(*JHD1313M1Driver)
 	if !ok {
-		t.Errorf("NewJHD1313M1Driver() should have returned a *JHD1313M1Driver")
+		require.Fail(t, "NewJHD1313M1Driver() should have returned a *JHD1313M1Driver")
 	}
 }
 

--- a/drivers/i2c/l3gd20h_driver_test.go
+++ b/drivers/i2c/l3gd20h_driver_test.go
@@ -33,7 +33,7 @@ func TestNewL3GD20HDriver(t *testing.T) {
 	var di interface{} = NewL3GD20HDriver(newI2cTestAdaptor())
 	d, ok := di.(*L3GD20HDriver)
 	if !ok {
-		t.Errorf("NewL3GD20HDriver() should have returned a *L3GD20HDriver")
+		require.Fail(t, "NewL3GD20HDriver() should have returned a *L3GD20HDriver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "L3GD20H"))

--- a/drivers/i2c/lidarlite_driver_test.go
+++ b/drivers/i2c/lidarlite_driver_test.go
@@ -34,7 +34,7 @@ func TestNewLIDARLiteDriver(t *testing.T) {
 	var di interface{} = NewLIDARLiteDriver(newI2cTestAdaptor())
 	d, ok := di.(*LIDARLiteDriver)
 	if !ok {
-		t.Errorf("NewLIDARLiteDriver() should have returned a *LIDARLiteDriver")
+		require.Fail(t, "NewLIDARLiteDriver() should have returned a *LIDARLiteDriver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "LIDARLite"))

--- a/drivers/i2c/mcp23017_driver_test.go
+++ b/drivers/i2c/mcp23017_driver_test.go
@@ -46,7 +46,7 @@ func TestNewMCP23017Driver(t *testing.T) {
 	var di interface{} = NewMCP23017Driver(newI2cTestAdaptor())
 	d, ok := di.(*MCP23017Driver)
 	if !ok {
-		t.Errorf("NewMCP23017Driver() should have returned a *MCP23017Driver")
+		require.Fail(t, "NewMCP23017Driver() should have returned a *MCP23017Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "MCP23017"))

--- a/drivers/i2c/mma7660_driver_test.go
+++ b/drivers/i2c/mma7660_driver_test.go
@@ -29,7 +29,7 @@ func TestNewMMA7660Driver(t *testing.T) {
 	var di interface{} = NewMMA7660Driver(newI2cTestAdaptor())
 	d, ok := di.(*MMA7660Driver)
 	if !ok {
-		t.Errorf("NewMMA7660Driver() should have returned a *MMA7660Driver")
+		require.Fail(t, "NewMMA7660Driver() should have returned a *MMA7660Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "MMA7660"))

--- a/drivers/i2c/mpl115a2_driver_test.go
+++ b/drivers/i2c/mpl115a2_driver_test.go
@@ -24,7 +24,7 @@ func TestNewMPL115A2Driver(t *testing.T) {
 	var di interface{} = NewMPL115A2Driver(newI2cTestAdaptor())
 	d, ok := di.(*MPL115A2Driver)
 	if !ok {
-		t.Errorf("NewMPL115A2Driver() should have returned a *MPL115A2Driver")
+		require.Fail(t, "NewMPL115A2Driver() should have returned a *MPL115A2Driver")
 	}
 	assert.NotNil(t, d.Connection())
 	assert.True(t, strings.HasPrefix(d.Name(), "MPL115A2"))

--- a/drivers/i2c/mpu6050_driver_test.go
+++ b/drivers/i2c/mpu6050_driver_test.go
@@ -28,7 +28,7 @@ func TestNewMPU6050Driver(t *testing.T) {
 	var di interface{} = NewMPU6050Driver(newI2cTestAdaptor())
 	d, ok := di.(*MPU6050Driver)
 	if !ok {
-		t.Errorf("NewMPU6050Driver() should have returned a *MPU6050Driver")
+		require.Fail(t, "NewMPU6050Driver() should have returned a *MPU6050Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.name, "MPU6050"))

--- a/drivers/i2c/pca9501_driver_test.go
+++ b/drivers/i2c/pca9501_driver_test.go
@@ -48,7 +48,7 @@ func TestNewPCA9501Driver(t *testing.T) {
 	// assert
 	d, ok := di.(*PCA9501Driver)
 	if !ok {
-		t.Errorf("NewPCA9501Driver() should have returned a *PCA9501Driver")
+		require.Fail(t, "NewPCA9501Driver() should have returned a *PCA9501Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "PCA9501"))

--- a/drivers/i2c/pca953x_driver_test.go
+++ b/drivers/i2c/pca953x_driver_test.go
@@ -29,7 +29,7 @@ func TestNewPCA953xDriver(t *testing.T) {
 	// assert
 	d, ok := di.(*PCA953xDriver)
 	if !ok {
-		t.Errorf("NewPCA953xDriver() should have returned a *PCA953xDriver")
+		require.Fail(t, "NewPCA953xDriver() should have returned a *PCA953xDriver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "PCA953x"))

--- a/drivers/i2c/pcf8583_driver_test.go
+++ b/drivers/i2c/pcf8583_driver_test.go
@@ -27,7 +27,7 @@ func TestNewPCF8583Driver(t *testing.T) {
 	var di interface{} = NewPCF8583Driver(newI2cTestAdaptor())
 	d, ok := di.(*PCF8583Driver)
 	if !ok {
-		t.Errorf("NewPCF8583Driver() should have returned a *PCF8583Driver")
+		require.Fail(t, "NewPCF8583Driver() should have returned a *PCF8583Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.name, "PCF8583"))

--- a/drivers/i2c/pcf8591_driver_test.go
+++ b/drivers/i2c/pcf8591_driver_test.go
@@ -28,7 +28,7 @@ func TestNewPCF8591Driver(t *testing.T) {
 	var di interface{} = NewPCF8591Driver(newI2cTestAdaptor())
 	d, ok := di.(*PCF8591Driver)
 	if !ok {
-		t.Errorf("NewPCF8591Driver() should have returned a *PCF8591Driver")
+		require.Fail(t, "NewPCF8591Driver() should have returned a *PCF8591Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "PCF8591"))

--- a/drivers/i2c/sht2x_driver_test.go
+++ b/drivers/i2c/sht2x_driver_test.go
@@ -28,7 +28,7 @@ func TestNewSHT2xDriver(t *testing.T) {
 	var di interface{} = NewSHT2xDriver(newI2cTestAdaptor())
 	d, ok := di.(*SHT2xDriver)
 	if !ok {
-		t.Errorf("NewSHT2xDriver() should have returned a *SHT2xDriver")
+		require.Fail(t, "NewSHT2xDriver() should have returned a *SHT2xDriver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "SHT2x"))

--- a/drivers/i2c/sht3x_driver_test.go
+++ b/drivers/i2c/sht3x_driver_test.go
@@ -28,7 +28,7 @@ func TestNewSHT3xDriver(t *testing.T) {
 	var di interface{} = NewSHT3xDriver(newI2cTestAdaptor())
 	d, ok := di.(*SHT3xDriver)
 	if !ok {
-		t.Errorf("NewSHT3xDriver() should have returned a *SHT3xDriver")
+		require.Fail(t, "NewSHT3xDriver() should have returned a *SHT3xDriver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "SHT3x"))

--- a/drivers/i2c/ssd1306_driver_test.go
+++ b/drivers/i2c/ssd1306_driver_test.go
@@ -35,7 +35,7 @@ func TestNewSSD1306Driver(t *testing.T) {
 	var di interface{} = NewSSD1306Driver(newI2cTestAdaptor())
 	d, ok := di.(*SSD1306Driver)
 	if !ok {
-		t.Errorf("new should have returned a *SSD1306Driver")
+		require.Fail(t, "new should have returned a *SSD1306Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "SSD1306"))
@@ -271,11 +271,11 @@ func TestDisplayBuffer(t *testing.T) {
 	display := NewDisplayBuffer(width, height, 8)
 
 	if display.Size() != size {
-		t.Errorf("invalid Size() (%d, expected %d)",
+		require.Fail(t, "invalid Size() (%d, expected %d)",
 			display.Size(), size)
 	}
 	if len(display.buffer) != size {
-		t.Errorf("allocated buffer size invalid (%d, expected %d)",
+		require.Fail(t, "allocated buffer size invalid (%d, expected %d)",
 			len(display.buffer), size)
 	}
 

--- a/drivers/i2c/th02_driver_test.go
+++ b/drivers/i2c/th02_driver_test.go
@@ -29,7 +29,7 @@ func TestNewTH02Driver(t *testing.T) {
 	var di interface{} = NewTH02Driver(newI2cTestAdaptor())
 	d, ok := di.(*TH02Driver)
 	if !ok {
-		t.Errorf("NewTH02Driver() should have returned a *NewTH02Driver")
+		require.Fail(t, "NewTH02Driver() should have returned a *NewTH02Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "TH02"))
@@ -56,7 +56,7 @@ func TestTH02SetAccuracy(t *testing.T) {
 	}
 
 	if acc := b.Accuracy(); acc != TH02LowAccuracy {
-		t.Errorf("Accuracy() didn't return what was expected")
+		require.Fail(t, "Accuracy() didn't return what was expected")
 	}
 }
 

--- a/drivers/i2c/tsl2561_driver_test.go
+++ b/drivers/i2c/tsl2561_driver_test.go
@@ -39,7 +39,7 @@ func TestNewTSL2561Driver(t *testing.T) {
 	var di interface{} = NewTSL2561Driver(newI2cTestAdaptor())
 	d, ok := di.(*TSL2561Driver)
 	if !ok {
-		t.Errorf("NewTSL2561Driver() should have returned a *TSL2561Driver")
+		require.Fail(t, "NewTSL2561Driver() should have returned a *TSL2561Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "TSL2561"))

--- a/drivers/i2c/wiichuck_driver_test.go
+++ b/drivers/i2c/wiichuck_driver_test.go
@@ -27,7 +27,7 @@ func TestNewWiichuckDriver(t *testing.T) {
 	var di interface{} = NewWiichuckDriver(newI2cTestAdaptor())
 	d, ok := di.(*WiichuckDriver)
 	if !ok {
-		t.Errorf("NewWiichuckDriver() should have returned a *WiichuckDriver")
+		require.Fail(t, "NewWiichuckDriver() should have returned a *WiichuckDriver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "Wiichuck"))
@@ -63,7 +63,7 @@ func TestWiichuckDriverStart(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(100 * time.Millisecond):
-		t.Errorf("origin not read correctly")
+		require.Fail(t, "origin not read correctly")
 	}
 }
 
@@ -118,7 +118,7 @@ func TestWiichuckDriverCButton(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(10 * time.Second):
-		t.Errorf("Did not receive 'C' event")
+		require.Fail(t, "Did not receive 'C' event")
 	}
 }
 
@@ -141,7 +141,7 @@ func TestWiichuckDriverZButton(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(10 * time.Second):
-		t.Errorf("Did not receive 'Z' event")
+		require.Fail(t, "Did not receive 'Z' event")
 	}
 }
 
@@ -169,7 +169,7 @@ func TestWiichuckDriverUpdateJoystick(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(10 * time.Second):
-		t.Errorf("Did not receive 'Joystick' event")
+		require.Fail(t, "Did not receive 'Joystick' event")
 	}
 }
 

--- a/drivers/serial/neurosky/mindwave_driver_test.go
+++ b/drivers/serial/neurosky/mindwave_driver_test.go
@@ -56,7 +56,7 @@ func TestNeuroskyDriverStart(t *testing.T) {
 	case <-sem:
 	case <-time.After(100 * time.Millisecond):
 		{
-			t.Errorf("error was not emitted")
+			require.Fail(t, "error was not emitted")
 		}
 
 	}
@@ -84,7 +84,7 @@ func TestNeuroskyDriverParse(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(100 * time.Millisecond):
-		t.Errorf("Event \"extended\" was not published")
+		require.Fail(t, "Event \"extended\" was not published")
 	}
 
 	// mindWaveCodeSignalQuality

--- a/drivers/spi/apa102_test.go
+++ b/drivers/spi/apa102_test.go
@@ -28,7 +28,7 @@ func TestNewAPA102Driver(t *testing.T) {
 	var di interface{} = NewAPA102Driver(newSpiTestAdaptor(), 10, 31)
 	d, ok := di.(*APA102Driver)
 	if !ok {
-		t.Errorf("NewAPA102Driver() should have returned a *APA102Driver")
+		require.Fail(t, "NewAPA102Driver() should have returned a *APA102Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "APA102"))

--- a/drivers/spi/mcp3002_test.go
+++ b/drivers/spi/mcp3002_test.go
@@ -32,7 +32,7 @@ func TestNewMCP3002Driver(t *testing.T) {
 	var di interface{} = NewMCP3002Driver(newSpiTestAdaptor())
 	d, ok := di.(*MCP3002Driver)
 	if !ok {
-		t.Errorf("NewMCP3002Driver() should have returned a *MCP3002Driver")
+		require.Fail(t, "NewMCP3002Driver() should have returned a *MCP3002Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "MCP3002"))

--- a/drivers/spi/mcp3004_test.go
+++ b/drivers/spi/mcp3004_test.go
@@ -32,7 +32,7 @@ func TestNewMCP3004Driver(t *testing.T) {
 	var di interface{} = NewMCP3004Driver(newSpiTestAdaptor())
 	d, ok := di.(*MCP3004Driver)
 	if !ok {
-		t.Errorf("NewMCP3004Driver() should have returned a *MCP3004Driver")
+		require.Fail(t, "NewMCP3004Driver() should have returned a *MCP3004Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "MCP3004"))

--- a/drivers/spi/mcp3008_test.go
+++ b/drivers/spi/mcp3008_test.go
@@ -32,7 +32,7 @@ func TestNewMCP3008Driver(t *testing.T) {
 	var di interface{} = NewMCP3008Driver(newSpiTestAdaptor())
 	d, ok := di.(*MCP3008Driver)
 	if !ok {
-		t.Errorf("NewMCP3008Driver() should have returned a *MCP3008Driver")
+		require.Fail(t, "NewMCP3008Driver() should have returned a *MCP3008Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "MCP3008"))

--- a/drivers/spi/mcp3202_test.go
+++ b/drivers/spi/mcp3202_test.go
@@ -32,7 +32,7 @@ func TestNewMCP3202Driver(t *testing.T) {
 	var di interface{} = NewMCP3202Driver(newSpiTestAdaptor())
 	d, ok := di.(*MCP3202Driver)
 	if !ok {
-		t.Errorf("NewMCP3202Driver() should have returned a *MCP3202Driver")
+		require.Fail(t, "NewMCP3202Driver() should have returned a *MCP3202Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "MCP3202"))

--- a/drivers/spi/mcp3204_test.go
+++ b/drivers/spi/mcp3204_test.go
@@ -32,7 +32,7 @@ func TestNewMCP3204Driver(t *testing.T) {
 	var di interface{} = NewMCP3204Driver(newSpiTestAdaptor())
 	d, ok := di.(*MCP3204Driver)
 	if !ok {
-		t.Errorf("NewMCP3204Driver() should have returned a *MCP3204Driver")
+		require.Fail(t, "NewMCP3204Driver() should have returned a *MCP3204Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "MCP3204"))

--- a/drivers/spi/mcp3208_test.go
+++ b/drivers/spi/mcp3208_test.go
@@ -32,7 +32,7 @@ func TestNewMCP3208Driver(t *testing.T) {
 	var di interface{} = NewMCP3208Driver(newSpiTestAdaptor())
 	d, ok := di.(*MCP3208Driver)
 	if !ok {
-		t.Errorf("NewMCP3208Driver() should have returned a *MCP3208Driver")
+		require.Fail(t, "NewMCP3208Driver() should have returned a *MCP3208Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "MCP3208"))

--- a/drivers/spi/mcp3304_test.go
+++ b/drivers/spi/mcp3304_test.go
@@ -32,7 +32,7 @@ func TestNewMCP3304Driver(t *testing.T) {
 	var di interface{} = NewMCP3304Driver(newSpiTestAdaptor())
 	d, ok := di.(*MCP3304Driver)
 	if !ok {
-		t.Errorf("NewMCP3304Driver() should have returned a *MCP3304Driver")
+		require.Fail(t, "NewMCP3304Driver() should have returned a *MCP3304Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "MCP3304"))

--- a/drivers/spi/mfrc522_driver_test.go
+++ b/drivers/spi/mfrc522_driver_test.go
@@ -29,7 +29,7 @@ func TestNewMFRC522Driver(t *testing.T) {
 	var di interface{} = NewMFRC522Driver(newSpiTestAdaptor())
 	d, ok := di.(*MFRC522Driver)
 	if !ok {
-		t.Errorf("NewMFRC522Driver() should have returned a *MFRC522Driver")
+		require.Fail(t, "NewMFRC522Driver() should have returned a *MFRC522Driver")
 	}
 	assert.NotNil(t, d.Driver)
 	assert.True(t, strings.HasPrefix(d.Name(), "MFRC522"))

--- a/drivers/spi/spi_driver_test.go
+++ b/drivers/spi/spi_driver_test.go
@@ -25,7 +25,7 @@ func TestNewDriver(t *testing.T) {
 	var di interface{} = NewDriver(newSpiTestAdaptor(), "SPI_BASIC")
 	d, ok := di.(*Driver)
 	if !ok {
-		t.Errorf("NewDriver() should have returned a *Driver")
+		require.Fail(t, "NewDriver() should have returned a *Driver")
 	}
 	assert.True(t, strings.HasPrefix(d.Name(), "SPI_BASIC"))
 }

--- a/platforms/dji/tello/driver_test.go
+++ b/platforms/dji/tello/driver_test.go
@@ -123,12 +123,12 @@ func Test_handleResponse(t *testing.T) {
 						t.Error("subscription channel is closed")
 					}
 					if ev.Name != tc.wantEvent {
-						t.Errorf("\ngot: %s\nwant: %s\n", ev.Name, tc.wantEvent)
+						require.Fail(t, "\ngot: %s\nwant: %s\n", ev.Name, tc.wantEvent)
 					}
 					got := fmt.Sprintf("%T %+[1]v", ev.Data)
 					want := fmt.Sprintf("%T %+[1]v", tc.wantData)
 					if got != want {
-						t.Errorf("\ngot: %s\nwant: %s\n", got, want)
+						require.Fail(t, "\ngot: %s\nwant: %s\n", got, want)
 					}
 				case <-time.After(time.Millisecond):
 					t.Error("subscription channel seems empty")

--- a/platforms/firmata/client/client_test.go
+++ b/platforms/firmata/client/client_test.go
@@ -149,7 +149,7 @@ func TestProcessProtocolVersion(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(semPublishWait):
-		t.Errorf("ProtocolVersion was not published")
+		require.Fail(t, "ProtocolVersion was not published")
 	}
 }
 
@@ -168,7 +168,7 @@ func TestProcessAnalogRead0(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(semPublishWait):
-		t.Errorf("AnalogRead0 was not published")
+		require.Fail(t, "AnalogRead0 was not published")
 	}
 }
 
@@ -187,7 +187,7 @@ func TestProcessAnalogRead1(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(semPublishWait):
-		t.Errorf("AnalogRead1 was not published")
+		require.Fail(t, "AnalogRead1 was not published")
 	}
 }
 
@@ -207,7 +207,7 @@ func TestProcessDigitalRead2(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(semPublishWait):
-		t.Errorf("DigitalRead2 was not published")
+		require.Fail(t, "DigitalRead2 was not published")
 	}
 }
 
@@ -227,7 +227,7 @@ func TestProcessDigitalRead4(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(semPublishWait):
-		t.Errorf("DigitalRead4 was not published")
+		require.Fail(t, "DigitalRead4 was not published")
 	}
 }
 
@@ -267,7 +267,7 @@ func TestProcessPinState13(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(semPublishWait):
-		t.Errorf("PinState13 was not published")
+		require.Fail(t, "PinState13 was not published")
 	}
 }
 
@@ -310,7 +310,7 @@ func TestProcessI2cReply(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(semPublishWait):
-		t.Errorf("I2cReply was not published")
+		require.Fail(t, "I2cReply was not published")
 	}
 }
 
@@ -329,7 +329,7 @@ func TestProcessFirmwareQuery(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(semPublishWait):
-		t.Errorf("FirmwareQuery was not published")
+		require.Fail(t, "FirmwareQuery was not published")
 	}
 }
 
@@ -348,7 +348,7 @@ func TestProcessStringData(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(semPublishWait):
-		t.Errorf("StringData was not published")
+		require.Fail(t, "StringData was not published")
 	}
 }
 
@@ -433,6 +433,6 @@ func TestProcessSysexData(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(semPublishWait):
-		t.Errorf("SysexResponse was not published")
+		require.Fail(t, "SysexResponse was not published")
 	}
 }

--- a/platforms/joystick/joystick_driver_test.go
+++ b/platforms/joystick/joystick_driver_test.go
@@ -56,7 +56,7 @@ func TestDriverHandleEventDS3(t *testing.T) {
 	tj.buttonCount = 17
 
 	if err := d.initConfig(); err != nil {
-		t.Errorf("initConfig() error: %v", err)
+		require.Fail(t, "initConfig() error: %v", err)
 	}
 
 	d.initEvents()
@@ -73,7 +73,7 @@ func TestDriverHandleEventDS3(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(1 * time.Second):
-		t.Errorf("Button Event \"left_x\" was not published")
+		require.Fail(t, "Button Event \"left_x\" was not published")
 	}
 
 	// square button press
@@ -87,7 +87,7 @@ func TestDriverHandleEventDS3(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(1 * time.Second):
-		t.Errorf("Button Event \"square_press\" was not published")
+		require.Fail(t, "Button Event \"square_press\" was not published")
 	}
 
 	// square button release
@@ -101,7 +101,7 @@ func TestDriverHandleEventDS3(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(1 * time.Second):
-		t.Errorf("Button Event \"square_release\" was not published")
+		require.Fail(t, "Button Event \"square_release\" was not published")
 	}
 }
 
@@ -112,7 +112,7 @@ func TestDriverHandleEventJSONDS3(t *testing.T) {
 	tj.buttonCount = 17
 
 	if err := d.initConfig(); err != nil {
-		t.Errorf("initConfig() error: %v", err)
+		require.Fail(t, "initConfig() error: %v", err)
 	}
 
 	d.initEvents()
@@ -129,7 +129,7 @@ func TestDriverHandleEventJSONDS3(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(1 * time.Second):
-		t.Errorf("Button Event \"left_x\" was not published")
+		require.Fail(t, "Button Event \"left_x\" was not published")
 	}
 
 	// square button press
@@ -143,7 +143,7 @@ func TestDriverHandleEventJSONDS3(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(1 * time.Second):
-		t.Errorf("Button Event \"square_press\" was not published")
+		require.Fail(t, "Button Event \"square_press\" was not published")
 	}
 
 	// square button release
@@ -157,7 +157,7 @@ func TestDriverHandleEventJSONDS3(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(1 * time.Second):
-		t.Errorf("Button Event \"square_release\" was not published")
+		require.Fail(t, "Button Event \"square_release\" was not published")
 	}
 }
 
@@ -168,7 +168,7 @@ func TestDriverHandleEventDS4(t *testing.T) {
 	tj.buttonCount = 17
 
 	if err := d.initConfig(); err != nil {
-		t.Errorf("initConfig() error: %v", err)
+		require.Fail(t, "initConfig() error: %v", err)
 	}
 
 	d.initEvents()
@@ -185,7 +185,7 @@ func TestDriverHandleEventDS4(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(1 * time.Second):
-		t.Errorf("Button Event \"left_x\" was not published")
+		require.Fail(t, "Button Event \"left_x\" was not published")
 	}
 
 	// square button press
@@ -199,7 +199,7 @@ func TestDriverHandleEventDS4(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(1 * time.Second):
-		t.Errorf("Button Event \"square_press\" was not published")
+		require.Fail(t, "Button Event \"square_press\" was not published")
 	}
 
 	// square button release
@@ -213,7 +213,7 @@ func TestDriverHandleEventDS4(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(1 * time.Second):
-		t.Errorf("Button Event \"square_release\" was not published")
+		require.Fail(t, "Button Event \"square_release\" was not published")
 	}
 }
 

--- a/platforms/leap/leap_motion_driver_test.go
+++ b/platforms/leap/leap_motion_driver_test.go
@@ -90,7 +90,7 @@ func TestLeapMotionDriverParser(t *testing.T) {
 	parsedFrame, _ := d.ParseFrame(file)
 
 	if parsedFrame.Hands == nil || parsedFrame.Pointables == nil || parsedFrame.Gestures == nil {
-		t.Errorf("ParseFrame incorrectly parsed frame")
+		require.Fail(t, "ParseFrame incorrectly parsed frame")
 	}
 
 	assert.Equal(t, uint64(134211791358), parsedFrame.Timestamp)

--- a/platforms/mavlink/mavlink_driver_test.go
+++ b/platforms/mavlink/mavlink_driver_test.go
@@ -69,17 +69,17 @@ func TestMavlinkDriverStart(t *testing.T) {
 		require.NoError(t, d.SendPacket(p))
 
 	case <-time.After(100 * time.Millisecond):
-		t.Errorf("packet was not emitted")
+		require.Fail(t, "packet was not emitted")
 	}
 	select {
 	case <-message:
 	case <-time.After(100 * time.Millisecond):
-		t.Errorf("message was not emitted")
+		require.Fail(t, "message was not emitted")
 	}
 	select {
 	case <-err:
 	case <-time.After(100 * time.Millisecond):
-		t.Errorf("error was not emitted")
+		require.Fail(t, "error was not emitted")
 	}
 }
 

--- a/platforms/opencv/camera_driver_test.go
+++ b/platforms/opencv/camera_driver_test.go
@@ -45,7 +45,7 @@ func TestCameraDriverStart(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(100 * time.Millisecond):
-		t.Errorf("Event \"frame\" was not published")
+		require.Fail(t, "Event \"frame\" was not published")
 	}
 
 	d = NewCameraDriver("")

--- a/platforms/particle/adaptor_test.go
+++ b/platforms/particle/adaptor_test.go
@@ -29,7 +29,7 @@ func getDummyResponseForPath(t *testing.T, path string, dummyResponse string) *h
 	return createTestServer(func(w http.ResponseWriter, r *http.Request) {
 		actualPath := "/v1/devices" + path
 		if r.URL.Path != actualPath {
-			t.Errorf("Path doesn't match, expected %#v, got %#v", actualPath, r.URL.Path)
+			require.Fail(t, "Path doesn't match, expected %#v, got %#v", actualPath, r.URL.Path)
 		}
 		_, _ = w.Write(dummyData)
 	})
@@ -48,7 +48,7 @@ func getDummyResponseForPathWithParams(
 	return createTestServer(func(w http.ResponseWriter, r *http.Request) {
 		actualPath := "/v1/devices" + path
 		if r.URL.Path != actualPath {
-			t.Errorf("Path doesn't match, expected %#v, got %#v", actualPath, r.URL.Path)
+			require.Fail(t, "Path doesn't match, expected %#v, got %#v", actualPath, r.URL.Path)
 		}
 
 		_ = r.ParseForm()
@@ -78,7 +78,7 @@ func TestAdaptor(t *testing.T) {
 	var a interface{} = initTestAdaptor()
 	_, ok := a.(gobot.Adaptor)
 	if !ok {
-		t.Errorf("Adaptor{} should be a gobot.Adaptor")
+		require.Fail(t, "Adaptor{} should be a gobot.Adaptor")
 	}
 }
 
@@ -87,7 +87,7 @@ func TestNewAdaptor(t *testing.T) {
 	var a interface{} = initTestAdaptor()
 	core, ok := a.(*Adaptor)
 	if !ok {
-		t.Errorf("NewAdaptor() should have returned a *Adaptor")
+		require.Fail(t, "NewAdaptor() should have returned a *Adaptor")
 	}
 
 	assert.Equal(t, "https://api.particle.io", core.APIServer)

--- a/platforms/pebble/pebble_driver_test.go
+++ b/platforms/pebble/pebble_driver_test.go
@@ -50,7 +50,7 @@ func TestDriver(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(100 * time.Millisecond):
-		t.Errorf("Button Event was not published")
+		require.Fail(t, "Button Event was not published")
 	}
 
 	_ = d.On(d.Event("accel"), func(data interface{}) {
@@ -62,7 +62,7 @@ func TestDriver(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(100 * time.Millisecond):
-		t.Errorf("Accel Event was not published")
+		require.Fail(t, "Accel Event was not published")
 	}
 
 	d.Command("send_notification")(map[string]interface{}{"message": "Hey buddy!"})

--- a/utils_test.go
+++ b/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEvery(t *testing.T) {
@@ -35,7 +36,7 @@ func TestEveryWhenStopped(t *testing.T) {
 		done.Stop()
 	case <-time.After(190 * time.Millisecond):
 		done.Stop()
-		t.Errorf("Every was not called")
+		require.Fail(t, "Every was not called")
 	}
 
 	select {
@@ -57,7 +58,7 @@ func TestAfter(t *testing.T) {
 	select {
 	case <-sem:
 	case <-time.After(190 * time.Millisecond):
-		t.Errorf("After was not called")
+		require.Fail(t, "After was not called")
 	}
 
 	assert.Equal(t, 1, i)
@@ -82,7 +83,7 @@ func TestRand(t *testing.T) {
 	a := Rand(10000)
 	b := Rand(10000)
 	if a == b {
-		t.Errorf("%v should not equal %v", a, b)
+		require.Fail(t, "%v should not equal %v", a, b)
 	}
 }
 


### PR DESCRIPTION
## Solved issues and/or description of the change

"TestEventerOn" fails sporadically. This change try to stabilize by adding a wait before the event will be fired. Additionally all "t.Errorf" usages are replaced by "require.Fail".

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test_race`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code