### PR TITLE
ble: fix some issues in connect and disconnect

### DIFF
--- a/platforms/bleclient/ble_client_adaptor.go
+++ b/platforms/bleclient/ble_client_adaptor.go
@@ -12,9 +12,10 @@ import (
 )
 
 type configuration struct {
-	scanTimeout          time.Duration
-	sleepAfterDisconnect time.Duration
-	debug                bool
+	scanTimeout                     time.Duration
+	sleepAfterDisconnect            time.Duration
+	dropCharacteristicsOnDisconnect bool
+	debug                           bool
 }
 
 // Adaptor represents a Client Connection to a BLE Peripheral
@@ -38,8 +39,9 @@ type Adaptor struct {
 //
 // Supported options:
 //
-//	"WithAdaptorDebug"
-//	"WithAdaptorScanTimeout"
+//	"WithDebug"
+//	"WithDropCharacteristicsOnDisconnect"
+//	"WithScanTimeout"
 func NewAdaptor(identifier string, opts ...optionApplier) *Adaptor {
 	cfg := configuration{
 		scanTimeout:          10 * time.Minute,
@@ -65,6 +67,13 @@ func NewAdaptor(identifier string, opts ...optionApplier) *Adaptor {
 // WithDebug switch on some debug messages.
 func WithDebug() debugOption {
 	return debugOption(true)
+}
+
+// WithWithDropCharacteristicsOnDisconnect leads to clean all discovered services from last connect command if a
+// disconnect command happen. Also all subscriptions will be cleaned. A new discover of services and characteristics is
+// done on next connect and the subscriptions needs to be done again afterwards by the caller.
+func WithDropCharacteristicsOnDisconnect() dropCharacteristicsOnDisconnect {
+	return dropCharacteristicsOnDisconnect(true)
 }
 
 // WithScanTimeout substitute the default scan timeout of 10 min.
@@ -104,6 +113,10 @@ func (a *Adaptor) Connect() error {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 
+	if a.connected {
+		return fmt.Errorf("%s is already connected", a.name)
+	}
+
 	var err error
 
 	if a.cfg.debug {
@@ -139,28 +152,30 @@ func (a *Adaptor) Connect() error {
 	a.rssi = int(result.RSSI)
 	a.btDevice = dev
 
-	if a.cfg.debug {
-		fmt.Println("[Connect]: get all services/characteristics...")
-	}
-	services, err := a.btDevice.discoverServices(nil)
-	if err != nil {
-		return err
-	}
-	for _, service := range services {
+	if len(a.characteristics) == 0 {
 		if a.cfg.debug {
-			fmt.Printf("[Connect]: service found: %s\n", service)
+			fmt.Println("[Connect]: get all services/characteristics...")
 		}
-		chars, err := service.DiscoverCharacteristics(nil)
+		services, err := a.btDevice.discoverServices(nil)
 		if err != nil {
-			log.Println(err)
-			continue
+			return err
 		}
-		for _, char := range chars {
+		for _, service := range services {
 			if a.cfg.debug {
-				fmt.Printf("[Connect]: characteristic found: %s\n", char)
+				fmt.Printf("[Connect]: service found: %s\n", service)
 			}
-			c := char // to prevent implicit memory aliasing in for loop, before go 1.22
-			a.characteristics[char.UUID().String()] = &c
+			chars, err := service.DiscoverCharacteristics(nil)
+			if err != nil {
+				log.Println(err)
+				continue
+			}
+			for _, char := range chars {
+				if a.cfg.debug {
+					fmt.Printf("[Connect]: characteristic found: %s\n", char)
+				}
+				c := char // to prevent implicit memory aliasing in for loop, before go 1.22
+				a.characteristics[char.UUID().String()] = &c
+			}
 		}
 	}
 
@@ -187,6 +202,26 @@ func (a *Adaptor) Disconnect() error {
 	if a.cfg.debug {
 		fmt.Println("[Disconnect]: disconnect...")
 	}
+
+	if a.cfg.dropCharacteristicsOnDisconnect {
+		if a.cfg.debug {
+			fmt.Println("[Disconnect]: unsubscribe...")
+		}
+
+		for id, chara := range a.characteristics {
+			if err := adjustNotificationsForCharacteristic(chara, nil); err != nil {
+				fmt.Printf("[Disconnect]: error on unsubscribe characteristic %s: %v\n", id, err)
+			}
+		}
+
+		if a.cfg.debug {
+			fmt.Println("[Disconnect]: drop characteristics...")
+		}
+		a.characteristics = make(map[string]bluetoothExtCharacteristicer)
+	} else if a.cfg.debug {
+		fmt.Println("[Disconnect]: as configured, characteristics not dropped")
+	}
+
 	err := a.btDevice.disconnect()
 	time.Sleep(a.cfg.sleepAfterDisconnect)
 	a.connected = false
@@ -252,7 +287,26 @@ func (a *Adaptor) Subscribe(cUUID string, f func(data []byte)) error {
 	}
 
 	if chara, ok := a.characteristics[cUUID]; ok {
-		return enableNotificationsForCharacteristic(chara, f)
+		return adjustNotificationsForCharacteristic(chara, f)
+	}
+
+	return fmt.Errorf("unknown characteristic: %s", cUUID)
+}
+
+// Unsubscribe remove subscription to notifications from the BLE device for the requested characteristic UUID.
+// The UUID can be given as 16-bit or 128-bit (with or without dashes) value.
+func (a *Adaptor) Unsubscribe(cUUID string) error {
+	if !a.connected {
+		return fmt.Errorf("cannot unsubscribe from BLE device until connected")
+	}
+
+	cUUID, err := convertUUID(cUUID)
+	if err != nil {
+		return err
+	}
+
+	if chara, ok := a.characteristics[cUUID]; ok {
+		return adjustNotificationsForCharacteristic(chara, nil)
 	}
 
 	return fmt.Errorf("unknown characteristic: %s", cUUID)

--- a/platforms/bleclient/ble_client_adaptor_options.go
+++ b/platforms/bleclient/ble_client_adaptor_options.go
@@ -7,11 +7,18 @@ type optionApplier interface {
 	apply(cfg *configuration)
 }
 
+// dropCharacteristicsOnDisconnect is the type for applying drop feature.
+type dropCharacteristicsOnDisconnect bool
+
 // debugOption is the type for applying the debug switch on or off.
 type debugOption bool
 
 // scanTimeoutOption is the type for applying another timeout than the default 10 min.
 type scanTimeoutOption time.Duration
+
+func (o dropCharacteristicsOnDisconnect) String() string {
+	return "drop characteristics on disconnect option for BLE client adaptors"
+}
 
 func (o debugOption) String() string {
 	return "debug option for BLE client adaptors"
@@ -19,6 +26,10 @@ func (o debugOption) String() string {
 
 func (o scanTimeoutOption) String() string {
 	return "scan timeout option for BLE client adaptors"
+}
+
+func (o dropCharacteristicsOnDisconnect) apply(cfg *configuration) {
+	cfg.dropCharacteristicsOnDisconnect = bool(o)
 }
 
 func (o debugOption) apply(cfg *configuration) {

--- a/platforms/bleclient/ble_client_adaptor_options_test.go
+++ b/platforms/bleclient/ble_client_adaptor_options_test.go
@@ -16,6 +16,15 @@ func TestWithDebug(t *testing.T) {
 	assert.True(t, a.cfg.debug)
 }
 
+func TestWithDropCharacteristicsOnDisconnect(t *testing.T) {
+	// arrange
+	cfg := &configuration{dropCharacteristicsOnDisconnect: false}
+	// act
+	WithDropCharacteristicsOnDisconnect().apply(cfg)
+	// assert
+	assert.True(t, cfg.dropCharacteristicsOnDisconnect)
+}
+
 func TestWithScanTimeout(t *testing.T) {
 	// arrange
 	newTimeout := 2 * time.Second

--- a/platforms/bleclient/ble_client_adaptor_test.go
+++ b/platforms/bleclient/ble_client_adaptor_test.go
@@ -36,12 +36,13 @@ func TestConnect(t *testing.T) {
 		rssi          = 56
 	)
 	tests := map[string]struct {
-		identifier  string
-		extAdapter  *btTestAdapter
-		extDevice   btTestDevice
-		wantAddress string
-		wantName    string
-		wantErr     string
+		identifier                  string
+		extAdapter                  *btTestAdapter
+		simulateConnected           bool
+		simulateDiscoverServicesErr bool
+		wantAddress                 string
+		wantName                    string
+		wantErr                     string
 	}{
 		"connect_by_address": {
 			identifier: deviceAddress,
@@ -50,7 +51,6 @@ func TestConnect(t *testing.T) {
 				rssi:          rssi,
 				payload:       &btTestPayload{name: deviceName},
 			},
-			extDevice:   btTestDevice{},
 			wantAddress: deviceAddress,
 			wantName:    deviceName,
 		},
@@ -61,9 +61,14 @@ func TestConnect(t *testing.T) {
 				rssi:          rssi,
 				payload:       &btTestPayload{name: deviceName},
 			},
-			extDevice:   btTestDevice{},
 			wantAddress: deviceAddress,
 			wantName:    deviceName,
+		},
+		"error_already_connected": {
+			extAdapter:        &btTestAdapter{},
+			simulateConnected: true,
+			wantName:          "BLEClient",
+			wantErr:           "is already connected",
 		},
 		"error_enable": {
 			extAdapter: &btTestAdapter{
@@ -122,26 +127,26 @@ func TestConnect(t *testing.T) {
 				deviceAddress: deviceAddress,
 				payload:       &btTestPayload{name: "disco_err"},
 			},
-			extDevice: btTestDevice{
-				simulateDiscoverServicesErr: true,
-			},
-			wantAddress: deviceAddress,
-			wantName:    "disco_err",
-			wantErr:     "device discover services error",
+			simulateDiscoverServicesErr: true,
+			wantAddress:                 deviceAddress,
+			wantName:                    "disco_err",
+			wantErr:                     "device discover services error",
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			// arrange
 			a := NewAdaptor(tc.identifier)
+			extDevice := btTestDevice{simulateDiscoverServicesErr: tc.simulateDiscoverServicesErr}
 			btdc := func(_ bluetoothExtDevicer, address, name string) *btDevice {
-				return &btDevice{extDevice: tc.extDevice, devAddress: address, devName: name}
+				return &btDevice{extDevice: extDevice, devAddress: address, devName: name}
 			}
 			btac := func(bluetoothExtAdapterer, bool) *btAdapter {
 				return &btAdapter{extAdapter: tc.extAdapter, btDeviceCreator: btdc}
 			}
 			a.btAdptCreator = btac
 			a.cfg.scanTimeout = scanTimeout // to speed up test
+			a.connected = tc.simulateConnected
 			// act
 			err := a.Connect()
 			// assert
@@ -155,8 +160,76 @@ func TestConnect(t *testing.T) {
 				require.ErrorContains(t, err, tc.wantErr)
 				assert.Contains(t, a.Name(), tc.wantName)
 				assert.Equal(t, tc.wantAddress, a.Address())
-				assert.False(t, a.connected)
+				assert.Equal(t, tc.simulateConnected, a.connected)
 			}
+		})
+	}
+}
+
+func TestDisconnect(t *testing.T) {
+	const (
+		scanTimeout   = 5 * time.Millisecond
+		deviceName    = "hello"
+		deviceAddress = "11:22:44:AA:BB:CC"
+	)
+	tests := map[string]struct {
+		connectBefore         bool
+		dropCharacteristics   bool
+		simulateDisconnectErr bool
+		wantErr               string
+	}{
+		"disconnect_not_connectected": {},
+		"disconnect_connectected_before": {
+			connectBefore: true,
+		},
+		"disconnect_drop_charas": {
+			connectBefore:       true,
+			dropCharacteristics: true,
+		},
+		"error_disconnect": {
+			simulateDisconnectErr: true,
+			connectBefore:         true,
+			wantErr:               "device disconnect error",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			a := NewAdaptor(deviceName)
+			a.cfg.sleepAfterDisconnect = 0 // to speed up test
+			a.cfg.dropCharacteristicsOnDisconnect = tc.dropCharacteristics
+			var wantCharaLen int
+			if tc.connectBefore {
+				extDevice := btTestDevice{simulateDisconnectErr: tc.simulateDisconnectErr}
+				btdc := func(_ bluetoothExtDevicer, address, name string) *btDevice {
+					return &btDevice{extDevice: extDevice, devAddress: address, devName: name}
+				}
+				extAdapter := &btTestAdapter{
+					deviceAddress: deviceAddress,
+					payload:       &btTestPayload{name: deviceName},
+				}
+				btac := func(bluetoothExtAdapterer, bool) *btAdapter {
+					return &btAdapter{extAdapter: extAdapter, btDeviceCreator: btdc}
+				}
+				a.btAdptCreator = btac
+				a.cfg.scanTimeout = scanTimeout // to speed up test
+				require.NoError(t, a.Connect())
+				a.characteristics["charauuid"] = &btTestChara{}
+				if !tc.dropCharacteristics {
+					wantCharaLen = 1
+				}
+			}
+			// act
+			err := a.Disconnect()
+			// assert
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.wantErr)
+			}
+			assert.False(t, a.connected)
+			require.NotNil(t, a.characteristics)
+			assert.Len(t, a.characteristics, wantCharaLen)
 		})
 	}
 }
@@ -169,42 +242,57 @@ func TestReconnect(t *testing.T) {
 		rssi          = 56
 	)
 	tests := map[string]struct {
-		extAdapter   *btTestAdapter
-		extDevice    *btTestDevice
-		wasConnected bool
-		wantErr      string
+		wasConnected          bool
+		dropCharacteristics   bool
+		simulateDisconnectErr bool
+		simulateConnectErr    bool
+		wantErr               string
 	}{
-		"reconnect_not_connected": {
-			extAdapter: &btTestAdapter{
-				deviceAddress: deviceAddress,
-				rssi:          rssi,
-				payload:       &btTestPayload{name: deviceName},
-			},
-			extDevice: &btTestDevice{},
-		},
+		"reconnect_not_connected": {},
 		"reconnect_was_connected": {
-			extAdapter: &btTestAdapter{
-				deviceAddress: deviceAddress,
-				rssi:          rssi,
-				payload:       &btTestPayload{name: deviceName},
-			},
-			extDevice:    &btTestDevice{},
 			wasConnected: true,
+		},
+		"reconnect_drop_charas": {
+			wasConnected:        true,
+			dropCharacteristics: true,
+		},
+		"error_disconnect": {
+			simulateDisconnectErr: true,
+			wasConnected:          true,
+			wantErr:               "device disconnect error",
+		},
+		"error_connect": {
+			simulateConnectErr: true,
+			wasConnected:       true,
+			wantErr:            "adapter connect error",
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			// arrange
 			a := NewAdaptor(deviceAddress)
+			extDevice := btTestDevice{simulateDisconnectErr: tc.simulateDisconnectErr}
 			btdc := func(_ bluetoothExtDevicer, address, name string) *btDevice {
-				return &btDevice{extDevice: tc.extDevice, devAddress: address, devName: name}
+				return &btDevice{extDevice: extDevice, devAddress: address, devName: name}
 			}
-			a.btAdpt = &btAdapter{extAdapter: tc.extAdapter, btDeviceCreator: btdc}
+			extAdapter := &btTestAdapter{
+				simulateConnectErr: tc.simulateConnectErr,
+				deviceAddress:      deviceAddress,
+				rssi:               rssi,
+				payload:            &btTestPayload{name: deviceName},
+			}
+			a.btAdpt = &btAdapter{extAdapter: extAdapter, btDeviceCreator: btdc}
 			a.cfg.scanTimeout = scanTimeout // to speed up test in case of errors
 			a.cfg.sleepAfterDisconnect = 0  // to speed up test
+			a.cfg.dropCharacteristicsOnDisconnect = tc.dropCharacteristics
+			var wantCharaLen int
 			if tc.wasConnected {
 				a.btDevice = btdc(nil, "", "")
 				a.connected = tc.wasConnected
+				a.characteristics["charauuid"] = &btTestChara{}
+				if !tc.dropCharacteristics {
+					wantCharaLen = 1
+				}
 			}
 			// act
 			err := a.Reconnect()
@@ -212,10 +300,11 @@ func TestReconnect(t *testing.T) {
 			if tc.wantErr == "" {
 				require.NoError(t, err)
 				assert.Equal(t, rssi, a.RSSI())
+				assert.Len(t, a.characteristics, wantCharaLen)
+				assert.True(t, a.connected)
 			} else {
 				require.ErrorContains(t, err, tc.wantErr)
 			}
-			assert.True(t, a.connected)
 		})
 	}
 }
@@ -223,17 +312,13 @@ func TestReconnect(t *testing.T) {
 func TestFinalize(t *testing.T) {
 	// this also tests Disconnect()
 	tests := map[string]struct {
-		extDevice *btTestDevice
-		wantErr   string
+		simulateDisconnectErr bool
+		wantErr               string
 	}{
-		"disconnect": {
-			extDevice: &btTestDevice{},
-		},
+		"disconnect": {},
 		"error_disconnect": {
-			extDevice: &btTestDevice{
-				simulateDisconnectErr: true,
-			},
-			wantErr: "device disconnect error",
+			simulateDisconnectErr: true,
+			wantErr:               "device disconnect error",
 		},
 	}
 	for name, tc := range tests {
@@ -241,7 +326,8 @@ func TestFinalize(t *testing.T) {
 			// arrange
 			a := NewAdaptor("")
 			a.cfg.sleepAfterDisconnect = 0 // to speed up test
-			a.btDevice = &btDevice{extDevice: tc.extDevice}
+			extDevice := btTestDevice{simulateDisconnectErr: tc.simulateDisconnectErr}
+			a.btDevice = &btDevice{extDevice: extDevice}
 			// act
 			err := a.Finalize()
 			// assert
@@ -402,6 +488,54 @@ func TestSubscribe(t *testing.T) {
 				require.ErrorContains(t, err, tc.wantErr)
 			}
 			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestUnsubscribe(t *testing.T) {
+	const uuid = "00004321-0000-1000-8000-00805f9b34fb"
+	tests := map[string]struct {
+		inUUID       string
+		notConnected bool
+		chara        *btTestChara
+		wantErr      string
+	}{
+		"unsubscribe_ok": {
+			inUUID: uuid,
+			chara:  &btTestChara{notificationFunc: func([]byte) {}},
+		},
+		"error_not_connected": {
+			notConnected: true,
+			wantErr:      "cannot unsubscribe from BLE device until connected",
+		},
+		"error_bad_chara": {
+			inUUID:  "gag2",
+			wantErr: "'gag2' is not a valid 16-bit Bluetooth UUID",
+		},
+		"error_unknown_chara": {
+			inUUID:  uuid,
+			wantErr: "unknown characteristic: 00004321-0000-1000-8000-00805f9b34fb",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			a := NewAdaptor("")
+			if tc.chara != nil {
+				a.characteristics[uuid] = tc.chara
+			}
+			a.connected = !tc.notConnected
+			// act
+			err := a.Unsubscribe(tc.inUUID)
+			// assert
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				require.NotNil(t, a.characteristics)
+				require.NotNil(t, a.characteristics[uuid])
+				assert.Nil(t, tc.chara.notificationFunc)
+			} else {
+				require.ErrorContains(t, err, tc.wantErr)
+			}
 		})
 	}
 }

--- a/platforms/bleclient/btwrapper.go
+++ b/platforms/bleclient/btwrapper.go
@@ -130,7 +130,11 @@ func (btd *btDevice) discoverServices(uuids []bluetooth.UUID) ([]bluetooth.Devic
 
 // Disconnect from the BLE device. This method is non-blocking and does not wait until the connection is fully gone.
 func (btd *btDevice) disconnect() error {
-	return btd.extDevice.Disconnect()
+	if btd != nil && btd.extDevice != nil {
+		return btd.extDevice.Disconnect()
+	}
+
+	return nil
 }
 
 func readFromCharacteristic(chara bluetoothExtCharacteristicer) ([]byte, error) {
@@ -149,6 +153,6 @@ func writeToCharacteristicWithoutResponse(chara bluetoothExtCharacteristicer, da
 	return nil
 }
 
-func enableNotificationsForCharacteristic(chara bluetoothExtCharacteristicer, f func(data []byte)) error {
+func adjustNotificationsForCharacteristic(chara bluetoothExtCharacteristicer, f func(data []byte)) error {
 	return chara.EnableNotifications(f)
 }

--- a/platforms/bleclient/helpers_test.go
+++ b/platforms/bleclient/helpers_test.go
@@ -97,6 +97,7 @@ func (btd btTestDevice) Disconnect() error {
 	return nil
 }
 
+// btTestChara implements bluetoothExtCharacteristicer
 type btTestChara struct {
 	readData         []byte
 	writtenData      []byte


### PR DESCRIPTION
## Solved issues and/or description of the change

* see #1157 and #1160
* introduced an option to drop all characteristics on each disconnect

## Manual test

- OS and Version (Win/Mac/Linux): Linux
- Adaptor(s) and/or driver(s):  bleclient on a pine64 rock64

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test_race`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code
