### PR TITLE
doc: update links to release or tagged branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,7 @@ Descriptions for each of these will eventually be provided below.
 
 ## General Guidelines
 
-* All active development is in the `dev` branch. New or updated features must be added to the `dev` branch. Hotfixes
-  will be considered on the `master` branch in situations where it does not alter behavior or features, only fixes a bug.
+* All active development is in the `dev` branch. New or updated features must be added to the `dev` branch.
 * All patches must be provided under the Apache 2.0 License
 * Please use the -S option in git to "sign off" that the commit is your work and you are providing it under the
   Apache 2.0 License
@@ -142,4 +141,4 @@ Gobot is released with a Contributor Code of Conduct. By participating in this p
 
 ## Origins
 
-This document is based on the original [io.js contribution guidelines](https://github.com/nodejs/io.js/blob/master/CONTRIBUTING.md)
+This document is based on the original [io.js contribution guidelines](https://github.com/nodejs/io.js/blob/main/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Appveyor Build status](https://ci.appveyor.com/api/projects/status/ix29evnbdrhkr7ud/branch/dev?svg=true)](https://ci.appveyor.com/project/deadprogram/gobot/branch/dev)
 [![codecov](https://codecov.io/gh/hybridgroup/gobot/branch/dev/graph/badge.svg)](https://codecov.io/gh/hybridgroup/gobot)
 [![Go Report Card](https://goreportcard.com/badge/hybridgroup/gobot)](https://goreportcard.com/report/hybridgroup/gobot)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/hybridgroup/gobot/blob/master/LICENSE.txt)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/hybridgroup/gobot/blob/release/LICENSE.txt)
 
 Gobot (<https://gobot.io/>) is a framework using the Go programming language (<https://golang.org/>) for robotics, physical
 computing, and the Internet of Things.
@@ -241,52 +241,52 @@ func main() {
 Gobot has a extensible system for connecting to hardware devices. The following robotics and physical computing
 platforms are currently supported:
 
-- [Arduino](http://www.arduino.cc/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/firmata)
-- Audio <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/audio)
-- [Beaglebone Black](http://beagleboard.org/boards) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/beaglebone)
-- [Beaglebone PocketBeagle](http://beagleboard.org/pocket/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/beaglebone)
-- [Bluetooth LE](https://www.bluetooth.com/what-is-bluetooth-technology/bluetooth-technology-basics/low-energy) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/bleclient)
-- [C.H.I.P](http://www.nextthing.co/pages/chip) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/chip)
-- [C.H.I.P Pro](https://docs.getchip.com/chip_pro.html) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/chip)
-- [Digispark](http://digistump.com/products/1) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/digispark)
-- [DJI Tello](https://www.ryzerobotics.com/tello) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/dji/tello)
-- [DragonBoard](https://developer.qualcomm.com/hardware/dragonboard-410c) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/dragonboard)
-- [ESP8266](http://esp8266.net/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/firmata)
-- [GoPiGo 3](https://www.dexterindustries.com/gopigo3/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/dexter/gopigo3)
-- [Intel Curie](https://www.intel.com/content/www/us/en/products/boards-kits/curie.html) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/intel-iot/curie)
-- [Intel Edison](http://www.intel.com/content/www/us/en/do-it-yourself/edison.html) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/intel-iot/edison)
-- [Intel Joule](http://intel.com/joule/getstarted) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/intel-iot/joule)
-- [Jetson Nano](https://developer.nvidia.com/embedded/jetson-nano/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/jetson)
-- [Joystick](http://en.wikipedia.org/wiki/Joystick) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/joystick)
-- [Keyboard](https://en.wikipedia.org/wiki/Computer_keyboard) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/keyboard)
-- [Leap Motion](https://www.leapmotion.com/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/leap)
-- [MavLink](http://qgroundcontrol.org/mavlink/start) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/mavlink)
-- [MegaPi](http://www.makeblock.com/megapi) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/megapi)
-- [Microbit](http://microbit.org/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/microbit)
-- [MQTT](http://mqtt.org/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/mqtt)
-- [NanoPi NEO](https://wiki.friendlyelec.com/wiki/index.php/NanoPi_NEO) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/nanopi)
-- [NATS](http://nats.io/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/nats)
-- [Neurosky](http://neurosky.com/products-markets/eeg-biosensors/hardware/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/neurosky)
-- [OpenCV](http://opencv.org/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/opencv)
-- [Particle](https://www.particle.io/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/particle)
-- [Parrot ARDrone 2.0](http://ardrone2.parrot.com/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/parrot/ardrone)
-- [Parrot Bebop](http://www.parrot.com/usa/products/bebop-drone/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/parrot/bebop)
-- [Parrot Minidrone](https://www.parrot.com/us/minidrones) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/parrot/minidrone)
-- [Pebble](https://www.getpebble.com/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/pebble)
-- [Radxa Rock Pi 4](https://wiki.radxa.com/Rock4/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/rockpi)
-- [Raspberry Pi](http://www.raspberrypi.org/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/raspi)
-- [Serial Port](https://en.wikipedia.org/wiki/Serial_port) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/serialport)
-- [Sphero](http://www.sphero.com/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/sphero/sphero)
-- [Sphero BB-8](http://www.sphero.com/bb8) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/sphero/bb8)
-- [Sphero Ollie](http://www.sphero.com/ollie) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/sphero/ollie)
-- [Sphero SPRK+](http://www.sphero.com/sprk-plus) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/sphero/sprkplus)
-- [Tinker Board](https://www.asus.com/us/Single-Board-Computer/Tinker-Board/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/tinkerboard)
-- [UP2](http://www.up-board.org/upsquared/) <=> [Package](https://github.com/hybridgroup/gobot/tree/master/platforms/upboard/up2)
+- [Arduino](http://www.arduino.cc/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/firmata)
+- Audio <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/audio)
+- [Beaglebone Black](http://beagleboard.org/boards) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/beaglebone)
+- [Beaglebone PocketBeagle](http://beagleboard.org/pocket/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/beaglebone)
+- [Bluetooth LE](https://www.bluetooth.com/what-is-bluetooth-technology/bluetooth-technology-basics/low-energy) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/bleclient)
+- [C.H.I.P](http://www.nextthing.co/pages/chip) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/chip)
+- [C.H.I.P Pro](https://docs.getchip.com/chip_pro.html) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/chip)
+- [Digispark](http://digistump.com/products/1) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/digispark)
+- [DJI Tello](https://www.ryzerobotics.com/tello) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/dji/tello)
+- [DragonBoard](https://developer.qualcomm.com/hardware/dragonboard-410c) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/dragonboard)
+- [ESP8266](http://esp8266.net/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/firmata)
+- [GoPiGo 3](https://www.dexterindustries.com/gopigo3/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/dexter/gopigo3)
+- [Intel Curie](https://www.intel.com/content/www/us/en/products/boards-kits/curie.html) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/intel-iot/curie)
+- [Intel Edison](http://www.intel.com/content/www/us/en/do-it-yourself/edison.html) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/intel-iot/edison)
+- [Intel Joule](http://intel.com/joule/getstarted) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/intel-iot/joule)
+- [Jetson Nano](https://developer.nvidia.com/embedded/jetson-nano/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/jetson)
+- [Joystick](http://en.wikipedia.org/wiki/Joystick) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/joystick)
+- [Keyboard](https://en.wikipedia.org/wiki/Computer_keyboard) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/keyboard)
+- [Leap Motion](https://www.leapmotion.com/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/leap)
+- [MavLink](http://qgroundcontrol.org/mavlink/start) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/mavlink)
+- [MegaPi](http://www.makeblock.com/megapi) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/megapi)
+- [Microbit](http://microbit.org/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/microbit)
+- [MQTT](http://mqtt.org/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/mqtt)
+- [NanoPi NEO](https://wiki.friendlyelec.com/wiki/index.php/NanoPi_NEO) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/nanopi)
+- [NATS](http://nats.io/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/nats)
+- [Neurosky](http://neurosky.com/products-markets/eeg-biosensors/hardware/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/neurosky)
+- [OpenCV](http://opencv.org/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/opencv)
+- [Particle](https://www.particle.io/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/particle)
+- [Parrot ARDrone 2.0](http://ardrone2.parrot.com/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/parrot/ardrone)
+- [Parrot Bebop](http://www.parrot.com/usa/products/bebop-drone/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/parrot/bebop)
+- [Parrot Minidrone](https://www.parrot.com/us/minidrones) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/parrot/minidrone)
+- [Pebble](https://www.getpebble.com/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/pebble)
+- [Radxa Rock Pi 4](https://wiki.radxa.com/Rock4/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/rockpi)
+- [Raspberry Pi](http://www.raspberrypi.org/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/raspi)
+- [Serial Port](https://en.wikipedia.org/wiki/Serial_port) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/serialport)
+- [Sphero](http://www.sphero.com/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/sphero/sphero)
+- [Sphero BB-8](http://www.sphero.com/bb8) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/sphero/bb8)
+- [Sphero Ollie](http://www.sphero.com/ollie) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/sphero/ollie)
+- [Sphero SPRK+](http://www.sphero.com/sprk-plus) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/sphero/sprkplus)
+- [Tinker Board](https://www.asus.com/us/Single-Board-Computer/Tinker-Board/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/tinkerboard)
+- [UP2](http://www.up-board.org/upsquared/) <=> [Package](https://github.com/hybridgroup/gobot/blob/release/platforms/upboard/up2)
 
 Support for many devices that use Analog Input/Output (AIO) have a shared set of drivers provided using
 the `gobot/drivers/aio` package:
 
-- [AIO](https://en.wikipedia.org/wiki/Analog-to-digital_converter) <=> [Drivers](https://github.com/hybridgroup/gobot/tree/master/drivers/aio)
+- [AIO](https://en.wikipedia.org/wiki/Analog-to-digital_converter) <=> [Drivers](https://github.com/hybridgroup/gobot/blob/release/drivers/aio)
   - Analog Actuator
   - Analog Sensor
   - Grove Light Sensor
@@ -300,7 +300,7 @@ the `gobot/drivers/aio` package:
 Support for many devices that use Bluetooth LE (BLE) have a shared set of drivers provided using
 the `gobot/drivers/ble` package:
 
-- [BLE](http://en.wikipedia.org/wiki/Bluetooth_low_energy) <=> [Drivers](https://github.com/hybridgroup/gobot/tree/master/drivers/ble)
+- [BLE](http://en.wikipedia.org/wiki/Bluetooth_low_energy) <=> [Drivers](https://github.com/hybridgroup/gobot/blob/release/drivers/ble)
   - Battery Service
   - Device Information Service
   - Generic Access Service
@@ -317,7 +317,7 @@ the `gobot/drivers/ble` package:
 Support for many devices that use General Purpose Input/Output (GPIO) have a shared set of drivers provided using
 the `gobot/drivers/gpio` package:
 
-- [GPIO](https://en.wikipedia.org/wiki/General_Purpose_Input/Output) <=> [Drivers](https://github.com/hybridgroup/gobot/tree/master/drivers/gpio)
+- [GPIO](https://en.wikipedia.org/wiki/General_Purpose_Input/Output) <=> [Drivers](https://github.com/hybridgroup/gobot/blob/release/drivers/gpio)
   - AIP1640 LED Dot Matrix/7 Segment Controller
   - Button
   - Buzzer
@@ -345,7 +345,7 @@ the `gobot/drivers/gpio` package:
 Support for devices that use Inter-Integrated Circuit (I2C) have a shared set of drivers provided using
 the `gobot/drivers/i2c` package:
 
-- [I2C](https://en.wikipedia.org/wiki/I%C2%B2C) <=> [Drivers](https://github.com/hybridgroup/gobot/tree/master/drivers/i2c)
+- [I2C](https://en.wikipedia.org/wiki/I%C2%B2C) <=> [Drivers](https://github.com/hybridgroup/gobot/blob/release/drivers/i2c)
   - Adafruit 1109 2x16 RGB-LCD with 5 keys
   - Adafruit 2327 16-Channel PWM/Servo HAT Hat
   - Adafruit 2348 DC and Stepper Motor Hat
@@ -388,7 +388,7 @@ the `gobot/drivers/i2c` package:
 Support for many devices that use Serial communication (UART) have a shared set of drivers provided using
 the `gobot/drivers/serial` package:
 
-- [UART](https://en.wikipedia.org/wiki/Serial_port) <=> [Drivers](https://github.com/hybridgroup/gobot/tree/master/drivers/serial)
+- [UART](https://en.wikipedia.org/wiki/Serial_port) <=> [Drivers](https://github.com/hybridgroup/gobot/blob/release/drivers/serial)
   - Sphero: Sphero
   - Neurosky: MindWave
   - MegaPi: MotorDriver
@@ -396,7 +396,7 @@ the `gobot/drivers/serial` package:
 Support for devices that use Serial Peripheral Interface (SPI) have
 a shared set of drivers provided using the `gobot/drivers/spi` package:
 
-- [SPI](https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus) <=> [Drivers](https://github.com/hybridgroup/gobot/tree/master/drivers/spi)
+- [SPI](https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus) <=> [Drivers](https://github.com/hybridgroup/gobot/blob/release/drivers/spi)
   - APA102 Programmable LEDs
   - MCP3002 Analog/Digital Converter
   - MCP3004 Analog/Digital Converter
@@ -453,12 +453,12 @@ Thank you!
 
 ## Contributing
 
-For our contribution guidelines, please go to [https://github.com/hybridgroup/gobot/blob/master/CONTRIBUTING.md
-](https://github.com/hybridgroup/gobot/blob/master/CONTRIBUTING.md
+For our contribution guidelines, please go to [https://github.com/hybridgroup/gobot/blob/release/CONTRIBUTING.md
+](https://github.com/hybridgroup/gobot/blob/release/CONTRIBUTING.md
 ).
 
 Gobot is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms.
-[You can read about it here](https://github.com/hybridgroup/gobot/tree/master/CODE_OF_CONDUCT.md).
+[You can read about it here](https://github.com/hybridgroup/gobot/blob/release/CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/api/basic_auth.go
+++ b/api/basic_auth.go
@@ -8,7 +8,7 @@ import (
 
 // BasicAuth returns basic auth handler.
 func BasicAuth(username, password string) http.HandlerFunc {
-	// Inspired by https://github.com/codegangsta/martini-contrib/blob/master/auth/
+	// Inspired by https://github.com/codegangsta/martini-contrib/tree/v0.1/auth
 	return func(res http.ResponseWriter, req *http.Request) {
 		if !secureCompare(req.Header.Get("Authorization"),
 			"Basic "+base64.StdEncoding.EncodeToString([]byte(username+":"+password)),

--- a/drivers/aio/doc.go
+++ b/drivers/aio/doc.go
@@ -6,6 +6,6 @@ Installing:
 	Please refer to the main [README.md](https://github.com/hybridgroup/gobot/blob/release/README.md)
 
 For further information refer to aio README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/aio/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/aio/README.md
 */
 package aio // import "gobot.io/x/gobot/v2/drivers/aio"

--- a/drivers/ble/sphero/doc.go
+++ b/drivers/ble/sphero/doc.go
@@ -2,8 +2,8 @@
 Package sphero provides the Gobot drivers for the Sphero BLE based platforms.
 
 For further information refer to sphero readme files:
-https://github.com/hybridgroup/gobot/blob/master/platforms/sphero/bb8/README.md
-https://github.com/hybridgroup/gobot/blob/master/platforms/sphero/ollie/README.md
-https://github.com/hybridgroup/gobot/blob/master/platforms/sphero/sprkplus/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/sphero/bb8/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/sphero/ollie/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/sphero/sprkplus/README.md
 */
 package sphero // import "gobot.io/x/gobot/v2/drivers/ble/sphero"

--- a/drivers/common/spherocommon/spherocommon_packets.go
+++ b/drivers/common/spherocommon/spherocommon_packets.go
@@ -1,7 +1,8 @@
 package spherocommon
 
 // LocatorConfig provides configuration for the Location api.
-// https://github.com/orbotix/DeveloperResources/blob/master/docs/Sphero_API_1.50.pdf
+// For more information refer to the api specification of "Orbotix Communication API"
+// see also: http://wiki.mark-toma.com/view/Sphero_API_Tutorial
 // The current (X,Y) coordinates of Sphero on the ground plane in centimeters.
 type LocatorConfig struct {
 	// Determines whether calibrate commands automatically correct the yaw tare value
@@ -15,8 +16,8 @@ type LocatorConfig struct {
 }
 
 // CollisionConfig provides configuration for the collision detection alogorithm.
-// For more information refer to the official api specification
-// https://github.com/orbotix/DeveloperResources/blob/master/docs/Collision%20detection%201.2.pdf.
+// For more information refer to the api specification of "Orbotix Communication API"
+// see also: http://wiki.mark-toma.com/view/Sphero_API_Tutorial
 type CollisionConfig struct {
 	// Detection method type to use. Methods 01h and 02h are supported as
 	// of FW ver 1.42. Use 00h to completely disable this service.
@@ -39,8 +40,8 @@ type CollisionConfig struct {
 }
 
 // DataStreamingConfig provides configuration for Sensor Data Streaming.
-// For more information refer to the official api specification
-// https://github.com/orbotix/DeveloperResources/blob/master/docs/Sphero_API_1.50.pdf page 28
+// For more information refer to the api specification of "Orbotix Communication API"
+// see also: http://wiki.mark-toma.com/view/Sphero_API_Tutorial
 type DataStreamingConfig struct {
 	// Divisor of the maximum sensor sampling rate
 	N uint16

--- a/drivers/gpio/doc.go
+++ b/drivers/gpio/doc.go
@@ -6,6 +6,6 @@ Installing:
 	Please refer to the main [README.md](https://github.com/hybridgroup/gobot/blob/release/README.md)
 
 For further information refer to gpio README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/gpio/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/gpio/README.md
 */
 package gpio // import "gobot.io/x/gobot/v2/drivers/gpio"

--- a/drivers/i2c/doc.go
+++ b/drivers/i2c/doc.go
@@ -6,6 +6,6 @@ Installing:
 	Please refer to the main [README.md](https://github.com/hybridgroup/gobot/blob/release/README.md)
 
 For further information refer to i2c README:
-https://github.com/hybridgroup/gobot/blob/master/drivers/i2c/README.md
+https://github.com/hybridgroup/gobot/blob/release/drivers/i2c/README.md
 */
 package i2c // import "gobot.io/x/gobot/v2/drivers/i2c"

--- a/drivers/i2c/grovepi_driver.go
+++ b/drivers/i2c/grovepi_driver.go
@@ -14,7 +14,7 @@ const grovePiDefaultAddress = 0x04
 
 // commands, see:
 // * https://www.dexterindustries.com/GrovePi/programming/grovepi-protocol-adding-custom-sensors/
-// * https://github.com/DexterInd/GrovePi/blob/master/Script/multi_grovepi_installer/grovepi4.py
+// * https://github.com/DexterInd/GrovePi/tree/1.3.0/Script/multi_grovepi_installer/grovepi4.py
 const (
 	commandReadDigital         = 1
 	commandWriteDigital        = 2
@@ -30,7 +30,7 @@ const (
 // https://www.dexterindustries.com/grovepi/
 //
 // To use this driver with the GrovePi, it must be running the firmware >= 1.4.0 and the system version >=3.
-// https://github.com/DexterInd/GrovePi/blob/master/README.md
+// https://github.com/DexterInd/GrovePi/tree/1.3.0/README.md
 type GrovePiDriver struct {
 	*Driver
 	pins map[int]string

--- a/drivers/i2c/mpl115a2_driver_test.go
+++ b/drivers/i2c/mpl115a2_driver_test.go
@@ -51,7 +51,7 @@ func TestMPL115A2ReadData(t *testing.T) {
 	//   * shift the temperature value right for 6 bits (resolution is 10 bit)
 	//   * shift the pressure value right for 6 bits (resolution is 10 bit)
 	// * calculate temperature in °C according to this implementation:
-	//   https://github.com/adafruit/Adafruit_MPL115A2/blob/master/Adafruit_MPL115A2.cpp
+	//   https://github.com/adafruit/Adafruit_MPL115A2/tree/2.0.2/Adafruit_MPL115A2.cpp
 	//
 	// arrange
 	d, a := initTestMPL115A2DriverWithStubbedAdaptor()

--- a/drivers/i2c/sht2x_driver.go
+++ b/drivers/i2c/sht2x_driver.go
@@ -43,16 +43,16 @@ const (
 	//  Power on default is 0/0
 	SHT2xAccuracyHigh = byte(0x00)
 
-	// SHT2xTriggerTempMeasureHold is the command for measureing temperature in hold master mode
+	// SHT2xTriggerTempMeasureHold is the command for measuring temperature in hold controller mode
 	SHT2xTriggerTempMeasureHold = 0xe3
 
-	// SHT2xTriggerHumdMeasureHold is the command for measureing humidity in hold master mode
+	// SHT2xTriggerHumdMeasureHold is the command for measuring humidity in hold controller mode
 	SHT2xTriggerHumdMeasureHold = 0xe5
 
-	// SHT2xTriggerTempMeasureNohold is the command for measureing humidity in no hold master mode
+	// SHT2xTriggerTempMeasureNohold is the command for measuring humidity in no hold controller mode
 	SHT2xTriggerTempMeasureNohold = 0xf3
 
-	// SHT2xTriggerHumdMeasureNohold is the command for measureing humidity in no hold master mode
+	// SHT2xTriggerHumdMeasureNohold is the command for measuring humidity in no hold controller mode
 	SHT2xTriggerHumdMeasureNohold = 0xf5
 
 	// SHT2xWriteUserReg is the command for writing user register

--- a/drivers/serial/doc.go
+++ b/drivers/serial/doc.go
@@ -2,6 +2,6 @@
 Package serial provides Gobot drivers for Serial Port communication based devices.
 
 For further information refer to readme:
-https://github.com/hybridgroup/gobot/blob/master/drivers/serial/README.md
+https://github.com/hybridgroup/gobot/blob/release/drivers/serial/README.md
 */
 package serial // import "gobot.io/x/gobot/v2/drivers/serial"

--- a/drivers/spi/doc.go
+++ b/drivers/spi/doc.go
@@ -6,6 +6,6 @@ Installing:
 	Please refer to the main [README.md](https://github.com/hybridgroup/gobot/blob/release/README.md)
 
 For further information refer to spi README:
-https://github.com/hybridgroup/gobot/blob/master/drivers/spi/README.md
+https://github.com/hybridgroup/gobot/blob/release/drivers/spi/README.md
 */
 package spi // import "gobot.io/x/gobot/v2/drivers/spi"

--- a/platforms/audio/doc.go
+++ b/platforms/audio/doc.go
@@ -2,6 +2,6 @@
 Package audio provides the Gobot adaptor for audio.
 
 For more information refer to the README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/audio/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/audio/README.md
 */
 package audio // import "gobot.io/x/gobot/v2/platforms/audio"

--- a/platforms/beaglebone/doc.go
+++ b/platforms/beaglebone/doc.go
@@ -42,6 +42,6 @@ Example:
 	}
 
 For more information refer to the beaglebone README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/beaglebone/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/beaglebone/README.md
 */
 package beaglebone // import "gobot.io/x/gobot/v2/platforms/beaglebone"

--- a/platforms/bleclient/doc.go
+++ b/platforms/bleclient/doc.go
@@ -2,6 +2,6 @@
 Package bleclient provides the Gobot client adaptor for Bluetooth LE.
 
 For more information refer to the README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/bleclient/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/bleclient/README.md
 */
 package bleclient // import "gobot.io/x/gobot/v2/platforms/bleclient"

--- a/platforms/chip/doc.go
+++ b/platforms/chip/doc.go
@@ -2,6 +2,6 @@
 Package chip contains the Gobot adaptor for the CHIP and CHIP Pro
 
 For further information refer to the chip README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/chip/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/chip/README.md
 */
 package chip // import "gobot.io/x/gobot/v2/platforms/chip"

--- a/platforms/dexter/dexter.go
+++ b/platforms/dexter/dexter.go
@@ -5,6 +5,6 @@ This package currently supports the following robots:
 - GoPiGo3
 
 For further information refer to Dexter README:
-https://gobot.io/x/gobot/v2/blob/master/platforms/dexter/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/dexter/README.md
 */
 package dexter

--- a/platforms/digispark/doc.go
+++ b/platforms/digispark/doc.go
@@ -44,6 +44,6 @@ Example:
 	}
 
 For further information refer to digispark README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/digispark/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/digispark/README.md
 */
 package digispark // import "gobot.io/x/gobot/v2/platforms/digispark"

--- a/platforms/dragonboard/doc.go
+++ b/platforms/dragonboard/doc.go
@@ -2,6 +2,6 @@
 Package dragonboard contains the Gobot adaptor for the DragonBoard 410c
 
 For further information refer to the chip README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/dragonboard/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/dragonboard/README.md
 */
 package dragonboard // import "gobot.io/x/gobot/v2/platforms/dragonboard"

--- a/platforms/firmata/doc.go
+++ b/platforms/firmata/doc.go
@@ -41,6 +41,6 @@ Example:
 	}
 
 For further information refer to firmata readme:
-https://github.com/hybridgroup/gobot/blob/master/platforms/firmata/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/firmata/README.md
 */
 package firmata // import "gobot.io/x/gobot/v2/platforms/firmata"

--- a/platforms/intel-iot/curie/README.md
+++ b/platforms/intel-iot/curie/README.md
@@ -69,8 +69,8 @@ func main() {
   )
 
   if err := robot.Start(); err != nil {
-		panic(err)
-	}
+    panic(err)
+  }
 }
 ```
 
@@ -78,7 +78,9 @@ func main() {
 
 ### Installing Firmware
 
-You need to flash your Intel Curie with firmware that uses ConfigurableFirmata along with the FirmataCurieIMU plugin. There are 2 versions of this firmware, once that allows connecting using the serial interface, the other using a Bluetooth LE connection.
+You need to flash your Intel Curie with firmware that uses ConfigurableFirmata along with the FirmataCurieIMU plugin.
+There are 2 versions of this firmware, once that allows connecting using the serial interface, the other using a
+Bluetooth LE connection.
 
 To setup your Arduino environment:
 
@@ -86,12 +88,8 @@ To setup your Arduino environment:
 - Install the "Intel Curie Boards" board files using the "Board Manager". You can find it in the Arduino IDE under the
   "Tools" menu. Choose "Boards > Boards Manager".
 - Search for the "Intel Curie Boards" package in the "Boards Manager" dialog, and then install the latest version.
-- Download the ZIP file for the ConfigurableFirmata library. You can download the latest version of the ConfigurableFirmata
-  from here:
-  [https://github.com/firmata/ConfigurableFirmata/archive/master.zip](https://github.com/firmata/ConfigurableFirmata/archive/master.zip)
-  Once you have downloaded ConfigurableFirmata, install it by using the "Library Manager". You can find it in the Arduino
-  IDE under the "Sketch" menu. Choose "Include Library > Add .ZIP Library". Select the ZIP file for the ConfigurableFirmata
-  library that you just downloaded.
+- Follow the [installation instructions](https://github.com/firmata/ConfigurableFirmata#installation) for the
+  ConfigurableFirmata library
 - Download the ZIP file for the FirmataCurieIMU library. You can download the latest version of FirmataCurieIMU from here:
   [https://github.com/intel-iot-devkit/firmata-curie-imu/archive/master.zip](https://github.com/intel-iot-devkit/firmata-curie-imu/archive/master.zip)
 - Once you have downloaded the FirmataCurieIMU library, install it by using the "Library Manager". You can find it in the

--- a/platforms/intel-iot/curie/doc.go
+++ b/platforms/intel-iot/curie/doc.go
@@ -2,6 +2,6 @@
 Package curie contains the Gobot driver for the Intel Curie IMU.
 
 For further information refer to intel-iot README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/intel-iot/curie/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/intel-iot/curie/README.md
 */
 package curie // import "gobot.io/x/gobot/v2/platforms/intel-iot/curie"

--- a/platforms/intel-iot/edison/doc.go
+++ b/platforms/intel-iot/edison/doc.go
@@ -2,6 +2,6 @@
 Package edison contains the Gobot adaptor for the Intel Edison.
 
 For further information refer to intel-iot README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/intel-iot/edison/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/intel-iot/edison/README.md
 */
 package edison // import "gobot.io/x/gobot/v2/platforms/intel-iot/edison"

--- a/platforms/intel-iot/intel-iot.go
+++ b/platforms/intel-iot/intel-iot.go
@@ -6,6 +6,6 @@ This package currently supports the following Intel IoT hardware:
 - Intel Joule developer kit
 
 For further information refer to intel-iot README:
-https://gobot.io/x/gobot/v2/blob/master/platforms/intel-iot/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/intel-iot/README.md
 */
 package inteliot

--- a/platforms/intel-iot/joule/doc.go
+++ b/platforms/intel-iot/joule/doc.go
@@ -2,6 +2,6 @@
 Package joule contains the Gobot adaptor for the Intel Joule.
 
 For further information refer to intel-iot README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/intel-iot/joule/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/intel-iot/joule/README.md
 */
 package joule // import "gobot.io/x/gobot/v2/platforms/intel-iot/joule"

--- a/platforms/jetson/doc.go
+++ b/platforms/jetson/doc.go
@@ -2,6 +2,6 @@
 Package jetson contains the Gobot adaptor for the Jetson Nano.
 
 For further information refer to Jetson README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/jetson/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/jetson/README.md
 */
 package jetson // import "gobot.io/x/gobot/v2/platforms/jetson"

--- a/platforms/joystick/doc.go
+++ b/platforms/joystick/doc.go
@@ -59,6 +59,6 @@ Example:
 	}
 
 For further information refer to joystick README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/joystick/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/joystick/README.md
 */
 package joystick // import "gobot.io/x/gobot/v2/platforms/joystick"

--- a/platforms/keyboard/doc.go
+++ b/platforms/keyboard/doc.go
@@ -45,6 +45,6 @@ Example:
 	}
 
 For further information refer to keyboard README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/keyboard/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/keyboard/README.md
 */
 package keyboard // import "gobot.io/x/gobot/v2/platforms/keyboard"

--- a/platforms/leap/doc.go
+++ b/platforms/leap/doc.go
@@ -40,6 +40,6 @@ Example:
 	}
 
 For more information refer to the leap README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/leap/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/leap/README.md
 */
 package leap // import "gobot.io/x/gobot/v2/platforms/leap"

--- a/platforms/mavlink/doc.go
+++ b/platforms/mavlink/doc.go
@@ -65,6 +65,6 @@ Example:
 	}
 
 For further information refer to mavlink README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/mavlink/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/mavlink/README.md
 */
 package mavlink // import "gobot.io/x/gobot/v2/platforms/mavlink"

--- a/platforms/megapi/doc.go
+++ b/platforms/megapi/doc.go
@@ -2,6 +2,6 @@
 Package megapi provides the Gobot adaptor for MegaPi.
 
 For more information refer to the README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/megapi/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/megapi/README.md
 */
 package megapi // import "gobot.io/x/gobot/v2/platforms/megapi"

--- a/platforms/mqtt/doc.go
+++ b/platforms/mqtt/doc.go
@@ -6,6 +6,6 @@ Installing:
 	Please refer to the main [README.md](https://github.com/hybridgroup/gobot/blob/release/README.md)
 
 For further information refer to mqtt README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/mqtt/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/mqtt/README.md
 */
 package mqtt // import "gobot.io/x/gobot/v2/platforms/mqtt"

--- a/platforms/nanopi/doc.go
+++ b/platforms/nanopi/doc.go
@@ -2,6 +2,6 @@
 Package nanopi contains the Gobot adaptor for the FriendlyARM NanoPi Boards.
 
 For further information refer to nanopi README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/nanopi/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/nanopi/README.md
 */
 package nanopi // import "gobot.io/x/gobot/v2/platforms/nanopi"

--- a/platforms/nats/doc.go
+++ b/platforms/nats/doc.go
@@ -5,6 +5,6 @@ Installing:
 	Please refer to the main [README.md](https://github.com/hybridgroup/gobot/blob/release/README.md)
 
 For further information refer to nats README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/nats/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/nats/README.md
 */
 package nats // import "gobot.io/x/gobot/v2/platforms/nats"

--- a/platforms/opencv/doc.go
+++ b/platforms/opencv/doc.go
@@ -40,6 +40,6 @@ Example:
 	}
 
 For further information refer to opencv README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/opencv/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/opencv/README.md
 */
 package opencv // import "gobot.io/x/gobot/v2/platforms/opencv"

--- a/platforms/parrot/ardrone/doc.go
+++ b/platforms/parrot/ardrone/doc.go
@@ -41,6 +41,6 @@ Example:
 	}
 
 For more information refer to the ardrone README:
-https://github.com/hybridgroup/gobot/tree/master/platforms/parrot/ardrone/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/parrot/ardrone/README.md
 */
 package ardrone // import "gobot.io/x/gobot/v2/platforms/parrot/ardrone"

--- a/platforms/parrot/bebop/doc.go
+++ b/platforms/parrot/bebop/doc.go
@@ -6,6 +6,6 @@ Installing:
 	Please refer to the main [README.md](https://github.com/hybridgroup/gobot/blob/release/README.md)
 
 For more information refer to the bebop README:
-https://github.com/hybridgroup/gobot/tree/master/platforms/parrot/bebop/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/parrot/bebop/README.md
 */
 package bebop // import "gobot.io/x/gobot/v2/platforms/parrot/bebop"

--- a/platforms/particle/doc.go
+++ b/platforms/particle/doc.go
@@ -41,6 +41,6 @@ Example:
 	}
 
 For further information refer to Particle readme:
-https://github.com/hybridgroup/gobot/blob/master/platforms/particle/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/particle/README.md
 */
 package particle // import "gobot.io/x/gobot/v2/platforms/particle"

--- a/platforms/pebble/doc.go
+++ b/platforms/pebble/doc.go
@@ -55,6 +55,6 @@ your computer IP, robot name is 'pebble' and robot api port is 8080
 	}
 
 For more information refer to the pebble README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/pebble/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/pebble/README.md
 */
 package pebble // import "gobot.io/x/gobot/v2/platforms/pebble"

--- a/platforms/raspi/doc.go
+++ b/platforms/raspi/doc.go
@@ -2,6 +2,6 @@
 Package raspi contains the Gobot adaptor for the Raspberry Pi.
 
 For further information refer to raspi README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/raspi/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/raspi/README.md
 */
 package raspi // import "gobot.io/x/gobot/v2/platforms/raspi"

--- a/platforms/rockpi/doc.go
+++ b/platforms/rockpi/doc.go
@@ -2,6 +2,6 @@
 Package rockpi contains the Gobot adaptor for Radxa's Rock Pi Single Board Computers.
 
 For further information refer to rockpi README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/rockpi/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/rockpi/README.md
 */
 package rockpi // import "gobot.io/x/gobot/v2/platforms/rockpi"

--- a/platforms/serialport/README.md
+++ b/platforms/serialport/README.md
@@ -8,5 +8,5 @@ Please refer to the main [README.md](https://github.com/hybridgroup/gobot/blob/r
 
 ## How to Use
 
-See documentation for [Sphero](https://github.com/hybridgroup/gobot/blob/master/platforms/sphero/sphero/README.md) or
-[Neurosky MindWave](https://github.com/hybridgroup/gobot/blob/master/platforms/neurosky/README.md).
+See documentation for [Sphero](https://github.com/hybridgroup/gobot/blob/release/platforms/sphero/sphero/README.md) or
+[Neurosky MindWave](https://github.com/hybridgroup/gobot/blob/release/platforms/neurosky/README.md).

--- a/platforms/serialport/doc.go
+++ b/platforms/serialport/doc.go
@@ -2,6 +2,6 @@
 Package serialport provides the Gobot adaptor for serial communication with drivers.
 
 For further information refer to readme:
-https://github.com/hybridgroup/gobot/blob/master/platforms/serialport/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/serialport/README.md
 */
 package serialport // import "gobot.io/x/gobot/v2/platforms/serialport"

--- a/platforms/tinkerboard/doc.go
+++ b/platforms/tinkerboard/doc.go
@@ -2,6 +2,6 @@
 Package tinkerboard contains the Gobot adaptor for the ASUS Tinker Board.
 
 For further information refer to tinkerboard README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/tinkerboard/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/tinkerboard/README.md
 */
 package tinkerboard // import "gobot.io/x/gobot/v2/platforms/tinkerboard"

--- a/platforms/upboard/up2/doc.go
+++ b/platforms/upboard/up2/doc.go
@@ -2,6 +2,6 @@
 Package up2 contains the Gobot adaptor for the Upboard UP2.
 
 For further information refer to the UP2 README:
-https://github.com/hybridgroup/gobot/blob/master/platforms/upboard/up2/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/upboard/up2/README.md
 */
 package up2 // import "gobot.io/x/gobot/v2/platforms/upboard/up2"

--- a/platforms/upboard/upboard.go
+++ b/platforms/upboard/upboard.go
@@ -5,6 +5,6 @@ This package currently supports the following hardware:
 - UP2 (Squared)
 
 For further information refer to the Upboard README:
-https://gobot.io/x/gobot/v2/blob/master/platforms/upboard/README.md
+https://github.com/hybridgroup/gobot/blob/release/platforms/upboard/README.md
 */
 package upboard


### PR DESCRIPTION
## Solved issues and/or description of the change

One step closer to #1013 by update documentation and comments. Links for some (sometimes old) github pages needs to remain, because no "main" branch exists yet instead of "master". If more suitable, we switch to a tagged version. Outdated links are substituted by a working one.

## Manual test

none

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] I have performed a self-review of my own code