### PR TITLE
gpio(core): fix sporadic hang on finish for discrete edge polling

### DIFF
--- a/system/digitalpin_poll.go
+++ b/system/digitalpin_poll.go
@@ -45,6 +45,9 @@ func startEdgePolling(
 		for {
 			select {
 			case <-quitChan:
+				if !firstLoopDone {
+					wg.Done()
+				}
 				return
 			default:
 				// note: pure reading takes between 30us and 1ms on rasperry Pi1, typically 50us, with sysfs also 500us


### PR DESCRIPTION
## Solved issues and/or description of the change

#1098 

## Manual test

- OS and Version (Win/Mac/Linux): Linux
- Adaptor(s) and/or driver(s): HCSR04 with tinkerboard

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test_race`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code