### PR TITLE
tests: fix for arm64 environment and stabilize

### DIFF
--- a/drivers/aio/grove_temperature_sensor_driver_test.go
+++ b/drivers/aio/grove_temperature_sensor_driver_test.go
@@ -2,7 +2,6 @@
 package aio
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -100,24 +99,37 @@ func TestGroveTemperatureSensor_publishesTemperatureInCelsius(t *testing.T) {
 	a := newAioTestAdaptor()
 	d := NewGroveTemperatureSensorDriver(a, "1", WithSensorCyclicRead(10*time.Millisecond))
 
+	// 584: 31.52208881030674, 585: 31.61532462352477
+	lastRawValue := 584
 	a.analogReadFunc = func() (int, error) {
-		return 585, nil
+		// ensure a changed value on each read, otherwise no event will be published
+		lastRawValue++
+		if lastRawValue > 585 {
+			lastRawValue = 584
+		}
+		return lastRawValue, nil
 	}
 
 	// act: start cyclic reading
 	require.NoError(t, d.Start())
 
+	// wait some time to ensure the cyclic go routine is working
+	time.Sleep(15 * time.Millisecond)
+
+	var eventValue float64
 	_ = d.Once(d.Event(Value), func(data interface{}) {
-		assert.Equal(t, "31.62", fmt.Sprintf("%.2f", data.(float64)))
+		eventValue = data.(float64)
 		sem <- true
 	})
 
-	// assert: value was published
+	// assert: value was published and is in expected delta
 	select {
 	case <-sem:
-	case <-time.After(1 * time.Second):
+		require.NoError(t, d.Halt())
+	case <-time.After(100 * time.Millisecond):
 		require.Fail(t, "Grove Temperature Sensor Event \"Value\" was not published")
 	}
 
-	assert.InDelta(t, 31.61532462352477, d.Temperature(), 0.0)
+	assert.InDelta(t, eventValue, d.Temperature(), 0.0)
+	assert.InDelta(t, 31.61532462352477, d.Temperature(), 31.61532462352477-31.52208881030674)
 }

--- a/drivers/i2c/mpl115a2_driver_test.go
+++ b/drivers/i2c/mpl115a2_driver_test.go
@@ -90,7 +90,7 @@ func TestMPL115A2ReadData(t *testing.T) {
 	assert.Equal(t, uint8(0x12), a.written[3])
 	assert.Equal(t, uint8(0x00), a.written[4])
 	assert.Equal(t, uint8(0x00), a.written[5])
-	assert.InDelta(t, float32(96.585915), press, 0.0)
+	assert.InDelta(t, float32(96.585915), press, 1.0e-5)
 	assert.InDelta(t, float32(23.317757), temp, 0.0)
 }
 

--- a/drivers/i2c/sht2x_driver_test.go
+++ b/drivers/i2c/sht2x_driver_test.go
@@ -78,7 +78,7 @@ func TestSHT2xMeasurements(t *testing.T) {
 	_ = d.Start()
 	temp, err := d.Temperature()
 	require.NoError(t, err)
-	assert.InDelta(t, float32(18.809052), temp, 0.0)
+	assert.InDelta(t, float32(18.809052), temp, 1.0e-5)
 	hum, err := d.Humidity()
 	require.NoError(t, err)
 	assert.InDelta(t, float32(40.279907), hum, 0.0)


### PR DESCRIPTION
## Solved issues and/or description of the change

Some unit tests with float numbers fail when running in arm64 environment. Some event based unit tests are known to be flaky. This PR covers both problems.

## Manual test

- OS and Version (Win/Mac/Linux): Linux
- Adaptor(s) and/or driver(s): none

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test_race`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code