### PR TITLE
examples: correct all usage of ps3 joystick reads

### DIFF
--- a/examples/ardrone_ps3.go
+++ b/examples/ardrone_ps3.go
@@ -50,22 +50,22 @@ func main() {
 		})
 
 		_ = stick.On(joystick.LeftX, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			leftX.Store(val)
 		})
 
 		_ = stick.On(joystick.LeftY, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			leftY.Store(val)
 		})
 
 		_ = stick.On(joystick.RightX, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			rightX.Store(val)
 		})
 
 		_ = stick.On(joystick.RightY, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			rightY.Store(val)
 		})
 

--- a/examples/bebop_ps3.go
+++ b/examples/bebop_ps3.go
@@ -73,22 +73,22 @@ func main() {
 		})
 
 		_ = stick.On(joystick.LeftX, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			leftX.Store(val)
 		})
 
 		_ = stick.On(joystick.LeftY, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			leftY.Store(val)
 		})
 
 		_ = stick.On(joystick.RightX, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			rightX.Store(val)
 		})
 
 		_ = stick.On(joystick.RightY, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			rightY.Store(val)
 		})
 

--- a/examples/bebop_ps3_video.go
+++ b/examples/bebop_ps3_video.go
@@ -139,22 +139,22 @@ func main() {
 			}
 		})
 		_ = stick.On(joystick.LeftX, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			leftX.Store(val)
 		})
 
 		_ = stick.On(joystick.LeftY, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			leftY.Store(val)
 		})
 
 		_ = stick.On(joystick.RightX, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			rightX.Store(val)
 		})
 
 		_ = stick.On(joystick.RightY, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			rightY.Store(val)
 		})
 

--- a/examples/bleclient_minidrone_mambo_ps3.go
+++ b/examples/bleclient_minidrone_mambo_ps3.go
@@ -104,22 +104,22 @@ func main() {
 		})
 
 		_ = stick.On(joystick.LeftX, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			leftX.Store(val)
 		})
 
 		_ = stick.On(joystick.LeftY, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			leftY.Store(val)
 		})
 
 		_ = stick.On(joystick.RightX, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			rightX.Store(val)
 		})
 
 		_ = stick.On(joystick.RightY, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			rightY.Store(val)
 		})
 

--- a/examples/bleclient_minidrone_ps3.go
+++ b/examples/bleclient_minidrone_ps3.go
@@ -93,22 +93,22 @@ func main() {
 		})
 
 		_ = stick.On(joystick.LeftX, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			leftX.Store(val)
 		})
 
 		_ = stick.On(joystick.LeftY, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			leftY.Store(val)
 		})
 
 		_ = stick.On(joystick.RightX, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			rightX.Store(val)
 		})
 
 		_ = stick.On(joystick.RightY, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			rightY.Store(val)
 		})
 

--- a/examples/tello_ps3.go
+++ b/examples/tello_ps3.go
@@ -89,22 +89,22 @@ func main() {
 		})
 
 		_ = stick.On(joystick.LeftX, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			leftX.Store(val)
 		})
 
 		_ = stick.On(joystick.LeftY, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			leftY.Store(val)
 		})
 
 		_ = stick.On(joystick.RightX, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			rightX.Store(val)
 		})
 
 		_ = stick.On(joystick.RightY, func(data interface{}) {
-			val := float64(data.(int16))
+			val := float64(data.(int))
 			rightY.Store(val)
 		})
 


### PR DESCRIPTION
## Solved issues and/or description of the change

This PR correct all usage of ps3 joystick reads, which are now `int` instead of `int16`

## Manual test

- OS and Version (Win/Mac/Linux): Linux
- Adaptor(s) and/or driver(s): Ran `examples/bleclient_minidrone_ps3.go` successfully.

## Checklist

- [X] The PR's target branch is 'hybridgroup:dev'
- [X] New and existing unit tests pass locally with my changes (e.g. by run `make test_race`)
- [X] No linter errors exist locally (e.g. by run `make fmt_check`)
- [X] I have performed a self-review of my own code
