### PR TITLE
drivers: fix some function names in comment

### DIFF
--- a/drivers/ble/parrot/minidrone_driver.go
+++ b/drivers/ble/parrot/minidrone_driver.go
@@ -80,7 +80,7 @@ type Pcmd struct {
 	Psi   float32
 }
 
-// NewDriver creates a Parrot Minidrone Driver
+// NewMinidroneDriver creates a Parrot Minidrone Driver
 func NewMinidroneDriver(a gobot.BLEConnector, opts ...ble.OptionApplier) *MinidroneDriver {
 	d := &MinidroneDriver{
 		Pcmd: Pcmd{

--- a/drivers/i2c/bmp180_driver.go
+++ b/drivers/i2c/bmp180_driver.go
@@ -82,7 +82,7 @@ func NewBMP180Driver(c Connector, options ...func(Config)) *BMP180Driver {
 	return d
 }
 
-// WithBMP180oversampling option sets oversampling mode.
+// WithBMP180OversamplingMode option sets oversampling mode.
 // Valid settings are of type "BMP180OversamplingMode"
 func WithBMP180OversamplingMode(val BMP180OversamplingMode) func(Config) {
 	return func(c Config) {

--- a/drivers/i2c/pcf8591_driver.go
+++ b/drivers/i2c/pcf8591_driver.go
@@ -132,7 +132,7 @@ func NewPCF8591Driver(c Connector, options ...func(Config)) *PCF8591Driver {
 	return p
 }
 
-// WithPCF8591With400kbitStabilisation option sets the PCF8591 additionalReadWrite and additionalRead value
+// WithPCF8591With400kbitStabilization option sets the PCF8591 additionalReadWrite and additionalRead value
 func WithPCF8591With400kbitStabilization(additionalReadWrite, additionalRead int) func(Config) {
 	return func(c Config) {
 		p, ok := c.(*PCF8591Driver)
@@ -154,7 +154,7 @@ func WithPCF8591With400kbitStabilization(additionalReadWrite, additionalRead int
 	}
 }
 
-// WithPCF8591ForceWrite option modifies the PCF8591Driver forceRefresh option
+// WithPCF8591ForceRefresh option modifies the PCF8591Driver forceRefresh option
 // Setting to true (1) will force refresh operation to register, although there is no change.
 // Normally this is not needed, so default is off (0).
 // When there is something flaky, there is a small chance to stabilize by setting this flag to true.


### PR DESCRIPTION
## Solved issues and/or description of the change

 fix some function names in comment


## Manual test

not needed

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code