### PR TITLE
i2c/spi: remove offensive terminology

### DIFF
--- a/drivers/i2c/i2c_connection_test.go
+++ b/drivers/i2c/i2c_connection_test.go
@@ -37,7 +37,7 @@ func getSyscallFuncImpl(
 				system.I2C_FUNC_SMBUS_WRITE_WORD_DATA
 		}
 		// set address
-		if (trap == system.Syscall_SYS_IOCTL) && (a2 == system.I2C_SLAVE) {
+		if (trap == system.Syscall_SYS_IOCTL) && (a2 == system.I2C_TARGET) {
 			if errorMask&0x02 == 0x02 {
 				return 0, 0, 1
 			}

--- a/examples/tinkerboard_mfcrc522gpio.go
+++ b/examples/tinkerboard_mfcrc522gpio.go
@@ -19,17 +19,17 @@ import (
 // Wiring
 // PWR  Tinkerboard: 1 (+3.3V, VCC), 2(+5V), 6, 9, 14, 20 (GND)
 // GPIO-SPI Tinkerboard (same as SPI2): 23 (CLK), 19 (TXD), 21 (RXD), 24 (CSN0)
-// MFRC522 plate: VCC, GND, SCK (CLK), MOSI (->TXD), MISO (->RXD), NSS/SDA (CSN0/CSN1?)
+// MFRC522 plate: VCC, GND, SCK (CLK), SDO (->TXD), SDI (->RXD), NCS/SDA (CSN0/CSN1?)
 const (
 	sclk    = "23"
-	nss     = "24"
-	mosi    = "19"
-	miso    = "21"
+	ncs     = "24"
+	sdo     = "19"
+	sdi     = "21"
 	speedHz = 5000 // more than 15kHz is not possible with GPIO's, so we choose 5kHz
 )
 
 func main() {
-	a := tinkerboard.NewAdaptor(adaptors.WithSpiGpioAccess(sclk, nss, mosi, miso))
+	a := tinkerboard.NewAdaptor(adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi))
 	d := spi.NewMFRC522Driver(a, spi.WithSpeed(speedHz))
 
 	wasCardDetected := false

--- a/examples/tinkerboard_mfcrc522spi.go
+++ b/examples/tinkerboard_mfcrc522spi.go
@@ -19,7 +19,7 @@ import (
 // PWR  Tinkerboard: 1 (+3.3V, VCC), 2(+5V), 6, 9, 14, 20 (GND)
 // SPI0 Tinkerboard (not working with armbian): 11 (CLK), 13 (TXD), 15 (RXD), 29 (CSN0), 31 (CSN1, n.c.)
 // SPI2 Tinkerboard: 23 (CLK), 19 (TXD), 21 (RXD), 24 (CSN0), 26 (CSN1, n.c.)
-// MFRC522 plate: VCC, GND, SCK (CLK), MOSI (->TXD), MISO (->RXD), NSS/SDA (CSN0/CSN1?)
+// MFRC522 plate: VCC, GND, SCK (CLK), SDO (->TXD), SDI (->RXD), NCS/SDA (CSN0/CSN1?)
 func main() {
 	a := tinkerboard.NewAdaptor()
 	d := spi.NewMFRC522Driver(a, spi.WithBusNumber(2))

--- a/platforms/adaptors/digitalpinsadaptor.go
+++ b/platforms/adaptors/digitalpinsadaptor.go
@@ -63,9 +63,9 @@ func WithGpiodAccess() func(DigitalPinsOptioner) {
 }
 
 // WithSpiGpioAccess can be used to switch the default SPI implementation to GPIO usage.
-func WithSpiGpioAccess(sclkPin, nssPin, mosiPin, misoPin string) func(DigitalPinsOptioner) {
+func WithSpiGpioAccess(sclkPin, ncsPin, sdoPin, sdiPin string) func(DigitalPinsOptioner) {
 	return func(o DigitalPinsOptioner) {
-		o.setDigitalPinsForSystemSpi(sclkPin, nssPin, mosiPin, misoPin)
+		o.setDigitalPinsForSystemSpi(sclkPin, ncsPin, sdoPin, sdiPin)
 	}
 }
 

--- a/platforms/adaptors/digitalpinsadaptoroptions.go
+++ b/platforms/adaptors/digitalpinsadaptoroptions.go
@@ -13,7 +13,7 @@ import (
 type DigitalPinsOptioner interface {
 	setDigitalPinInitializer(initializer digitalPinInitializer)
 	setDigitalPinsForSystemGpiod()
-	setDigitalPinsForSystemSpi(sclkPin, nssPin, mosiPin, misoPin string)
+	setDigitalPinsForSystemSpi(sclkPin, ncsPin, sdoPin, sdiPin string)
 	prepareDigitalPinsActiveLow(pin string, otherPins ...string)
 	prepareDigitalPinsPullDown(pin string, otherPins ...string)
 	prepareDigitalPinsPullUp(pin string, otherPins ...string)
@@ -37,8 +37,8 @@ func (a *DigitalPinsAdaptor) setDigitalPinsForSystemGpiod() {
 	system.WithDigitalPinGpiodAccess()(a.sys)
 }
 
-func (a *DigitalPinsAdaptor) setDigitalPinsForSystemSpi(sclkPin, nssPin, mosiPin, misoPin string) {
-	system.WithSpiGpioAccess(a, sclkPin, nssPin, mosiPin, misoPin)(a.sys)
+func (a *DigitalPinsAdaptor) setDigitalPinsForSystemSpi(sclkPin, ncsPin, sdoPin, sdiPin string) {
+	system.WithSpiGpioAccess(a, sclkPin, ncsPin, sdoPin, sdiPin)(a.sys)
 }
 
 func (a *DigitalPinsAdaptor) prepareDigitalPinsActiveLow(id string, otherIDs ...string) {

--- a/platforms/beaglebone/beaglebone_adaptor.go
+++ b/platforms/beaglebone/beaglebone_adaptor.go
@@ -60,7 +60,7 @@ type Adaptor struct {
 // Optional parameters:
 //
 //	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs
-//	adaptors.WithSpiGpioAccess(sclk, nss, mosi, miso):	use GPIO's instead of /dev/spidev#.#
+//	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //
 //	Optional parameters for PWM, see [adaptors.NewPWMPinsAdaptor]
 func NewAdaptor(opts ...interface{}) *Adaptor {

--- a/platforms/beaglebone/pocketbeagle_adaptor.go
+++ b/platforms/beaglebone/pocketbeagle_adaptor.go
@@ -16,7 +16,7 @@ type PocketBeagleAdaptor struct {
 // Optional parameters:
 //
 //	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs
-//	adaptors.WithSpiGpioAccess(sclk, nss, mosi, miso):	use GPIO's instead of /dev/spidev#.#
+//	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //
 //	Optional parameters for PWM, see [adaptors.NewPWMPinsAdaptor]
 func NewPocketBeagleAdaptor(opts ...interface{}) *PocketBeagleAdaptor {

--- a/platforms/chip/chip_adaptor.go
+++ b/platforms/chip/chip_adaptor.go
@@ -41,7 +41,7 @@ type Adaptor struct {
 // Optional parameters:
 //
 //	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs
-//	adaptors.WithSpiGpioAccess(sclk, nss, mosi, miso):	use GPIO's instead of /dev/spidev#.#
+//	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //
 //	Optional parameters for PWM, see [adaptors.NewPWMPinsAdaptor]
 func NewAdaptor(opts ...interface{}) *Adaptor {

--- a/platforms/digispark/littleWire.h
+++ b/platforms/digispark/littleWire.h
@@ -339,7 +339,7 @@ void spi_init(littleWire* lwHandle);
 void spi_sendMessage(littleWire* lwHandle, unsigned char * sendBuffer, unsigned char * inputBuffer, unsigned char length ,unsigned char mode);
 
 /**
-  * Send one byte SPI message over MOSI pin. Slightly slower than the actual one.
+  * Send one byte SPI message over SDO pin. Slightly slower than the actual one.
   * \n There isn't any chip select control involved. Useful for debug console app
   *
   * @param lwHandle littleWire device pointer
@@ -376,7 +376,7 @@ void i2c_init(littleWire* lwHandle);
   * Start the i2c communication
   *
   * @param lwHandle littleWire device pointer
-  * @param address 7 bit slave address.
+  * @param address 7 bit target address.
   * @param direction ( \b READ or \b WRITE )
   * @return 1 if received ACK
   */

--- a/platforms/dragonboard/dragonboard_adaptor.go
+++ b/platforms/dragonboard/dragonboard_adaptor.go
@@ -49,7 +49,7 @@ var fixedPins = map[string]int{
 // Optional parameters:
 //
 //	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs
-//	adaptors.WithSpiGpioAccess(sclk, nss, mosi, miso):	use GPIO's instead of /dev/spidev#.#
+//	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 func NewAdaptor(opts ...func(adaptors.DigitalPinsOptioner)) *Adaptor {
 	sys := system.NewAccesser()
 	c := &Adaptor{

--- a/platforms/intel-iot/curie/imu_driver.go
+++ b/platforms/intel-iot/curie/imu_driver.go
@@ -86,13 +86,13 @@ func (imu *IMUDriver) Start() error {
 // Halt stops the IMUDriver
 func (imu *IMUDriver) Halt() error { return nil }
 
-// Name returns the IMUDriver's name
+// Name returns the IMUDrivers name
 func (imu *IMUDriver) Name() string { return imu.name }
 
-// SetName sets the IMUDriver'ss name
+// SetName sets the IMUDrivers name
 func (imu *IMUDriver) SetName(n string) { imu.name = n }
 
-// Connection returns the IMUDriver's Connection
+// Connection returns the IMUDrivers Connection
 func (imu *IMUDriver) Connection() gobot.Connection { return imu.connection }
 
 // ReadAccelerometer calls the Curie's built-in accelerometer. The result will

--- a/platforms/intel-iot/joule/joule_adaptor.go
+++ b/platforms/intel-iot/joule/joule_adaptor.go
@@ -33,7 +33,7 @@ type Adaptor struct {
 // Optional parameters:
 //
 //	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs
-//	adaptors.WithSpiGpioAccess(sclk, nss, mosi, miso):	use GPIO's instead of /dev/spidev#.#
+//	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //
 //	Optional parameters for PWM, see [adaptors.NewPWMPinsAdaptor]
 func NewAdaptor(opts ...interface{}) *Adaptor {

--- a/platforms/jetson/jetson_adaptor.go
+++ b/platforms/jetson/jetson_adaptor.go
@@ -41,7 +41,7 @@ type Adaptor struct {
 // Optional parameters:
 //
 //	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs
-//	adaptors.WithSpiGpioAccess(sclk, nss, mosi, miso):	use GPIO's instead of /dev/spidev#.#
+//	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //
 //	Optional parameters for PWM, see [adaptors.NewPWMPinsAdaptor]
 func NewAdaptor(opts ...interface{}) *Adaptor {

--- a/platforms/mavlink/common/common.go
+++ b/platforms/mavlink/common/common.go
@@ -451,7 +451,7 @@ const (
 	MAV_CMD_DO_PARACHUTE                 = 208 // Mission command to trigger a parachute | action (0=disable, 1=enable, 2=release, for some systems see PARACHUTE_ACTION enum, not in general message set.) | Empty | Empty | Empty | Empty | Empty | Empty |
 	MAV_CMD_DO_INVERTED_FLIGHT           = 210 // Change to/from inverted flight | inverted (0=normal, 1=inverted) | Empty | Empty | Empty | Empty | Empty | Empty |
 	MAV_CMD_DO_MOUNT_CONTROL_QUAT        = 220 // Mission command to control a camera or antenna mount, using a quaternion as reference. | q1 - quaternion param #1, w (1 in null-rotation) | q2 - quaternion param #2, x (0 in null-rotation) | q3 - quaternion param #3, y (0 in null-rotation) | q4 - quaternion param #4, z (0 in null-rotation) | Empty | Empty | Empty |
-	MAV_CMD_DO_GUIDED_MASTER             = 221 // set id of master controller | System ID | Component ID | Empty | Empty | Empty | Empty | Empty |
+	MAV_CMD_DO_GUIDED_CONTROLLER         = 221 // set id of the controller | System ID | Component ID | Empty | Empty | Empty | Empty | Empty |
 	MAV_CMD_DO_GUIDED_LIMITS             = 222 // set limits for external control | timeout - maximum time (in seconds) that external controller will be allowed to control vehicle. 0 means no timeout | absolute altitude min (in meters, WGS84) - if vehicle moves below this alt, the command will be aborted and the mission will continue.  0 means no lower altitude limit | absolute altitude max (in meters)- if vehicle moves above this alt, the command will be aborted and the mission will continue.  0 means no upper altitude limit | horizontal move limit (in meters, WGS84) - if vehicle moves more than this distance from it's location at the moment the command was executed, the command will be aborted and the mission will continue. 0 means no horizontal altitude limit | Empty | Empty | Empty |
 	MAV_CMD_DO_LAST                      = 240 // NOP - This command is only used to mark the upper limit of the DO commands in the enumeration | Empty | Empty | Empty | Empty | Empty | Empty | Empty |
 	MAV_CMD_PREFLIGHT_CALIBRATION        = 241 // Trigger calibration. This command will be only accepted if in pre-flight mode. | Gyro calibration: 0: no, 1: yes | Magnetometer calibration: 0: no, 1: yes | Ground pressure: 0: no, 1: yes | Radio calibration: 0: no, 1: yes | Accelerometer calibration: 0: no, 1: yes | Compass/Motor interference calibration: 0: no, 1: yes | Empty |
@@ -879,7 +879,7 @@ func (m *SysStatus) Decode(buf []byte) {
 //
 // MAVLINK_MSG_ID_SYSTEM_TIME_CRC 137
 type SystemTime struct {
-	TIME_UNIX_USEC uint64 // Timestamp of the master clock in microseconds since UNIX epoch.
+	TIME_UNIX_USEC uint64 // Timestamp of the primary reference clock in microseconds since UNIX epoch.
 	TIME_BOOT_MS   uint32 // Timestamp of the component clock since boot time in milliseconds.
 }
 

--- a/platforms/nanopi/nanopi_adaptor.go
+++ b/platforms/nanopi/nanopi_adaptor.go
@@ -63,7 +63,7 @@ type Adaptor struct {
 // Optional parameters:
 //
 //	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs (still used by default)
-//	adaptors.WithSpiGpioAccess(sclk, nss, mosi, miso):	use GPIO's instead of /dev/spidev#.#
+//	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //	adaptors.WithGpiosActiveLow(pin's): invert the pin behavior
 //	adaptors.WithGpiosPullUp/Down(pin's): sets the internal pull resistor
 //	adaptors.WithGpiosOpenDrain/Source(pin's): sets the output behavior

--- a/platforms/nanopi/nanopineo_pin_map.go
+++ b/platforms/nanopi/nanopineo_pin_map.go
@@ -8,8 +8,8 @@ var neoGpioPins = map[string]gpioPinDefinition{
 	"13": {sysfs: 2, cdev: cdevPin{chip: 0, line: 2}},     // UART2_RTS/GPIOA2
 	"15": {sysfs: 3, cdev: cdevPin{chip: 0, line: 3}},     // UART2_CTS/GPIOA3
 	"12": {sysfs: 6, cdev: cdevPin{chip: 0, line: 6}},     // GPIOA6
-	"19": {sysfs: 64, cdev: cdevPin{chip: 0, line: 64}},   // SPI0_MOSI/GPIOC0
-	"21": {sysfs: 65, cdev: cdevPin{chip: 0, line: 65}},   // SPI0_MISO/GPIOC1
+	"19": {sysfs: 64, cdev: cdevPin{chip: 0, line: 64}},   // SPI0_SDO/GPIOC0
+	"21": {sysfs: 65, cdev: cdevPin{chip: 0, line: 65}},   // SPI0_SDI/GPIOC1
 	"23": {sysfs: 66, cdev: cdevPin{chip: 0, line: 66}},   // SPI0_CLK/GPIOC2
 	"24": {sysfs: 67, cdev: cdevPin{chip: 0, line: 67}},   // SPI0_CS/GPIOC3
 	"8":  {sysfs: 198, cdev: cdevPin{chip: 0, line: 198}}, // UART1_TX/GPIOG6

--- a/platforms/raspi/raspi_adaptor.go
+++ b/platforms/raspi/raspi_adaptor.go
@@ -48,7 +48,7 @@ type Adaptor struct {
 // Optional parameters:
 //
 //	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs (still used by default)
-//	adaptors.WithSpiGpioAccess(sclk, nss, mosi, miso):	use GPIO's instead of /dev/spidev#.#
+//	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //	adaptors.WithGpiosActiveLow(pin's): invert the pin behavior
 //	adaptors.WithGpiosPullUp/Down(pin's): sets the internal pull resistor
 //	adaptors.WithGpiosOpenDrain/Source(pin's): sets the output behavior

--- a/platforms/rockpi/rockpi_adaptor.go
+++ b/platforms/rockpi/rockpi_adaptor.go
@@ -42,7 +42,7 @@ type Adaptor struct {
 // Optional parameters:
 //
 //	adaptors.WithGpiodAccess():	use character device gpiod driver instead of the default sysfs (NOT work on RockPi4C+!)
-//	adaptors.WithSpiGpioAccess(sclk, nss, mosi, miso):	use GPIO's instead of /dev/spidev#.#
+//	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //	adaptors.WithGpiosActiveLow(pin's): invert the pin behavior
 func NewAdaptor(opts ...func(adaptors.DigitalPinsOptioner)) *Adaptor {
 	sys := system.NewAccesser()

--- a/platforms/tinkerboard/adaptor.go
+++ b/platforms/tinkerboard/adaptor.go
@@ -61,7 +61,7 @@ type Adaptor struct {
 // Optional parameters:
 //
 //	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs (still used by default)
-//	adaptors.WithSpiGpioAccess(sclk, nss, mosi, miso):	use GPIO's instead of /dev/spidev#.#
+//	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //	adaptors.WithGpiosActiveLow(pin's): invert the pin behavior
 //	adaptors.WithGpiosPullUp/Down(pin's): sets the internal pull resistor
 //

--- a/platforms/upboard/up2/adaptor.go
+++ b/platforms/upboard/up2/adaptor.go
@@ -55,7 +55,7 @@ type Adaptor struct {
 // Optional parameters:
 //
 //	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs
-//	adaptors.WithSpiGpioAccess(sclk, nss, mosi, miso):	use GPIO's instead of /dev/spidev#.#
+//	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //
 //	Optional parameters for PWM, see [adaptors.NewPWMPinsAdaptor]
 func NewAdaptor(opts ...interface{}) *Adaptor {

--- a/system/GPIO.md
+++ b/system/GPIO.md
@@ -66,8 +66,8 @@ gpiochip0 - 54 lines:
   ...
   line   7:  "SPI_CE1_N"       unused   input  active-high 
   line   8:  "SPI_CE0_N"       unused   input  active-high 
-  line   9:   "SPI_MISO"       unused   input  active-high 
-  line  10:   "SPI_MOSI"       unused   input  active-high 
+  line   9:    "SPI_SDI"       unused   input  active-high
+  line  10:    "SPI_SDO"       unused   input  active-high
   line  11:   "SPI_SCLK"       unused   input  active-high 
   ...
   line  14:       "TXD0"       unused   input  active-high 

--- a/system/I2C.md
+++ b/system/I2C.md
@@ -23,7 +23,7 @@ In general there are different ioctl features for I2C
 > Some calls are branched by kernels [i2c-dev.c:i2cdev_ioctl()](https://elixir.bootlin.com/linux/latest/source/drivers/i2c/i2c-dev.c#L392)
 > to the next listed calls.
 
-Set the device address `ioctl(file, I2C_SLAVE, long addr)`. The call set the address directly to the character device.  
+Set the device address `ioctl(file, I2C_TARGET, long addr)`. The call set the address directly to the character device.
 
 Query the supported functions `ioctl(file, I2C_FUNCS, unsigned long *funcs)`. The call is converted to in-kernel function
 [i2c.h:i2c_get_functionality()](https://elixir.bootlin.com/linux/latest/source/include/linux/i2c.h#L902)

--- a/system/i2c_device.go
+++ b/system/i2c_device.go
@@ -16,9 +16,9 @@ const (
 const (
 	// From  /usr/include/linux/i2c-dev.h:
 	// ioctl signals
-	I2C_SLAVE = 0x0703
-	I2C_FUNCS = 0x0705
-	I2C_SMBUS = 0x0720
+	I2C_TARGET = 0x0703
+	I2C_FUNCS  = 0x0705
+	I2C_SMBUS  = 0x0720
 	// Read/write markers
 	I2C_SMBUS_READ  = 1
 	I2C_SMBUS_WRITE = 0
@@ -371,7 +371,7 @@ func (d *i2cDevice) setAddress(address int) error {
 		return nil
 	}
 
-	if err := d.syscallIoctl(I2C_SLAVE, nil, address, "Setting address"); err != nil {
+	if err := d.syscallIoctl(I2C_TARGET, nil, address, "Setting address"); err != nil {
 		return err
 	}
 	d.lastAddress = address

--- a/system/i2c_device_test.go
+++ b/system/i2c_device_test.go
@@ -34,7 +34,7 @@ func getSyscallFuncImpl(
 				I2C_FUNC_SMBUS_WRITE_WORD_DATA
 		}
 		// set address
-		if (trap == Syscall_SYS_IOCTL) && (a2 == I2C_SLAVE) {
+		if (trap == Syscall_SYS_IOCTL) && (a2 == I2C_TARGET) {
 			if errorMask&0x02 == 0x02 {
 				return 0, 0, 1
 			}

--- a/system/syscall.go
+++ b/system/syscall.go
@@ -39,7 +39,7 @@ func (sys *nativeSyscall) syscall(
 	address uint16,
 ) (r1, r2 uintptr, err SyscallErrno) {
 	var errNo unix.Errno
-	if signal == I2C_SLAVE {
+	if signal == I2C_TARGET {
 		// this is the setup for the address, it just needs to be converted to an uintptr,
 		// the given payload is not used in this case, see the comment on the function
 		r1, r2, errNo = unix.Syscall(trap, f.Fd(), signal, uintptr(address))

--- a/system/syscall_mock.go
+++ b/system/syscall_mock.go
@@ -30,7 +30,7 @@ func (sys *mockSyscall) syscall(
 	sys.lastFile = f        // a character device file (e.g. file to path "/dev/i2c-1")
 	sys.lastSignal = signal // points to used function type (e.g. I2C_SMBUS, I2C_RDWR)
 
-	if signal == I2C_SLAVE {
+	if signal == I2C_TARGET {
 		// this is the setup for the address, it needs to be converted to an uintptr,
 		// the given payload is not used in this case, see the comment on the function used for production
 		sys.devAddress = uintptr(address)

--- a/system/system_options.go
+++ b/system/system_options.go
@@ -10,7 +10,7 @@ import (
 // caller/user when creating the system access, e.g. by "NewAccesser()".
 type Optioner interface {
 	setDigitalPinToGpiodAccess()
-	setSpiToGpioAccess(p gobot.DigitalPinnerProvider, sclkPin, nssPin, mosiPin, misoPin string)
+	setSpiToGpioAccess(p gobot.DigitalPinnerProvider, sclkPin, ncsPin, sdoPin, sdiPin string)
 }
 
 // WithDigitalPinGpiodAccess can be used to change the default sysfs implementation for digital pins to the character
@@ -22,9 +22,9 @@ func WithDigitalPinGpiodAccess() func(Optioner) {
 }
 
 // WithSpiGpioAccess can be used to switch the default SPI implementation to GPIO usage.
-func WithSpiGpioAccess(p gobot.DigitalPinnerProvider, sclkPin, nssPin, mosiPin, misoPin string) func(Optioner) {
+func WithSpiGpioAccess(p gobot.DigitalPinnerProvider, sclkPin, ncsPin, sdoPin, sdiPin string) func(Optioner) {
 	return func(s Optioner) {
-		s.setSpiToGpioAccess(p, sclkPin, nssPin, mosiPin, misoPin)
+		s.setSpiToGpioAccess(p, sclkPin, ncsPin, sdoPin, sdiPin)
 	}
 }
 
@@ -42,13 +42,13 @@ func (a *Accesser) setDigitalPinToGpiodAccess() {
 	}
 }
 
-func (a *Accesser) setSpiToGpioAccess(p gobot.DigitalPinnerProvider, sclkPin, nssPin, mosiPin, misoPin string) {
+func (a *Accesser) setSpiToGpioAccess(p gobot.DigitalPinnerProvider, sclkPin, ncsPin, sdoPin, sdiPin string) {
 	cfg := spiGpioConfig{
 		pinProvider: p,
 		sclkPinID:   sclkPin,
-		nssPinID:    nssPin,
-		mosiPinID:   mosiPin,
-		misoPinID:   misoPin,
+		ncsPinID:    ncsPin,
+		sdoPinID:    sdoPin,
+		sdiPinID:    sdiPin,
 	}
 	gsa := &gpioSpiAccess{cfg: cfg}
 	if gsa.isSupported() {


### PR DESCRIPTION
## Solved issues and/or description of the change

Finally resolves #1013 by removing offensive terminology from code base (with small exceptions when needed).

## Manual test

none

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test_race`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code