### PR TITLE
feature: allow for Tello optional external video processing

### DIFF
--- a/platforms/dji/tello/driver.go
+++ b/platforms/dji/tello/driver.go
@@ -194,6 +194,7 @@ type Driver struct {
 	rx, ry, lx, ly float32
 	throttle       int
 	bouncing       bool
+	ExternalVideo  bool
 	gobot.Eventer
 	doneCh            chan struct{}
 	doneChReaderCount int32
@@ -272,8 +273,11 @@ func (d *Driver) Start() error {
 			if err := d.SendDateTime(); err != nil {
 				panic(err)
 			}
-			if err := d.processVideo(); err != nil {
-				panic(err)
+			// start processing video frames unless being handled by external processor
+			if !d.ExternalVideo {
+				if err := d.processVideo(); err != nil {
+					panic(err)
+				}
 			}
 		})
 		if err != nil {


### PR DESCRIPTION
## Solved issues and/or description of the change

This PR adds a new field `ExternalVideo` to the Tello driver.

The purpose is to allow programs that want to control Tello drone, but have some external program perform the video processing instead of the Gobot program itself.

The way this is accomplished is by setting `drone.ExternalVideo = true` before calling `drone.Start()`.

...

## Manual test

- OS and Version (Win/Mac/Linux):
Linux

- Adaptor(s) and/or driver(s):
...

## Checklist

- [X] The PR's target branch is 'hybridgroup:dev'
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (e.g. by run `make test_race`)
- [X] No linter errors exist locally (e.g. by run `make fmt_check`)
- [X] I have performed a self-review of my own code

If this is a new driver or adaptor:

- [ ] I have added the name to the corresponding README.md
- [ ] I have added an example to see how to setup and use it
- [ ] I have checked or build at least my new example (e.g. by run `make examples_check`)

If this is a Go version update:

- [ ] go.mod to new version updated
- [ ] modules updated (go get -u -t ./...)
- [ ] CI files updated
- [ ] linter setting and linter version (if a newer one exist) updated
- [ ] linter issues fixed or suppressed by config

If this is a PR for release:

- [ ] The PR's target branch is 'hybridgroup:release'
- [ ] I have adjusted the CHANGELOG.md (or already prepared and will be merged as soon as possible)
