### PR TITLE
fix: close tmp file

### DIFF
--- a/system/fs_mock.go
+++ b/system/fs_mock.go
@@ -149,6 +149,7 @@ func (fs *MockFilesystem) stat(name string) (os.FileInfo, error) {
 			log.Println("A")
 			return nil, err
 		}
+		defer tmpFile.Close()
 		defer os.Remove(tmpFile.Name())
 
 		return os.Stat(tmpFile.Name())


### PR DESCRIPTION
## Solved issues and/or description of the change

Closing the file before removing it will prevent problems, e.g. see:
https://stackoverflow.com/questions/63519526/should-i-close-os-file-before-calling-os-removeall

## Manual test

none

## Checklist

- [ ] The PR's target branch is 'hybridgroup:dev'
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (e.g. by run `make test_race`)
- [ ] No linter errors exist locally (e.g. by run `make fmt_check`)
- [ ] I have performed a self-review of my own code