### PR TITLE
firmata: try to stabilize tests

### DIFF
--- a/platforms/firmata/client/client_test.go
+++ b/platforms/firmata/client/client_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const semPublishWait = 20 * time.Millisecond
+const semPublishWait = 30 * time.Millisecond
 
 type readWriteCloser struct {
 	id string


### PR DESCRIPTION
## Solved issues and/or description of the change

Firmata test "TestProcessDigitalRead4" (run "test_platforms") failed several times in succession on the server but works locally. Try to stabilize test by increasing the timeout from 20ms to 30ms.

## Manual test

none

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test_race`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code