### PR TITLE
GPIO: rename gpiod to cdev

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,11 +1,52 @@
-# Migration of drivers
+# Migration guide
 
 From time to time a breaking change of API can happen. Following to [SemVer](https://semver.org/), the gobot main version
 should be increased. In such case all users needs to adjust there projects for the next update, although they not using
-a driver with changed API.
+a driver or platform with changed API.
 
-To prevent this scenario for most users, the main version will not always increased, but affected drivers are listed
-here and a migration strategy is provided.
+To prevent this scenario for most users, the main version will not always increased, but affected drivers and platforms
+are listed here and a migration strategy is provided.
+
+## Switch from version 2.4.0 (applications using the gpiod options affected)
+
+### The term gpiod was renamed to cdev
+
+Using the term "cdev" (short for character device Kernel ABI for GPIO access) is more suitable than using "gpiod" (the
+name of the user space driver in Linux). Also it relates better to the term "sysfs" (the legacy sysfs Kernel ABI for
+GPIO access). The former name was chosen so there would be no difference to the used go module "gpiod". Since also this
+module is now renamed to "go-gpiocdev", we choose the better name "cdev" from now on.
+
+This change affects all applications, which using the With... options of "gpiod" or "sysfs". A search and replace is
+suitable:
+
+```go
+// old
+...
+  a := NewAdaptor(adaptors.WithGpiodAccess())
+...
+
+// new
+...
+  a := NewAdaptor(adaptors.WithGpioCdevAccess())
+...
+```
+
+```go
+// old
+...
+  a := NewAdaptor(adaptors.WithSysfsAccess())
+...
+
+// new
+...
+  a := NewAdaptor(adaptors.WithGpioSysfsAccess())
+...
+```
+
+Also those findings needs to be replaced, which usually affects developers, but not users:
+
+* `system.WithDigitalPinGpiodAccess()` --> `system.WithDigitalPinCdevAccess()`
+* `IsGpiodDigitalPinAccess()` --> `IsCdevDigitalPinAccess()`
 
 ## Switch from version 2.3.0 (ble and sphero adaptors affected)
 

--- a/adaptor.go
+++ b/adaptor.go
@@ -29,7 +29,7 @@ type DigitalPinOptioner interface {
 		lseqno uint32), edge int) (changed bool)
 	// SetPollForEdgeDetection use a discrete input polling method to detect edges. A poll interval of zero or smaller
 	// will deactivate this function. Please note: Using this feature is CPU consuming and less accurate than using cdev
-	// event handler (gpiod implementation) and should be done only if the former is not implemented or not working for
+	// event handler (go-gpiocdev package) and should be done only if the former is not implemented or not working for
 	// the adaptor. E.g. sysfs driver in gobot has not implemented edge detection yet. The function is only useful
 	// together with SetEventHandlerForEdge() and its corresponding With*() functions.
 	SetPollForEdgeDetection(pollInterval time.Duration, pollQuitChan chan struct{}) (changed bool)

--- a/drivers/gpio/hcsr04_driver.go
+++ b/drivers/gpio/hcsr04_driver.go
@@ -36,7 +36,7 @@ type hcsr04Configuration struct {
 }
 
 // hcsr04UseEdgePollingOption is the type for applying to use discrete edge polling instead pin edge detection
-// by "cdev" from gpiod.
+// by "cdev" from the go-gpiocdev package.
 type hcsr04UseEdgePollingOption bool
 
 // HCSR04Driver is a driver for ultrasonic range measurement.
@@ -132,7 +132,7 @@ func NewHCSR04Driver(a gobot.Adaptor, triggerPinID, echoPinID string, opts ...in
 	return &d
 }
 
-// WithHCSR04UseEdgePolling use discrete edge polling instead pin edge detection by "cdev" from gpiod.
+// WithHCSR04UseEdgePolling use discrete edge polling instead pin edge detection by "cdev" from the go-gpiocdev package.
 func WithHCSR04UseEdgePolling() hcsr04OptionApplier {
 	return hcsr04UseEdgePollingOption(true)
 }

--- a/platforms/adaptors/digitalpinsadaptor.go
+++ b/platforms/adaptors/digitalpinsadaptor.go
@@ -66,7 +66,7 @@ type DigitalPinsAdaptor struct {
 	mutex          sync.Mutex
 }
 
-// NewDigitalPinsAdaptor provides the access to digital pins of the board. It supports sysfs and gpiod system drivers.
+// NewDigitalPinsAdaptor provides the access to digital pins of the board. It supports sysfs and cdev system drivers.
 // This is decided by the given accesser. The translator is used to adapt the pin header naming, which is given by user,
 // to the internal file name or chip/line nomenclature. This varies by each platform. If for some reasons the default
 // initializer is not suitable, it can be given by the option "WithDigitalPinInitializer()". This is especially needed,
@@ -92,15 +92,15 @@ func WithDigitalPinInitializer(pc digitalPinInitializer) digitalPinsInitializeOp
 	return digitalPinsInitializeOption(pc)
 }
 
