### PR TITLE
Feature/gobot update eventer

### DIFF
--- a/eventer.go
+++ b/eventer.go
@@ -4,6 +4,13 @@ import (
 	"sync"
 )
 
+const (
+	defaultEventChanBufferSize = 10
+	maxEventChanBufferSize     = 10240
+	maxChanWorkerCount         = 128
+	EventCrash                 = "crash"
+)
+
 type eventChannel chan *Event
 
 type eventer struct {
@@ -25,13 +32,6 @@ type eventer struct {
 	// mutex to protect the eventChannel map
 	eventsMutex sync.Mutex
 }
-
-const (
-	eventChanBufferSize    = 10
-	maxEventChanBufferSize = 10240
-	maxChanWorkerCount     = 128
-	EventCrash             = "crash"
-)
 
 // Eventer is the interface which describes how a Driver or Adaptor
 // handles events.
@@ -74,7 +74,7 @@ func WithBufferSize(bufferSize int) EventerOptionFn {
 		if bufferSize >= maxEventChanBufferSize {
 			e.bufferSize = maxEventChanBufferSize
 		} else if bufferSize <= 0 {
-			e.bufferSize = eventChanBufferSize
+			e.bufferSize = defaultEventChanBufferSize
 		} else {
 			e.bufferSize = bufferSize
 		}
@@ -98,7 +98,7 @@ func WithWorkerCount(workerCount int) EventerOptionFn {
 func NewEventer(fns ...EventerOptionFn) Eventer {
 	evtr := &eventer{
 		eventnames:  make(map[string]string),
-		bufferSize:  eventChanBufferSize,
+		bufferSize:  defaultEventChanBufferSize,
 		workerCount: 1,
 	}
 
@@ -106,7 +106,7 @@ func NewEventer(fns ...EventerOptionFn) Eventer {
 		fn(evtr)
 	}
 
-	evtr.in = make(eventChannel, eventChanBufferSize)
+	evtr.in = make(eventChannel, defaultEventChanBufferSize)
 	evtr.outs = make(map[eventChannel]eventChannel)
 
 	// goroutine to cascade "in" events to all "out" event channels

--- a/eventer.go
+++ b/eventer.go
@@ -98,6 +98,7 @@ func WithWorkerCount(workerCount int) EventerOptionFn {
 func NewEventer(fns ...EventerOptionFn) Eventer {
 	evtr := &eventer{
 		eventnames:  make(map[string]string),
+		outs:        make(map[eventChannel]eventChannel),
 		bufferSize:  defaultEventChanBufferSize,
 		workerCount: 1,
 	}
@@ -106,10 +107,8 @@ func NewEventer(fns ...EventerOptionFn) Eventer {
 		fn(evtr)
 	}
 
-	evtr.in = make(eventChannel, defaultEventChanBufferSize)
-	evtr.outs = make(map[eventChannel]eventChannel)
-
 	// goroutine to cascade "in" events to all "out" event channels
+	evtr.in = make(eventChannel, evtr.bufferSize)
 	go func() {
 		for evt := range evtr.in {
 			evtr.eventsMutex.Lock()

--- a/eventer.go
+++ b/eventer.go
@@ -82,15 +82,12 @@ func NewEventerWithBufferSize(bufferSize int) Eventer {
 
 	// goroutine to cascade "in" events to all "out" event channels
 	go func() {
-		for {
-			select {
-			case evt := <-evtr.in:
-				evtr.eventsMutex.Lock()
-				for _, out := range evtr.outs {
-					out <- evt
-				}
-				evtr.eventsMutex.Unlock()
+		for evt := range evtr.in {
+			evtr.eventsMutex.Lock()
+			for _, out := range evtr.outs {
+				out <- evt
 			}
+			evtr.eventsMutex.Unlock()
 		}
 	}()
 
@@ -160,12 +157,9 @@ func (e *eventer) OnWithParallel(n string, workerCnt int, f func(s interface{}))
 				}
 			}()
 
-			for {
-				select {
-				case evt := <-out:
-					if evt.Name == n {
-						f(evt.Data)
-					}
+			for evt := range out {
+				if evt.Name == n {
+					f(evt.Data)
 				}
 			}
 		}()

--- a/eventer.go
+++ b/eventer.go
@@ -1,7 +1,6 @@
 package gobot
 
 import (
-	"errors"
 	"sync"
 )
 
@@ -19,6 +18,9 @@ type eventer struct {
 
 	// the in/out channel length
 	bufferSize int
+
+	// controls the maximum number of concurrent executions when eventer is Published to
+	workerCount int
 
 	// mutex to protect the eventChannel map
 	eventsMutex sync.Mutex
@@ -63,22 +65,49 @@ type Eventer interface {
 	Once(name string, f func(s interface{})) (err error)
 }
 
-// NewEventer returns a new Eventer.
-func NewEventer() Eventer {
-	return NewEventerWithBufferSize(eventChanBufferSize)
+// EventerOptionFn allows the configurable parameters of an eventer to be modified
+type EventerOptionFn func(*eventer)
+
+// WithBufferSize allows an eventer's buffer size to be configured
+func WithBufferSize(bufferSize int) EventerOptionFn {
+	return func(e *eventer) {
+		if bufferSize >= maxEventChanBufferSize {
+			e.bufferSize = maxEventChanBufferSize
+		} else if bufferSize <= 0 {
+			e.bufferSize = eventChanBufferSize
+		} else {
+			e.bufferSize = bufferSize
+		}
+	}
 }
 
-func NewEventerWithBufferSize(bufferSize int) Eventer {
-	if bufferSize >= maxEventChanBufferSize {
-		bufferSize = maxEventChanBufferSize
+// WithWorkerCount allows an eventer's workerCount to be configured
+func WithWorkerCount(workerCount int) EventerOptionFn {
+	return func(e *eventer) {
+		if workerCount >= maxChanWorkerCount {
+			e.workerCount = maxChanWorkerCount
+		} else if workerCount <= 0 {
+			e.workerCount = 1
+		} else {
+			e.workerCount = workerCount
+		}
+	}
+}
+
+// NewEventer returns a new Eventer.
+func NewEventer(fns ...EventerOptionFn) Eventer {
+	evtr := &eventer{
+		eventnames:  make(map[string]string),
+		bufferSize:  eventChanBufferSize,
+		workerCount: 1,
 	}
 
-	evtr := &eventer{
-		eventnames: make(map[string]string),
-		in:         make(eventChannel, bufferSize),
-		outs:       make(map[eventChannel]eventChannel),
-		bufferSize: bufferSize,
+	for _, fn := range fns {
+		fn(evtr)
 	}
+
+	evtr.in = make(eventChannel, eventChanBufferSize)
+	evtr.outs = make(map[eventChannel]eventChannel)
 
 	// goroutine to cascade "in" events to all "out" event channels
 	go func() {
@@ -139,16 +168,8 @@ func (e *eventer) Unsubscribe(events eventChannel) {
 
 // On executes the event handler f when e is Published to.
 func (e *eventer) On(n string, f func(s interface{})) (err error) {
-	return e.OnWithParallel(n, 1, f)
-}
-
-// Multi goroutines On executes the event handler f when e is Published to.
-func (e *eventer) OnWithParallel(n string, workerCnt int, f func(s interface{})) (err error) {
-	if workerCnt > maxChanWorkerCount {
-		return errors.New("out of max worker count")
-	}
 	out := e.Subscribe()
-	for i := 0; i < workerCnt; i++ {
+	for i := 0; i < e.workerCount; i++ {
 		go func() {
 			// Add panic handling for goroutines to prevent panics caused by the callback function `f`
 			defer func() {

--- a/eventer.go
+++ b/eventer.go
@@ -153,7 +153,7 @@ func (e *eventer) OnWithParallel(n string, workerCnt int, f func(s interface{}))
 	out := e.Subscribe()
 	for i := 0; i < workerCnt; i++ {
 		go func() {
-			// 增加goroutine的panic处理，防止因回调f引起panic
+			// Add panic handling for goroutines to prevent panics caused by the callback function `f`
 			defer func() {
 				if r := recover(); r != nil {
 					e.Publish(EventCrash, r)


### PR DESCRIPTION
This PR is a continuation of #980, which appears to have been abandoned.

## Solved issues and/or description of the change

The following is a translation from the original PR:
> Hello, I encountered some issues during project development and hope to make the following adjustments:
	•	Allow customizing the channel length of the eventer.
	•	Allow defining the number of goroutines consuming the out channel to implement a multi-consumer model.
	•	When a callback function triggers a panic, output the error through a crash event.
>
> Please review the code and check if the modifications are appropriate.

...

## Manual test

- OS and Version (Win/Mac/Linux):
- Adaptor(s) and/or driver(s):
...

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (e.g. by run `make test_race`)
- [ ] No linter errors exist locally (e.g. by run `make fmt_check`)
- [ ] I have performed a self-review of my own code

If this is a new driver or adaptor:

- [ ] I have added the name to the corresponding README.md
- [ ] I have added an example to see how to setup and use it
- [ ] I have checked or build at least my new example (e.g. by run `make examples_check`)

If this is a Go version update:

- [ ] go.mod to new version updated
- [ ] modules updated (go get -u -t ./...)
- [ ] CI files updated
- [ ] linter setting and linter version (if a newer one exist) updated
- [ ] linter issues fixed or suppressed by config

If this is a PR for release:

- [ ] The PR's target branch is 'hybridgroup:release'
- [ ] I have adjusted the CHANGELOG.md (or already prepared and will be merged as soon as possible)