-// WithGpiodAccess can be used to change the default legacy sysfs implementation to the character device Kernel ABI,
-// provided by the gpiod package.
-func WithGpiodAccess() digitalPinsSystemSysfsOption {
+// WithGpioCdevAccess can be used to change the default legacy sysfs implementation to the character device Kernel ABI,
+// provided by the go-gpiocdev package.
+func WithGpioCdevAccess() digitalPinsSystemSysfsOption {
 	return digitalPinsSystemSysfsOption(false)
 }
 
-// WithSysfsAccess can be used to change the default character device implementation, provided by the gpiod package, to
-// the legacy sysfs Kernel ABI.
-func WithSysfsAccess() digitalPinsSystemSysfsOption {
+// WithGpioSysfsAccess can be used to change the default character device implementation, provided by the go-gpiocdev
+// package, to the legacy sysfs Kernel ABI.
+func WithGpioSysfsAccess() digitalPinsSystemSysfsOption {
 	return digitalPinsSystemSysfsOption(true)
 }
 
@@ -206,7 +206,7 @@ func (a *DigitalPinsAdaptor) Connect() error {
 		if *cfg.useSysfs {
 			system.WithDigitalPinSysfsAccess()(a.sys)
 		} else {
-			system.WithDigitalPinGpiodAccess()(a.sys)
+			system.WithDigitalPinCdevAccess()(a.sys)
 		}
 	}
 

--- a/platforms/adaptors/digitalpinsadaptor_test.go
+++ b/platforms/adaptors/digitalpinsadaptor_test.go
@@ -63,7 +63,7 @@ func TestNewDigitalPinsAdaptor(t *testing.T) {
 	assert.NotNil(t, a.translate)
 	assert.Nil(t, a.pins)       // will be created on connect
 	assert.Nil(t, a.pinOptions) // will be created on connect
-	assert.True(t, a.sys.IsGpiodDigitalPinAccess())
+	assert.True(t, a.sys.IsCdevDigitalPinAccess())
 }
 
 func TestDigitalPinsConnect(t *testing.T) {

--- a/platforms/adaptors/digitalpinsadaptoroptions.go
+++ b/platforms/adaptors/digitalpinsadaptoroptions.go
@@ -80,7 +80,7 @@ func (o digitalPinsInitializeOption) String() string {
 }
 
 func (o digitalPinsSystemSysfsOption) String() string {
-	return "use gpiod system access option for digital pins"
+	return "use sysfs vs. cdev system access option for digital pins"
 }
 
 func (o digitalPinsForSystemSpiOption) String() string {

--- a/platforms/adaptors/digitalpinsadaptoroptions_test.go
+++ b/platforms/adaptors/digitalpinsadaptoroptions_test.go
@@ -53,16 +53,16 @@ func TestDigitalPinsWithSysfsAccess(t *testing.T) {
 	// arrange
 	a := NewDigitalPinsAdaptor(system.NewAccesser(), nil)
 	require.NoError(t, a.Connect())
-	require.True(t, a.sys.IsGpiodDigitalPinAccess())
+	require.True(t, a.sys.IsCdevDigitalPinAccess())
 	require.NoError(t, a.Finalize())
 	// act, connect is mandatory to set options to the system
-	WithSysfsAccess().apply(a.digitalPinsCfg)
+	WithGpioSysfsAccess().apply(a.digitalPinsCfg)
 	require.NoError(t, a.Connect())
 	// assert
 	assert.True(t, a.sys.IsSysfsDigitalPinAccess())
 }
 
-func TestDigitalPinsWithGpiodAccess(t *testing.T) {
+func TestDigitalPinsWithCdevAccess(t *testing.T) {
 	// arrange
 	a := NewDigitalPinsAdaptor(system.NewAccesser(system.WithDigitalPinSysfsAccess()), nil)
 	require.NoError(t, a.Connect())
@@ -71,10 +71,10 @@ func TestDigitalPinsWithGpiodAccess(t *testing.T) {
 	// we have to mock the fs at this point to ensure the option can be applied on each test environment
 	a.sys.UseMockFilesystem([]string{"/dev/gpiochip0"})
 	// act, connect is mandatory to set options to the system
-	WithGpiodAccess().apply(a.digitalPinsCfg)
+	WithGpioCdevAccess().apply(a.digitalPinsCfg)
 	require.NoError(t, a.Connect())
 	// assert
-	assert.True(t, a.sys.IsGpiodDigitalPinAccess())
+	assert.True(t, a.sys.IsCdevDigitalPinAccess())
 }
 
 func TestDigitalReadWithGpiosActiveLow(t *testing.T) {

--- a/platforms/beaglebone/beaglebone_adaptor.go
+++ b/platforms/beaglebone/beaglebone_adaptor.go
@@ -45,7 +45,7 @@ type Adaptor struct {
 //
 // Optional parameters:
 //
-//	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs
+//	adaptors.WithGpioCdevAccess():	use character device driver instead of sysfs
 //	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //
 //	Optional parameters for PWM, see [adaptors.NewPWMPinsAdaptor]

--- a/platforms/beaglebone/pocketbeagle_adaptor.go
+++ b/platforms/beaglebone/pocketbeagle_adaptor.go
@@ -16,7 +16,7 @@ type PocketBeagleAdaptor struct {
 // NewPocketBeagleAdaptor creates a new Adaptor for the PocketBeagle
 // Optional parameters:
 //
-//	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs
+//	adaptors.WithGpioCdevAccess():	use character device driver instead of sysfs
 //	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //
 //	Optional parameters for PWM, see [adaptors.NewPWMPinsAdaptor]

--- a/platforms/beaglebone/pocketbeagle_adaptor_test.go
+++ b/platforms/beaglebone/pocketbeagle_adaptor_test.go
@@ -26,10 +26,10 @@ func TestNewPocketBeagleAdaptor(t *testing.T) {
 
 func TestNewPocketBeagleAdaptorWithOption(t *testing.T) {
 	// arrange & act
-	a := NewPocketBeagleAdaptor(adaptors.WithGpiodAccess())
+	a := NewPocketBeagleAdaptor(adaptors.WithGpioCdevAccess())
 	// we have to mock the fs at this point to ensure the option can be applied on each test environment
 	a.sys.UseMockFilesystem([]string{"/dev/gpiochip0"})
 	// assert
 	require.NoError(t, a.Connect())
-	assert.True(t, a.sys.IsGpiodDigitalPinAccess())
+	assert.True(t, a.sys.IsCdevDigitalPinAccess())
 }

--- a/platforms/chip/chip_adaptor.go
+++ b/platforms/chip/chip_adaptor.go
@@ -40,7 +40,7 @@ type Adaptor struct {
 //
 // Optional parameters:
 //
-//	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs
+//	adaptors.WithGpioCdevAccess():	use character device driver instead of sysfs
 //	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //
 //	Optional parameters for PWM, see [adaptors.NewPWMPinsAdaptor]

--- a/platforms/dragonboard/dragonboard_adaptor.go
+++ b/platforms/dragonboard/dragonboard_adaptor.go
@@ -48,7 +48,7 @@ var fixedPins = map[string]int{
 //
 // Optional parameters:
 //
-//	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs
+//	adaptors.WithGpioCdevAccess():	use character device driver instead of sysfs
 //	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 func NewAdaptor(opts ...adaptors.DigitalPinsOptionApplier) *Adaptor {
 	sys := system.NewAccesser(system.WithDigitalPinSysfsAccess())

--- a/platforms/intel-iot/joule/joule_adaptor.go
+++ b/platforms/intel-iot/joule/joule_adaptor.go
@@ -32,7 +32,7 @@ type Adaptor struct {
 //
 // Optional parameters:
 //
-//	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs
+//	adaptors.WithGpioCdevAccess():	use character device driver instead of sysfs
 //	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //
 //	Optional parameters for PWM, see [adaptors.NewPWMPinsAdaptor]

--- a/platforms/jetson/jetson_adaptor.go
+++ b/platforms/jetson/jetson_adaptor.go
@@ -40,7 +40,7 @@ type Adaptor struct {
 //
 // Optional parameters:
 //
-//	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs
+//	adaptors.WithGpioCdevAccess():	use character device driver instead of sysfs
 //	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //
 //	Optional parameters for PWM, see [adaptors.NewPWMPinsAdaptor]

--- a/platforms/nanopi/nanopi_adaptor.go
+++ b/platforms/nanopi/nanopi_adaptor.go
@@ -37,7 +37,7 @@ type Adaptor struct {
 //
 // Optional parameters:
 //
-//	adaptors.WithSysfsAccess():	use legacy sysfs driver instead of default character device gpiod
+//	adaptors.WithGpioSysfsAccess():	use legacy sysfs driver instead of default character device driver
 //	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //	adaptors.WithGpiosActiveLow(pin's): invert the pin behavior
 //	adaptors.WithGpiosPullUp/Down(pin's): sets the internal pull resistor

--- a/platforms/nanopi/nanopi_adaptor_test.go
+++ b/platforms/nanopi/nanopi_adaptor_test.go
@@ -85,7 +85,7 @@ func TestNewAdaptor(t *testing.T) {
 	assert.NotNil(t, a.PWMPinsAdaptor)
 	assert.NotNil(t, a.I2cBusAdaptor)
 	assert.NotNil(t, a.SpiBusAdaptor)
-	assert.True(t, a.sys.IsGpiodDigitalPinAccess())
+	assert.True(t, a.sys.IsCdevDigitalPinAccess())
 	// act & assert
 	a.SetName("NewName")
 	assert.Equal(t, "NewName", a.Name())
@@ -93,7 +93,7 @@ func TestNewAdaptor(t *testing.T) {
 
 func TestNewAdaptorWithOption(t *testing.T) {
 	// arrange & act
-	a := NewNeoAdaptor(adaptors.WithGpiosActiveLow("1"), adaptors.WithSysfsAccess())
+	a := NewNeoAdaptor(adaptors.WithGpiosActiveLow("1"), adaptors.WithGpioSysfsAccess())
 	// assert
 	require.NoError(t, a.Connect())
 	assert.True(t, a.sys.IsSysfsDigitalPinAccess())
@@ -104,7 +104,7 @@ func TestDigitalIO(t *testing.T) {
 	// arrange
 	a := initConnectedTestAdaptor()
 	dpa := a.sys.UseMockDigitalPinAccess()
-	require.True(t, a.sys.IsGpiodDigitalPinAccess())
+	require.True(t, a.sys.IsCdevDigitalPinAccess())
 	// act & assert write
 	err := a.DigitalWrite("7", 1)
 	require.NoError(t, err)
@@ -125,7 +125,7 @@ func TestDigitalIO(t *testing.T) {
 func TestDigitalIOSysfs(t *testing.T) {
 	// some basic tests, further tests are done in "digitalpinsadaptor.go"
 	// arrange
-	a := NewNeoAdaptor(adaptors.WithSysfsAccess())
+	a := NewNeoAdaptor(adaptors.WithGpioSysfsAccess())
 	require.NoError(t, a.Connect())
 	dpa := a.sys.UseMockDigitalPinAccess()
 	require.True(t, a.sys.IsSysfsDigitalPinAccess())
@@ -274,7 +274,7 @@ func TestFinalizeErrorAfterGPIO(t *testing.T) {
 	// arrange
 	a := initConnectedTestAdaptor()
 	dpa := a.sys.UseMockDigitalPinAccess()
-	require.True(t, a.sys.IsGpiodDigitalPinAccess())
+	require.True(t, a.sys.IsCdevDigitalPinAccess())
 	require.NoError(t, a.DigitalWrite("7", 1))
 	dpa.UseUnexportError("gpiochip0", "203")
 	// act

--- a/platforms/raspi/raspi_adaptor.go
+++ b/platforms/raspi/raspi_adaptor.go
@@ -40,7 +40,7 @@ type Adaptor struct {
 //
 // Optional parameters:
 //
-//	adaptors.WithSysfsAccess():	use legacy sysfs driver instead of default character device gpiod
+//	adaptors.WithGpioSysfsAccess():	use legacy sysfs driver instead of default character device driver
 //	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //	adaptors.WithGpiosActiveLow(pin's): invert the pin behavior
 //	adaptors.WithGpiosPullUp/Down(pin's): sets the internal pull resistor

--- a/platforms/raspi/raspi_adaptor_test.go
+++ b/platforms/raspi/raspi_adaptor_test.go
@@ -84,7 +84,7 @@ func TestNewAdaptor(t *testing.T) {
 	assert.NotNil(t, a.PWMPinsAdaptor)
 	assert.NotNil(t, a.I2cBusAdaptor)
 	assert.NotNil(t, a.SpiBusAdaptor)
-	assert.True(t, a.sys.IsGpiodDigitalPinAccess())
+	assert.True(t, a.sys.IsCdevDigitalPinAccess())
 	// act & assert
 	a.SetName("NewName")
 	assert.Equal(t, "NewName", a.Name())
@@ -92,7 +92,7 @@ func TestNewAdaptor(t *testing.T) {
 
 func TestNewAdaptorWithOption(t *testing.T) {
 	// arrange & act
-	a := NewAdaptor(adaptors.WithGpiosActiveLow("1"), adaptors.WithSysfsAccess())
+	a := NewAdaptor(adaptors.WithGpiosActiveLow("1"), adaptors.WithGpioSysfsAccess())
 	// assert
 	require.NoError(t, a.Connect())
 	assert.True(t, a.sys.IsSysfsDigitalPinAccess())
@@ -283,7 +283,7 @@ func TestDigitalIO(t *testing.T) {
 		panic(err)
 	}
 	dpa := a.sys.UseMockDigitalPinAccess()
-	require.True(t, a.sys.IsGpiodDigitalPinAccess())
+	require.True(t, a.sys.IsCdevDigitalPinAccess())
 	// act & assert write
 	_ = a.DigitalWrite("7", 1)
 	assert.Equal(t, []int{1}, dpa.Written("gpiochip0", "4"))

--- a/platforms/rockpi/rockpi_adaptor.go
+++ b/platforms/rockpi/rockpi_adaptor.go
@@ -40,7 +40,7 @@ type Adaptor struct {
 //
 // Optional parameters:
 //
-//	adaptors.WithGpiodAccess():	use character device gpiod driver instead of the default sysfs (NOT work on RockPi4C+!)
+//	adaptors.WithGpioCdevAccess():	use character device driver instead of the default sysfs (NOT work on RockPi4C+!)
 //	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //	adaptors.WithGpiosActiveLow(pin's): invert the pin behavior
 func NewAdaptor(opts ...adaptors.DigitalPinsOptionApplier) *Adaptor {

--- a/platforms/tinkerboard/adaptor.go
+++ b/platforms/tinkerboard/adaptor.go
@@ -38,7 +38,7 @@ type Adaptor struct {
 //
 // Optional parameters:
 //
-//	adaptors.WithSysfsAccess():	use legacy sysfs driver instead of default character device gpiod
+//	adaptors.WithGpioSysfsAccess():	use legacy sysfs driver instead of default character device driver
 //	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //	adaptors.WithGpiosActiveLow(pin's): invert the pin behavior
 //	adaptors.WithGpiosPullUp/Down(pin's): sets the internal pull resistor

--- a/platforms/tinkerboard/adaptor_test.go
+++ b/platforms/tinkerboard/adaptor_test.go
@@ -87,7 +87,7 @@ func TestNewAdaptor(t *testing.T) {
 	assert.NotNil(t, a.I2cBusAdaptor)
 	assert.NotNil(t, a.SpiBusAdaptor)
 	assert.NotNil(t, a.OneWireBusAdaptor)
-	assert.True(t, a.sys.IsGpiodDigitalPinAccess())
+	assert.True(t, a.sys.IsCdevDigitalPinAccess())
 	// act & assert
 	a.SetName("NewName")
 	assert.Equal(t, "NewName", a.Name())
@@ -95,7 +95,7 @@ func TestNewAdaptor(t *testing.T) {
 
 func TestNewAdaptorWithOption(t *testing.T) {
 	// arrange & act
-	a := NewAdaptor(adaptors.WithGpiosActiveLow("1"), adaptors.WithSysfsAccess())
+	a := NewAdaptor(adaptors.WithGpiosActiveLow("1"), adaptors.WithGpioSysfsAccess())
 	// assert
 	require.NoError(t, a.Connect())
 	assert.True(t, a.sys.IsSysfsDigitalPinAccess())
@@ -106,7 +106,7 @@ func TestDigitalIO(t *testing.T) {
 	// arrange
 	a := initConnectedTestAdaptor()
 	dpa := a.sys.UseMockDigitalPinAccess()
-	require.True(t, a.sys.IsGpiodDigitalPinAccess())
+	require.True(t, a.sys.IsCdevDigitalPinAccess())
 	// act & assert write
 	err := a.DigitalWrite("7", 1)
 	require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestDigitalIO(t *testing.T) {
 func TestDigitalIOSysfs(t *testing.T) {
 	// some basic tests, further tests are done in "digitalpinsadaptor.go"
 	// arrange
-	a := NewAdaptor(adaptors.WithSysfsAccess())
+	a := NewAdaptor(adaptors.WithGpioSysfsAccess())
 	require.NoError(t, a.Connect())
 	dpa := a.sys.UseMockDigitalPinAccess()
 	require.True(t, a.sys.IsSysfsDigitalPinAccess())
@@ -262,7 +262,7 @@ func TestFinalizeErrorAfterGPIO(t *testing.T) {
 	// arrange
 	a := initConnectedTestAdaptor()
 	dpa := a.sys.UseMockDigitalPinAccess()
-	require.True(t, a.sys.IsGpiodDigitalPinAccess())
+	require.True(t, a.sys.IsCdevDigitalPinAccess())
 	require.NoError(t, a.DigitalWrite("7", 1))
 	dpa.UseUnexportError("gpiochip0", "17")
 	// act

--- a/platforms/tinkerboard/tinkerboard2/adaptor.go
+++ b/platforms/tinkerboard/tinkerboard2/adaptor.go
@@ -28,7 +28,7 @@ type Tinkerboard2Adaptor struct {
 //
 // Optional parameters:
 //
-//	adaptors.WithSysfsAccess():	use legacy sysfs driver instead of default character device gpiod
+//	adaptors.WithGpioSysfsAccess():	use legacy sysfs driver instead of default character device driver
 //	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //	adaptors.WithGpiosActiveLow(pin's): invert the pin behavior
 //	adaptors.WithGpiosPullUp/Down(pin's): sets the internal pull resistor

--- a/platforms/tinkerboard/tinkerboard2/adaptor_test.go
+++ b/platforms/tinkerboard/tinkerboard2/adaptor_test.go
@@ -21,7 +21,7 @@ func TestNewAdaptor(t *testing.T) {
 	assert.NotNil(t, a.PWMPinsAdaptor)
 	assert.NotNil(t, a.I2cBusAdaptor)
 	assert.NotNil(t, a.SpiBusAdaptor)
-	assert.True(t, a.sys.IsGpiodDigitalPinAccess())
+	assert.True(t, a.sys.IsCdevDigitalPinAccess())
 	// act & assert
 	a.SetName("NewName")
 	assert.Equal(t, "NewName", a.Name())
@@ -29,7 +29,7 @@ func TestNewAdaptor(t *testing.T) {
 
 func TestNewAdaptorWithOption(t *testing.T) {
 	// arrange & act
-	a := NewAdaptor(adaptors.WithGpiosActiveLow("1"), adaptors.WithSysfsAccess())
+	a := NewAdaptor(adaptors.WithGpiosActiveLow("1"), adaptors.WithGpioSysfsAccess())
 	// assert
 	require.NoError(t, a.Connect())
 	assert.True(t, a.sys.IsSysfsDigitalPinAccess())

--- a/platforms/upboard/up2/adaptor.go
+++ b/platforms/upboard/up2/adaptor.go
@@ -54,7 +54,7 @@ type Adaptor struct {
 //
 // Optional parameters:
 //
-//	adaptors.WithGpiodAccess():	use character device gpiod driver instead of sysfs
+//	adaptors.WithGpioCdevAccess():	use character device driver instead of sysfs
 //	adaptors.WithSpiGpioAccess(sclk, ncs, sdo, sdi):	use GPIO's instead of /dev/spidev#.#
 //
 //	Optional parameters for PWM, see [adaptors.NewPWMPinsAdaptor]

--- a/system/digitalpin_access.go
+++ b/system/digitalpin_access.go
@@ -11,8 +11,8 @@ type sysfsDigitalPinAccess struct {
 	sfa *sysfsFileAccess
 }
 
-// gpiodDigitalPinAccess represents the character device implementation
-type gpiodDigitalPinAccess struct {
+// cdevDigitalPinAccess represents the character device implementation
+type cdevDigitalPinAccess struct {
 	fs    filesystem
 	chips []string
 }
@@ -36,11 +36,11 @@ func (dpa *sysfsDigitalPinAccess) setFs(fs filesystem) {
 	dpa.sfa = &sysfsFileAccess{fs: fs, readBufLen: 2}
 }
 
-func (dpa *gpiodDigitalPinAccess) isType(accesserType digitalPinAccesserType) bool {
-	return accesserType == digitalPinAccesserTypeGpiod
+func (dpa *cdevDigitalPinAccess) isType(accesserType digitalPinAccesserType) bool {
+	return accesserType == digitalPinAccesserTypeCdev
 }
 
-func (dpa *gpiodDigitalPinAccess) isSupported() bool {
+func (dpa *cdevDigitalPinAccess) isSupported() bool {
 	chips, err := dpa.fs.find("/dev", "gpiochip")
 	if err != nil || len(chips) == 0 {
 		return false
@@ -49,12 +49,12 @@ func (dpa *gpiodDigitalPinAccess) isSupported() bool {
 	return true
 }
 
-func (dpa *gpiodDigitalPinAccess) createPin(chip string, pin int,
+func (dpa *cdevDigitalPinAccess) createPin(chip string, pin int,
 	o ...func(gobot.DigitalPinOptioner) bool,
 ) gobot.DigitalPinner {
-	return newDigitalPinGpiod(chip, pin, o...)
+	return newDigitalPinCdev(chip, pin, o...)
 }
 
-func (dpa *gpiodDigitalPinAccess) setFs(fs filesystem) {
+func (dpa *cdevDigitalPinAccess) setFs(fs filesystem) {
 	dpa.fs = fs
 }

--- a/system/digitalpin_access_test.go
+++ b/system/digitalpin_access_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_isSupportedSysfs(t *testing.T) {
+func Test_isSupported_sysfs(t *testing.T) {
 	// arrange
 	dpa := sysfsDigitalPinAccess{}
 	// act
@@ -16,7 +16,7 @@ func Test_isSupportedSysfs(t *testing.T) {
 	assert.True(t, got)
 }
 
-func Test_isSupportedGpiod(t *testing.T) {
+func Test_isSupported_cdev(t *testing.T) {
 	tests := map[string]struct {
 		mockPaths []string
 		want      bool
@@ -34,7 +34,7 @@ func Test_isSupportedGpiod(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// arrange
 			fs := newMockFilesystem(tc.mockPaths)
-			dpa := gpiodDigitalPinAccess{fs: fs}
+			dpa := cdevDigitalPinAccess{fs: fs}
 			// act
 			got := dpa.isSupported()
 			// assert
@@ -55,24 +55,24 @@ func Test_createAsSysfs(t *testing.T) {
 	assert.Equal(t, "gpio8", dps.label)
 }
 
-func Test_createAsGpiod(t *testing.T) {
+func Test_createPin_cdev(t *testing.T) {
 	// arrange
 	const (
 		pin   = 18
 		label = "gobotio18"
 		chip  = "gpiochip1"
 	)
-	dpa := gpiodDigitalPinAccess{}
+	dpa := cdevDigitalPinAccess{}
 	// act
 	dp := dpa.createPin(chip, 18)
 	// assert
 	assert.NotNil(t, dp)
-	dpg := dp.(*digitalPinGpiod)
+	dpg := dp.(*digitalPinCdev)
 	assert.Equal(t, label, dpg.label)
 	assert.Equal(t, chip, dpg.chipName)
 }
 
-func Test_createPinWithOptionsSysfs(t *testing.T) {
+func Test_createPin_WithOptions_sysfs(t *testing.T) {
 	// This is a general test, that options are applied by using "create" with the WithPinLabel() option.
 	// All other configuration options will be tested in tests for "digitalPinConfig".
 	//
@@ -86,16 +86,16 @@ func Test_createPinWithOptionsSysfs(t *testing.T) {
 	assert.Equal(t, label, dps.label)
 }
 
-func Test_createPinWithOptionsGpiod(t *testing.T) {
+func Test_createPin_WithOptions_cdev(t *testing.T) {
 	// This is a general test, that options are applied by using "create" with the WithPinLabel() option.
 	// All other configuration options will be tested in tests for "digitalPinConfig".
 	//
 	// arrange
-	const label = "my gpiod label"
-	dpa := gpiodDigitalPinAccess{}
+	const label = "my cdev label"
+	dpa := cdevDigitalPinAccess{}
 	// act
 	dp := dpa.createPin("", 19, WithPinLabel(label))
-	dpg := dp.(*digitalPinGpiod)
+	dpg := dp.(*digitalPinCdev)
 	// assert
 	assert.Equal(t, label, dpg.label)
 	// test fallback for empty chip

--- a/system/digitalpin_config.go
+++ b/system/digitalpin_config.go
@@ -239,7 +239,7 @@ func (d *digitalPinConfig) SetEventHandlerForEdge(
 
 // SetPollForEdgeDetection use a discrete input polling method to detect edges. A poll interval of zero or smaller
 // will deactivate this function. Please note: Using this feature is CPU consuming and less accurate than using cdev
-// event handler (gpiod implementation) and should be done only if the former is not implemented or not working for
+// event handler (go-gpiocdev package) and should be done only if the former is not implemented or not working for
 // the adaptor. E.g. sysfs driver in gobot has not implemented edge detection yet. The function is only useful
 // together with SetEventHandlerForEdge() and its corresponding With*() functions.
 // The function is intended to use by WithPinPollForEdgeDetection().

--- a/system/system.go
+++ b/system/system.go
@@ -13,7 +13,7 @@ const systemDebug = false
 type digitalPinAccesserType int
 
 const (
-	digitalPinAccesserTypeGpiod digitalPinAccesserType = iota
+	digitalPinAccesserTypeCdev digitalPinAccesserType = iota
 	digitalPinAccesserTypeSysfs
 )
 
@@ -81,7 +81,7 @@ func NewAccesser(options ...func(Optioner)) *Accesser {
 		fs:  &nativeFilesystem{},
 	}
 	a.spiAccess = &periphioSpiAccess{fs: a.fs}
-	a.digitalPinAccess = &gpiodDigitalPinAccess{fs: a.fs}
+	a.digitalPinAccess = &cdevDigitalPinAccess{fs: a.fs}
 	for _, option := range options {
 		if option == nil {
 			continue
@@ -132,9 +132,9 @@ func (a *Accesser) IsSysfsDigitalPinAccess() bool {
 	return a.digitalPinAccess.isType(digitalPinAccesserTypeSysfs)
 }
 
-// IsGpiodDigitalPinAccess returns whether the used digital pin accesser is a sysfs one.
-func (a *Accesser) IsGpiodDigitalPinAccess() bool {
-	return a.digitalPinAccess.isType(digitalPinAccesserTypeGpiod)
+// IsCdevDigitalPinAccess returns whether the used digital pin accesser is a sysfs one.
+func (a *Accesser) IsCdevDigitalPinAccess() bool {
+	return a.digitalPinAccess.isType(digitalPinAccesserTypeCdev)
 }
 
 // NewPWMPin returns a new system PWM pin, according to the given pin number.

--- a/system/system_options.go
+++ b/system/system_options.go
@@ -10,16 +10,16 @@ import (
 // caller/user when creating the system access, e.g. by "NewAccesser()".
 // TODO: change to applier-architecture, see options of pwmpinsadaptor.go
 type Optioner interface {
-	setDigitalPinToGpiodAccess()
+	setDigitalPinToCdevAccess()
 	setDigitalPinToSysfsAccess()
 	setSpiToGpioAccess(p gobot.DigitalPinnerProvider, sclkPin, ncsPin, sdoPin, sdiPin string)
 }
 
-// WithDigitalPinGpiodAccess can be used to change the default sysfs implementation for digital pins to the character
-// device Kernel ABI. The access is provided by the gpiod package.
-func WithDigitalPinGpiodAccess() func(Optioner) {
+// WithDigitalPinCdevAccess can be used to change the default sysfs implementation for digital pins to the character
+// device Kernel ABI. The access is provided by the go-gpiocdev package.
+func WithDigitalPinCdevAccess() func(Optioner) {
 	return func(s Optioner) {
-		s.setDigitalPinToGpiodAccess()
+		s.setDigitalPinToCdevAccess()
 	}
 }
 
@@ -38,18 +38,18 @@ func WithSpiGpioAccess(p gobot.DigitalPinnerProvider, sclkPin, ncsPin, sdoPin, s
 	}
 }
 
-func (a *Accesser) setDigitalPinToGpiodAccess() {
-	dpa := &gpiodDigitalPinAccess{fs: a.fs}
+func (a *Accesser) setDigitalPinToCdevAccess() {
+	dpa := &cdevDigitalPinAccess{fs: a.fs}
 	if dpa.isSupported() {
 		a.digitalPinAccess = dpa
 		if systemDebug {
-			fmt.Printf("use gpiod driver for digital pins with this chips: %v\n", dpa.chips)
+			fmt.Printf("use cdev driver for digital pins with this chips: %v\n", dpa.chips)
 		}
 
 		return
 	}
 	if systemDebug {
-		fmt.Println("gpiod driver not supported, fallback to sysfs")
+		fmt.Println("cdev driver not supported, fallback to sysfs driver")
 	}
 }
 
@@ -64,7 +64,7 @@ func (a *Accesser) setDigitalPinToSysfsAccess() {
 		return
 	}
 	if systemDebug {
-		fmt.Println("sysfs driver not supported, fallback to gpiod")
+		fmt.Println("sysfs driver not supported, fallback to cdev driver")
 	}
 }
 

--- a/system/system_test.go
+++ b/system/system_test.go
@@ -15,7 +15,7 @@ func TestNewAccesser(t *testing.T) {
 	nativeSys := a.sys.(*nativeSyscall)
 	nativeFsSys := a.fs.(*nativeFilesystem)
 	perphioSpi := a.spiAccess.(*periphioSpiAccess)
-	gpiodDigitalPin := a.digitalPinAccess.(*gpiodDigitalPinAccess)
+	gpiodDigitalPin := a.digitalPinAccess.(*cdevDigitalPinAccess)
 	assert.NotNil(t, a)
 	assert.NotNil(t, nativeSys)
 	assert.NotNil(t, nativeFsSys)
@@ -50,14 +50,14 @@ func TestNewAccesser_NewSpiDevice(t *testing.T) {
 func TestNewAccesser_IsSysfsDigitalPinAccess(t *testing.T) {
 	tests := map[string]struct {
 		sysfsAccesser bool
-		wantGpiod     bool
+		wantCdev      bool
 	}{
 		"default_accesser_gpiod": {
-			wantGpiod: true,
+			wantCdev: true,
 		},
 		"accesser_sysfs": {
 			sysfsAccesser: true,
-			wantGpiod:     false,
+			wantCdev:      false,
 		},
 	}
 	for name, tc := range tests {
@@ -68,18 +68,18 @@ func TestNewAccesser_IsSysfsDigitalPinAccess(t *testing.T) {
 				WithDigitalPinSysfsAccess()(a)
 			}
 			// act
-			gotGpiod := a.IsGpiodDigitalPinAccess()
+			gotCdev := a.IsCdevDigitalPinAccess()
 			gotSysfs := a.IsSysfsDigitalPinAccess()
 			// assert
 			assert.NotNil(t, a)
-			if tc.wantGpiod {
-				assert.True(t, gotGpiod)
+			if tc.wantCdev {
+				assert.True(t, gotCdev)
 				assert.False(t, gotSysfs)
-				dpaGpiod := a.digitalPinAccess.(*gpiodDigitalPinAccess)
-				assert.NotNil(t, dpaGpiod)
-				assert.Equal(t, a.fs.(*nativeFilesystem), dpaGpiod.fs)
+				dpaGpioCdev := a.digitalPinAccess.(*cdevDigitalPinAccess)
+				assert.NotNil(t, dpaGpioCdev)
+				assert.Equal(t, a.fs.(*nativeFilesystem), dpaGpioCdev.fs)
 			} else {
-				assert.False(t, gotGpiod)
+				assert.False(t, gotCdev)
 				assert.True(t, gotSysfs)
 				dpaSys := a.digitalPinAccess.(*sysfsDigitalPinAccess)
 				assert.NotNil(t, dpaSys)


### PR DESCRIPTION
## Solved issues and/or description of the change

Using the term cdev (short for character device Kernel ABI) is more suitable than using gpiod (the name of the user space driver in Linux). The former name was chosen so there would be no difference to the used go module "gpiod". Since also this module is now renamed, we choose the better name cdev from now on.

Because this is an API change, the migration guide was moved one level above and adjusted.

## Manual test

- OS and Version (Win/Mac/Linux): Linux
- Adaptor(s) and/or driver(s): 
  - nanopi NEO (for cdev)
  - PocketBeagle (for sysfs)

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test_race`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code
