### PR TITLE
i2c(all): ensure halt is idempotent

### DIFF
--- a/drivers/i2c/adafruit1109_driver.go
+++ b/drivers/i2c/adafruit1109_driver.go
@@ -26,22 +26,23 @@ type Adafruit1109Driver struct {
 	*MCP23017Driver
 	*gpio.HD44780Driver
 
-	name      string
-	redPin    adafruit1109PortPin
-	greenPin  adafruit1109PortPin
-	bluePin   adafruit1109PortPin
-	selectPin adafruit1109PortPin
-	upPin     adafruit1109PortPin
-	downPin   adafruit1109PortPin
-	leftPin   adafruit1109PortPin
-	rightPin  adafruit1109PortPin
-	rwPin     adafruit1109PortPin
-	rsPin     adafruit1109PortPin
-	enPin     adafruit1109PortPin
-	dataPinD4 adafruit1109PortPin
-	dataPinD5 adafruit1109PortPin
-	dataPinD6 adafruit1109PortPin
-	dataPinD7 adafruit1109PortPin
+	name       string
+	redPin     adafruit1109PortPin
+	greenPin   adafruit1109PortPin
+	bluePin    adafruit1109PortPin
+	selectPin  adafruit1109PortPin
+	upPin      adafruit1109PortPin
+	downPin    adafruit1109PortPin
+	leftPin    adafruit1109PortPin
+	rightPin   adafruit1109PortPin
+	rwPin      adafruit1109PortPin
+	rsPin      adafruit1109PortPin
+	enPin      adafruit1109PortPin
+	dataPinD4  adafruit1109PortPin
+	dataPinD5  adafruit1109PortPin
+	dataPinD6  adafruit1109PortPin
+	dataPinD7  adafruit1109PortPin
+	mcpStarted bool
 }
 
 // NewAdafruit1109Driver creates is a new driver for the 2x16 LCD display with RGB backlit and 5 keys.
@@ -120,6 +121,8 @@ func (d *Adafruit1109Driver) Start() error {
 		return err
 	}
 
+	d.mcpStarted = true
+
 	// set all to output (inputs will be set by initButton)
 	for pin := uint8(0); pin <= 7; pin++ {
 		if err := d.SetPinMode(pin, "A", 0); err != nil {
@@ -169,14 +172,19 @@ func (d *Adafruit1109Driver) Halt() error {
 	if err := d.HD44780Driver.Halt(); err != nil {
 		errors = append(errors, err.Error())
 	}
-	// switch off the background light
-	if err := d.SetRGB(false, false, false); err != nil {
-		errors = append(errors, err.Error())
+
+	if d.mcpStarted {
+		// switch off the background light
+		if err := d.SetRGB(false, false, false); err != nil {
+			errors = append(errors, err.Error())
+		}
+		// must be after HD44780Driver
+		if err := d.MCP23017Driver.Halt(); err != nil {
+			errors = append(errors, err.Error())
+		}
 	}
-	// must be after HD44780Driver
-	if err := d.MCP23017Driver.Halt(); err != nil {
-		errors = append(errors, err.Error())
-	}
+
+	d.mcpStarted = false
 
 	if len(errors) > 0 {
 		return fmt.Errorf("'Halt' the driver %s", strings.Join(errors, ", "))

--- a/drivers/i2c/adafruit1109_driver_test.go
+++ b/drivers/i2c/adafruit1109_driver_test.go
@@ -88,7 +88,8 @@ func TestAdafruit1109StartReadErr(t *testing.T) {
 
 func TestAdafruit1109Halt(t *testing.T) {
 	d, _ := initTestAdafruit1109WithStubbedAdaptor()
-	_ = d.Start()
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
 	require.NoError(t, d.Halt())
 }
 

--- a/drivers/i2c/adafruit2327_driver_test.go
+++ b/drivers/i2c/adafruit2327_driver_test.go
@@ -32,6 +32,15 @@ func TestNewAdafruit2327Driver(t *testing.T) {
 	assert.Equal(t, 0x40, d.defaultAddress)
 }
 
+func TestAdafruit2327Halt(t *testing.T) {
+	// arrange
+	d := NewAdafruit2327Driver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestAdafruit2327Options(t *testing.T) {
 	// This is a general test, that options are applied in constructor by using the common WithBus() option and
 	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".

--- a/drivers/i2c/adafruit2348_driver.go
+++ b/drivers/i2c/adafruit2348_driver.go
@@ -125,32 +125,32 @@ func NewAdafruit2348Driver(c Connector, options ...func(Config)) *Adafruit2348Dr
 }
 
 // SetDCMotorSpeed will set the appropriate pins to run the specified DC motor for the given speed.
-func (a *Adafruit2348Driver) SetDCMotorSpeed(dcMotor int, speed int32) error {
-	return a.SetPWM(int(a.dcMotors[dcMotor].pwmPin), 0, uint16(speed*16)) //nolint:gosec // TODO: fix later
+func (d *Adafruit2348Driver) SetDCMotorSpeed(dcMotor int, speed int32) error {
+	return d.SetPWM(int(d.dcMotors[dcMotor].pwmPin), 0, uint16(speed*16)) //nolint:gosec // TODO: fix later
 }
 
 // RunDCMotor will set the appropriate pins to run the specified DC motor for the given direction.
-func (a *Adafruit2348Driver) RunDCMotor(dcMotor int, dir Adafruit2348Direction) error {
+func (d *Adafruit2348Driver) RunDCMotor(dcMotor int, dir Adafruit2348Direction) error {
 	switch dir {
 	case Adafruit2348Forward:
-		if err := a.setPin(a.dcMotors[dcMotor].in2Pin, 0); err != nil {
+		if err := d.setPin(d.dcMotors[dcMotor].in2Pin, 0); err != nil {
 			return err
 		}
-		if err := a.setPin(a.dcMotors[dcMotor].in1Pin, 1); err != nil {
+		if err := d.setPin(d.dcMotors[dcMotor].in1Pin, 1); err != nil {
 			return err
 		}
 	case Adafruit2348Backward:
-		if err := a.setPin(a.dcMotors[dcMotor].in1Pin, 0); err != nil {
+		if err := d.setPin(d.dcMotors[dcMotor].in1Pin, 0); err != nil {
 			return err
 		}
-		if err := a.setPin(a.dcMotors[dcMotor].in2Pin, 1); err != nil {
+		if err := d.setPin(d.dcMotors[dcMotor].in2Pin, 1); err != nil {
 			return err
 		}
 	case Adafruit2348Release:
-		if err := a.setPin(a.dcMotors[dcMotor].in1Pin, 0); err != nil {
+		if err := d.setPin(d.dcMotors[dcMotor].in1Pin, 0); err != nil {
 			return err
 		}
-		if err := a.setPin(a.dcMotors[dcMotor].in2Pin, 0); err != nil {
+		if err := d.setPin(d.dcMotors[dcMotor].in2Pin, 0); err != nil {
 			return err
 		}
 	}
@@ -158,21 +158,21 @@ func (a *Adafruit2348Driver) RunDCMotor(dcMotor int, dir Adafruit2348Direction) 
 }
 
 // SetStepperMotorSpeed sets the seconds-per-step for the given stepper motor. It is applied in the next cycle.
-func (a *Adafruit2348Driver) SetStepperMotorSpeed(stepperMotor int, rpm int) error {
-	a.stepperSpeedMutex.Lock()
-	defer a.stepperSpeedMutex.Unlock()
+func (d *Adafruit2348Driver) SetStepperMotorSpeed(stepperMotor int, rpm int) error {
+	d.stepperSpeedMutex.Lock()
+	defer d.stepperSpeedMutex.Unlock()
 
-	revSteps := a.stepperMotors[stepperMotor].revSteps
-	a.stepperMotors[stepperMotor].secPerStep = 60.0 / float64(revSteps*rpm)
+	revSteps := d.stepperMotors[stepperMotor].revSteps
+	d.stepperMotors[stepperMotor].secPerStep = 60.0 / float64(revSteps*rpm)
 	return nil
 }
 
 // Step will rotate the stepper motor the given number of steps, in the given direction and step style.
-func (a *Adafruit2348Driver) Step(motor, steps int, dir Adafruit2348Direction, style Adafruit2348StepStyle) error {
-	a.stepperSpeedMutex.Lock()
-	defer a.stepperSpeedMutex.Unlock()
+func (d *Adafruit2348Driver) Step(motor, steps int, dir Adafruit2348Direction, style Adafruit2348StepStyle) error {
+	d.stepperSpeedMutex.Lock()
+	defer d.stepperSpeedMutex.Unlock()
 
-	secPerStep := a.stepperMotors[motor].secPerStep
+	secPerStep := d.stepperMotors[motor].secPerStep
 	var latestStep int
 	var err error
 	if style == Adafruit2348Interleave {
@@ -186,7 +186,7 @@ func (a *Adafruit2348Driver) Step(motor, steps int, dir Adafruit2348Direction, s
 		log.Printf("[adafruit2348_driver] %f seconds per step", secPerStep)
 	}
 	for i := 0; i < steps; i++ {
-		if latestStep, err = a.oneStep(motor, dir, style); err != nil {
+		if latestStep, err = d.oneStep(motor, dir, style); err != nil {
 			return err
 		}
 		time.Sleep(time.Duration(secPerStep) * time.Second)
@@ -195,7 +195,7 @@ func (a *Adafruit2348Driver) Step(motor, steps int, dir Adafruit2348Direction, s
 	// This is an edge case, if we are in between full steps, keep going to end on a full step
 	if style == Adafruit2348Microstep {
 		for latestStep != 0 && latestStep != adafruit2348StepperMicrosteps {
-			if latestStep, err = a.oneStep(motor, dir, style); err != nil {
+			if latestStep, err = d.oneStep(motor, dir, style); err != nil {
 				return err
 			}
 			time.Sleep(time.Duration(secPerStep) * time.Second)
@@ -204,94 +204,94 @@ func (a *Adafruit2348Driver) Step(motor, steps int, dir Adafruit2348Direction, s
 	return nil
 }
 
-func (a *Adafruit2348Driver) oneStep(motor int, dir Adafruit2348Direction, style Adafruit2348StepStyle) (int, error) {
+func (d *Adafruit2348Driver) oneStep(motor int, dir Adafruit2348Direction, style Adafruit2348StepStyle) (int, error) {
 	pwmA := 255
 	pwmB := 255
 
 	// Determine the stepping procedure
 	switch style {
 	case Adafruit2348Single:
-		if (a.stepperMotors[motor].currentStep / (adafruit2348StepperMicrosteps / 2) % 2) != 0 {
+		if (d.stepperMotors[motor].currentStep / (adafruit2348StepperMicrosteps / 2) % 2) != 0 {
 			// we're at an odd step
 			if dir == Adafruit2348Forward {
-				a.stepperMotors[motor].currentStep += adafruit2348StepperMicrosteps / 2
+				d.stepperMotors[motor].currentStep += adafruit2348StepperMicrosteps / 2
 			} else {
-				a.stepperMotors[motor].currentStep -= adafruit2348StepperMicrosteps / 2
+				d.stepperMotors[motor].currentStep -= adafruit2348StepperMicrosteps / 2
 			}
 		} else {
 			// go to next even step
 			if dir == Adafruit2348Forward {
-				a.stepperMotors[motor].currentStep += adafruit2348StepperMicrosteps
+				d.stepperMotors[motor].currentStep += adafruit2348StepperMicrosteps
 			} else {
-				a.stepperMotors[motor].currentStep -= adafruit2348StepperMicrosteps
+				d.stepperMotors[motor].currentStep -= adafruit2348StepperMicrosteps
 			}
 		}
 	case Adafruit2348Double:
-		if (a.stepperMotors[motor].currentStep / (adafruit2348StepperMicrosteps / 2) % 2) == 0 {
+		if (d.stepperMotors[motor].currentStep / (adafruit2348StepperMicrosteps / 2) % 2) == 0 {
 			// we're at an even step, weird
 			if dir == Adafruit2348Forward {
-				a.stepperMotors[motor].currentStep += adafruit2348StepperMicrosteps / 2
+				d.stepperMotors[motor].currentStep += adafruit2348StepperMicrosteps / 2
 			} else {
-				a.stepperMotors[motor].currentStep -= adafruit2348StepperMicrosteps / 2
+				d.stepperMotors[motor].currentStep -= adafruit2348StepperMicrosteps / 2
 			}
 		} else {
 			// go to next odd step
 			if dir == Adafruit2348Forward {
-				a.stepperMotors[motor].currentStep += adafruit2348StepperMicrosteps
+				d.stepperMotors[motor].currentStep += adafruit2348StepperMicrosteps
 			} else {
-				a.stepperMotors[motor].currentStep -= adafruit2348StepperMicrosteps
+				d.stepperMotors[motor].currentStep -= adafruit2348StepperMicrosteps
 			}
 		}
 	case Adafruit2348Interleave:
 		if dir == Adafruit2348Forward {
-			a.stepperMotors[motor].currentStep += adafruit2348StepperMicrosteps / 2
+			d.stepperMotors[motor].currentStep += adafruit2348StepperMicrosteps / 2
 		} else {
-			a.stepperMotors[motor].currentStep -= adafruit2348StepperMicrosteps / 2
+			d.stepperMotors[motor].currentStep -= adafruit2348StepperMicrosteps / 2
 		}
 	case Adafruit2348Microstep:
 		if dir == Adafruit2348Forward {
-			a.stepperMotors[motor].currentStep++
+			d.stepperMotors[motor].currentStep++
 		} else {
-			a.stepperMotors[motor].currentStep--
+			d.stepperMotors[motor].currentStep--
 		}
 		// go to next step and wrap around
-		a.stepperMotors[motor].currentStep += adafruit2348StepperMicrosteps * 4
-		a.stepperMotors[motor].currentStep %= adafruit2348StepperMicrosteps * 4
+		d.stepperMotors[motor].currentStep += adafruit2348StepperMicrosteps * 4
+		d.stepperMotors[motor].currentStep %= adafruit2348StepperMicrosteps * 4
 
 		pwmA = 0
 		pwmB = 0
-		currStep := a.stepperMotors[motor].currentStep
+		currStep := d.stepperMotors[motor].currentStep
 		switch {
 		case currStep >= 0 && currStep < adafruit2348StepperMicrosteps:
-			pwmA = a.stepperMicrostepCurve[adafruit2348StepperMicrosteps-currStep]
-			pwmB = a.stepperMicrostepCurve[currStep]
+			pwmA = d.stepperMicrostepCurve[adafruit2348StepperMicrosteps-currStep]
+			pwmB = d.stepperMicrostepCurve[currStep]
 		case currStep >= adafruit2348StepperMicrosteps && currStep < adafruit2348StepperMicrosteps*2:
-			pwmA = a.stepperMicrostepCurve[currStep-adafruit2348StepperMicrosteps]
-			pwmB = a.stepperMicrostepCurve[adafruit2348StepperMicrosteps*2-currStep]
+			pwmA = d.stepperMicrostepCurve[currStep-adafruit2348StepperMicrosteps]
+			pwmB = d.stepperMicrostepCurve[adafruit2348StepperMicrosteps*2-currStep]
 		case currStep >= adafruit2348StepperMicrosteps*2 && currStep < adafruit2348StepperMicrosteps*3:
-			pwmA = a.stepperMicrostepCurve[adafruit2348StepperMicrosteps*3-currStep]
-			pwmB = a.stepperMicrostepCurve[currStep-adafruit2348StepperMicrosteps*2]
+			pwmA = d.stepperMicrostepCurve[adafruit2348StepperMicrosteps*3-currStep]
+			pwmB = d.stepperMicrostepCurve[currStep-adafruit2348StepperMicrosteps*2]
 		case currStep >= adafruit2348StepperMicrosteps*3 && currStep < adafruit2348StepperMicrosteps*4:
-			pwmA = a.stepperMicrostepCurve[currStep-adafruit2348StepperMicrosteps*3]
-			pwmB = a.stepperMicrostepCurve[adafruit2348StepperMicrosteps*4-currStep]
+			pwmA = d.stepperMicrostepCurve[currStep-adafruit2348StepperMicrosteps*3]
+			pwmB = d.stepperMicrostepCurve[adafruit2348StepperMicrosteps*4-currStep]
 		}
 	} // switch
 
 	// go to next 'step' and wrap around
-	a.stepperMotors[motor].currentStep += adafruit2348StepperMicrosteps * 4
-	a.stepperMotors[motor].currentStep %= adafruit2348StepperMicrosteps * 4
+	d.stepperMotors[motor].currentStep += adafruit2348StepperMicrosteps * 4
+	d.stepperMotors[motor].currentStep %= adafruit2348StepperMicrosteps * 4
 
 	// only really used for microstepping, otherwise always on!
 	//nolint:gosec // TODO: fix later
-	if err := a.SetPWM(int(a.stepperMotors[motor].pwmPinA), 0, uint16(pwmA*16)); err != nil {
+	if err := d.SetPWM(int(d.stepperMotors[motor].pwmPinA), 0, uint16(pwmA*16)); err != nil {
 		return 0, err
 	}
 	//nolint:gosec // TODO: fix later
-	if err := a.SetPWM(int(a.stepperMotors[motor].pwmPinB), 0, uint16(pwmB*16)); err != nil {
+	if err := d.SetPWM(int(d.stepperMotors[motor].pwmPinB), 0, uint16(pwmB*16)); err != nil {
 		return 0, err
 	}
 	var coils []int32
-	currStep := a.stepperMotors[motor].currentStep
+	currStep := d.stepperMotors[motor].currentStep
 	if style == Adafruit2348Microstep {
 		switch {
 		case currStep >= 0 && currStep < adafruit2348StepperMicrosteps:
@@ -305,34 +305,34 @@ func (a *Adafruit2348Driver) oneStep(motor int, dir Adafruit2348Direction, style
 		}
 	} else {
 		// step-2-coils is initialized in init()
-		coils = a.step2coils[(currStep / (adafruit2348StepperMicrosteps / 2))]
+		coils = d.step2coils[(currStep / (adafruit2348StepperMicrosteps / 2))]
 	}
 	if adafruit2348Debug {
 		log.Printf("[adafruit2348_driver] currStep: %d, index into step2coils: %d\n",
 			currStep, (currStep / (adafruit2348StepperMicrosteps / 2)))
 		log.Printf("[adafruit2348_driver] coils state = %v", coils)
 	}
-	if err := a.setPin(a.stepperMotors[motor].ain2, coils[0]); err != nil {
+	if err := d.setPin(d.stepperMotors[motor].ain2, coils[0]); err != nil {
 		return 0, err
 	}
-	if err := a.setPin(a.stepperMotors[motor].bin1, coils[1]); err != nil {
+	if err := d.setPin(d.stepperMotors[motor].bin1, coils[1]); err != nil {
 		return 0, err
 	}
-	if err := a.setPin(a.stepperMotors[motor].ain1, coils[2]); err != nil {
+	if err := d.setPin(d.stepperMotors[motor].ain1, coils[2]); err != nil {
 		return 0, err
 	}
-	if err := a.setPin(a.stepperMotors[motor].bin2, coils[3]); err != nil {
+	if err := d.setPin(d.stepperMotors[motor].bin2, coils[3]); err != nil {
 		return 0, err
 	}
-	return a.stepperMotors[motor].currentStep, nil
+	return d.stepperMotors[motor].currentStep, nil
 }
 
-func (a *Adafruit2348Driver) setPin(pin byte, value int32) error {
+func (d *Adafruit2348Driver) setPin(pin byte, value int32) error {
 	if value == 0 {
-		return a.SetPWM(int(pin), 0, 4096)
+		return d.SetPWM(int(pin), 0, 4096)
 	}
 	if value == 1 {
-		return a.SetPWM(int(pin), 4096, 0)
+		return d.SetPWM(int(pin), 4096, 0)
 	}
 	return errors.New("invalid pin")
 }

--- a/drivers/i2c/adafruit2348_driver_test.go
+++ b/drivers/i2c/adafruit2348_driver_test.go
@@ -33,6 +33,15 @@ func TestNewAdafruit2348Driver(t *testing.T) {
 	assert.Equal(t, 0x60, d.GetAddressOrDefault(d.defaultAddress)) // the really used address
 }
 
+func TestAdafruit2348Halt(t *testing.T) {
+	// arrange
+	d := NewAdafruit2348Driver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestAdafruit2348Options(t *testing.T) {
 	// This is a general test, that options are applied in constructor by using the common WithBus() option and
 	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".

--- a/drivers/i2c/ads1x15_driver.go
+++ b/drivers/i2c/ads1x15_driver.go
@@ -476,11 +476,11 @@ func (d *ADS1x15Driver) waitForConversionFinished(delay time.Duration) error {
 }
 
 func (d *ADS1x15Driver) writeWordBigEndian(reg uint8, val uint16) error {
-	return d.connection.WriteWordData(reg, swapBytes(val))
+	return d.writeWordData(reg, swapBytes(val))
 }
 
 func (d *ADS1x15Driver) readWordBigEndian(reg uint8) (uint16, error) {
-	data, err := d.connection.ReadWordData(reg)
+	data, err := d.readWordData(reg)
 	if err != nil {
 		return 0, err
 	}

--- a/drivers/i2c/ads1x15_driver_1015_test.go
+++ b/drivers/i2c/ads1x15_driver_1015_test.go
@@ -32,6 +32,15 @@ func TestNewADS1015Driver(t *testing.T) {
 	}
 }
 
+func TestADS1015Halt(t *testing.T) {
+	// arrange
+	d := NewADS1015Driver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestADS1015Options(t *testing.T) {
 	// This is a general test, that options are applied in constructor by using the common WithBus() option and
 	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".

--- a/drivers/i2c/ads1x15_driver_1115_test.go
+++ b/drivers/i2c/ads1x15_driver_1115_test.go
@@ -32,6 +32,15 @@ func TestNewADS1115Driver(t *testing.T) {
 	}
 }
 
+func TestADS1115Halt(t *testing.T) {
+	// arrange
+	d := NewADS1115Driver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestADS1115Options(t *testing.T) {
 	// This is a general test, that options are applied in constructor by using the common WithBus() option and
 	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".

--- a/drivers/i2c/adxl345_driver.go
+++ b/drivers/i2c/adxl345_driver.go
@@ -2,7 +2,6 @@ package i2c
 
 import (
 	"encoding/binary"
-	"fmt"
 	"log"
 )
 
@@ -192,7 +191,7 @@ func (d *ADXL345Driver) UseLowPower(lowPower bool) error {
 	defer d.mutex.Unlock()
 
 	d.bwRate.lowPower = lowPower
-	return d.connection.WriteByteData(adxl345Reg_BW_RATE, d.bwRate.toByte())
+	return d.writeByteData(adxl345Reg_BW_RATE, d.bwRate.toByte())
 }
 
 // SetRate change the current rate of the sensor immediately
@@ -201,7 +200,7 @@ func (d *ADXL345Driver) SetRate(rate ADXL345RateConfig) error {
 	defer d.mutex.Unlock()
 
 	d.bwRate.rate = rate
-	return d.connection.WriteByteData(adxl345Reg_BW_RATE, d.bwRate.toByte())
+	return d.writeByteData(adxl345Reg_BW_RATE, d.bwRate.toByte())
 }
 
 // SetRange change the current range of the sensor immediately
@@ -210,7 +209,7 @@ func (d *ADXL345Driver) SetRange(fullScaleRange ADXL345FsRangeConfig) error {
 	defer d.mutex.Unlock()
 
 	d.dataFormat.fullScaleRange = fullScaleRange
-	return d.connection.WriteByteData(adxl345Reg_DATA_FORMAT, d.dataFormat.toByte())
+	return d.writeByteData(adxl345Reg_DATA_FORMAT, d.dataFormat.toByte())
 }
 
 // XYZ returns the adjusted x, y and z axis, unit [g]
@@ -236,7 +235,7 @@ func (d *ADXL345Driver) RawXYZ() (int16, int16, int16, error) {
 
 func (d *ADXL345Driver) readRawData() (int16, int16, int16, error) {
 	buf := []byte{0, 0, 0, 0, 0, 0}
-	if err := d.connection.ReadBlockData(adxl345Reg_DATAX0, buf); err != nil {
+	if err := d.readBlockData(adxl345Reg_DATAX0, buf); err != nil {
 		return 0, 0, 0, err
 	}
 
@@ -247,13 +246,13 @@ func (d *ADXL345Driver) readRawData() (int16, int16, int16, error) {
 }
 
 func (d *ADXL345Driver) initialize() error {
-	if err := d.connection.WriteByteData(adxl345Reg_BW_RATE, d.bwRate.toByte()); err != nil {
+	if err := d.writeByteData(adxl345Reg_BW_RATE, d.bwRate.toByte()); err != nil {
 		return err
 	}
-	if err := d.connection.WriteByteData(adxl345Reg_POWER_CTL, d.powerCtl.toByte()); err != nil {
+	if err := d.writeByteData(adxl345Reg_POWER_CTL, d.powerCtl.toByte()); err != nil {
 		return err
 	}
-	if err := d.connection.WriteByteData(adxl345Reg_DATA_FORMAT, d.dataFormat.toByte()); err != nil {
+	if err := d.writeByteData(adxl345Reg_DATA_FORMAT, d.dataFormat.toByte()); err != nil {
 		return err
 	}
 
@@ -261,11 +260,12 @@ func (d *ADXL345Driver) initialize() error {
 }
 
 func (d *ADXL345Driver) shutdown() error {
-	d.powerCtl.measure = 0
 	if d.connection == nil {
-		return fmt.Errorf("connection not available")
+		return nil
 	}
-	return d.connection.WriteByteData(adxl345Reg_POWER_CTL, d.powerCtl.toByte())
+
+	d.powerCtl.measure = 0
+	return d.writeByteData(adxl345Reg_POWER_CTL, d.powerCtl.toByte())
 }
 
 // convertToG converts the given raw value by range configuration to the unit [g]

--- a/drivers/i2c/adxl345_driver_test.go
+++ b/drivers/i2c/adxl345_driver_test.go
@@ -36,6 +36,15 @@ func TestNewADXL345Driver(t *testing.T) {
 	assert.True(t, d.bwRate.lowPower)
 }
 
+func TestADXL345Halt(t *testing.T) {
+	// arrange
+	d := NewADXL345Driver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestADXL345Options(t *testing.T) {
 	// This is a general test, that options are applied in constructor by using the common WithBus() option and
 	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".

--- a/drivers/i2c/bh1750_driver.go
+++ b/drivers/i2c/bh1750_driver.go
@@ -36,24 +36,24 @@ type BH1750Driver struct {
 //	i2c.WithBus(int):	bus to use with this driver
 //	i2c.WithAddress(int):	address to use with this driver
 func NewBH1750Driver(c Connector, options ...func(Config)) *BH1750Driver {
-	h := &BH1750Driver{
+	d := &BH1750Driver{
 		Driver: NewDriver(c, "BH1750", bh1750DefaultAddress),
 		mode:   BH1750_CONTINUOUS_HIGH_RES_MODE,
 	}
-	h.afterStart = h.initialize
+	d.afterStart = d.initialize
 
 	for _, option := range options {
-		option(h)
+		option(d)
 	}
 
 	// TODO: add commands for API
-	return h
+	return d
 }
 
 // RawSensorData returns the raw value from the bh1750
-func (h *BH1750Driver) RawSensorData() (int, error) {
+func (d *BH1750Driver) RawSensorData() (int, error) {
 	buf := []byte{0, 0}
-	bytesRead, err := h.connection.Read(buf)
+	bytesRead, err := d.read(buf)
 	if err != nil {
 		return 0, err
 	}
@@ -67,15 +67,15 @@ func (h *BH1750Driver) RawSensorData() (int, error) {
 }
 
 // Lux returns the adjusted value from the bh1750
-func (h *BH1750Driver) Lux() (int, error) {
-	rawLux, err := h.RawSensorData()
+func (d *BH1750Driver) Lux() (int, error) {
+	rawLux, err := d.RawSensorData()
 	lux := int(float64(rawLux) / 1.2)
 
 	return lux, err
 }
 
-func (h *BH1750Driver) initialize() error {
-	err := h.connection.WriteByte(h.mode)
+func (d *BH1750Driver) initialize() error {
+	err := d.writeByte(d.mode)
 	time.Sleep(10 * time.Microsecond)
 	if err != nil {
 		return err

--- a/drivers/i2c/bh1750_driver_test.go
+++ b/drivers/i2c/bh1750_driver_test.go
@@ -49,7 +49,9 @@ func TestBH1750Start(t *testing.T) {
 }
 
 func TestBH1750Halt(t *testing.T) {
-	d, _ := initTestBH1750DriverWithStubbedAdaptor()
+	d := NewBH1750Driver(newI2cTestAdaptor())
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
 	require.NoError(t, d.Halt())
 }
 

--- a/drivers/i2c/blinkm_driver_test.go
+++ b/drivers/i2c/blinkm_driver_test.go
@@ -49,7 +49,9 @@ func TestBlinkMStart(t *testing.T) {
 }
 
 func TestBlinkMHalt(t *testing.T) {
-	d, _ := initTestBlinkMDriverWithStubbedAdaptor()
+	d := NewBlinkMDriver(newI2cTestAdaptor())
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
 	require.NoError(t, d.Halt())
 }
 

--- a/drivers/i2c/bme280_driver.go
+++ b/drivers/i2c/bme280_driver.go
@@ -154,7 +154,7 @@ func (d *BME280Driver) initializationBME280() error {
 
 // read the humidity calibration coefficients.
 func (d *BME280Driver) initHumidity() error {
-	hch1, err := d.connection.ReadByteData(bme280RegCalibDigH1)
+	hch1, err := d.readByteData(bme280RegCalibDigH1)
 	if err != nil {
 		return err
 	}
@@ -164,7 +164,7 @@ func (d *BME280Driver) initHumidity() error {
 	}
 
 	coefficients := make([]byte, 7)
-	if err = d.connection.ReadBlockData(bme280RegCalibDigH2LSB, coefficients); err != nil {
+	if err = d.readBlockData(bme280RegCalibDigH2LSB, coefficients); err != nil {
 		return err
 	}
 	buf = bytes.NewBuffer(coefficients)
@@ -204,21 +204,21 @@ func (d *BME280Driver) initHumidity() error {
 	// The 'ctrl_hum' register (0xF2) sets the humidity data acquisition options of
 	// the device. Changes to this register only become effective after a write
 	// operation to 'ctrl_meas' (0xF4). So we read the current value in, then write it back
-	if err := d.connection.WriteByteData(bme280RegControlHumidity, uint8(d.ctrlHumOversamp)); err != nil {
+	if err := d.writeByteData(bme280RegControlHumidity, uint8(d.ctrlHumOversamp)); err != nil {
 		return err
 	}
 
-	cmr, err := d.connection.ReadByteData(bmp280RegCtrl)
+	cmr, err := d.readByteData(bmp280RegCtrl)
 	if err != nil {
 		return err
 	}
 
-	return d.connection.WriteByteData(bmp280RegCtrl, cmr)
+	return d.writeByteData(bmp280RegCtrl, cmr)
 }
 
 func (d *BME280Driver) rawHumidity() (uint32, error) {
 	ret := make([]byte, 2)
-	if err := d.connection.ReadBlockData(bme280RegHumidityMSB, ret); err != nil {
+	if err := d.readBlockData(bme280RegHumidityMSB, ret); err != nil {
 		return 0, err
 	}
 	if ret[0] == 0x80 && ret[1] == 0x00 {

--- a/drivers/i2c/bme280_driver_test.go
+++ b/drivers/i2c/bme280_driver_test.go
@@ -38,6 +38,15 @@ func TestNewBME280Driver(t *testing.T) {
 	assert.NotNil(t, d.calCoeffs)
 }
 
+func TestBME280Halt(t *testing.T) {
+	// arrange
+	d := NewBME280Driver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestBME280Options(t *testing.T) {
 	// This is a general test, that options are applied in constructor by using the common WithBus() option and
 	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".

--- a/drivers/i2c/bmp180_driver.go
+++ b/drivers/i2c/bmp180_driver.go
@@ -126,7 +126,7 @@ func (d *BMP180Driver) Pressure() (float32, error) {
 func (d *BMP180Driver) initialization() error {
 	// read the 11 calibration coefficients.
 	coefficients := make([]byte, 22)
-	if err := d.connection.ReadBlockData(bmp180RegisterAC1MSB, coefficients); err != nil {
+	if err := d.readBlockData(bmp180RegisterAC1MSB, coefficients); err != nil {
 		return err
 	}
 	buf := bytes.NewBuffer(coefficients)
@@ -164,12 +164,12 @@ func (d *BMP180Driver) initialization() error {
 }
 
 func (d *BMP180Driver) rawTemp() (int16, error) {
-	if _, err := d.connection.Write([]byte{bmp180RegisterCtl, bmp180CtlTemp}); err != nil {
+	if _, err := d.write([]byte{bmp180RegisterCtl, bmp180CtlTemp}); err != nil {
 		return 0, err
 	}
 	time.Sleep(5 * time.Millisecond)
 	ret := make([]byte, 2)
-	err := d.connection.ReadBlockData(bmp180RegisterDataMSB, ret)
+	err := d.readBlockData(bmp180RegisterDataMSB, ret)
 	if err != nil {
 		return 0, err
 	}
@@ -194,12 +194,12 @@ func (d *BMP180Driver) calculateB5(rawTemp int16) int32 {
 }
 
 func (d *BMP180Driver) rawPressure(oversampling BMP180OversamplingMode) (int32, error) {
-	if _, err := d.connection.Write([]byte{bmp180RegisterCtl, bmp180CtlPressure + byte(oversampling<<6)}); err != nil {
+	if _, err := d.write([]byte{bmp180RegisterCtl, bmp180CtlPressure + byte(oversampling<<6)}); err != nil {
 		return 0, err
 	}
 	time.Sleep(bmp180PauseForReading(oversampling))
 	ret := make([]byte, 3)
-	if err := d.connection.ReadBlockData(bmp180RegisterDataMSB, ret); err != nil {
+	if err := d.readBlockData(bmp180RegisterDataMSB, ret); err != nil {
 		return 0, err
 	}
 	rawPressure := (int32(ret[0])<<16 + int32(ret[1])<<8 + int32(ret[2])) >> (8 - uint(oversampling))

--- a/drivers/i2c/bmp180_driver_test.go
+++ b/drivers/i2c/bmp180_driver_test.go
@@ -37,6 +37,15 @@ func TestNewBMP180Driver(t *testing.T) {
 	assert.NotNil(t, d.calCoeffs)
 }
 
+func TestBMP180Halt(t *testing.T) {
+	// arrange
+	d := NewBMP180Driver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestBMP180Options(t *testing.T) {
 	// This is a general test, that options are applied in constructor by using the common WithBus() option and
 	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".

--- a/drivers/i2c/bmp280_driver.go
+++ b/drivers/i2c/bmp280_driver.go
@@ -211,7 +211,7 @@ func (d *BMP280Driver) Altitude() (float32, error) {
 // initialization reads the calibration coefficients.
 func (d *BMP280Driver) initialization() error {
 	coefficients := make([]byte, 24)
-	if err := d.connection.ReadBlockData(bmp280RegCalib00, coefficients); err != nil {
+	if err := d.readBlockData(bmp280RegCalib00, coefficients); err != nil {
 		return err
 	}
 	buf := bytes.NewBuffer(coefficients)
@@ -253,19 +253,19 @@ func (d *BMP280Driver) initialization() error {
 	}
 
 	ctrlReg := d.ctrlPwrMode | uint8(d.ctrlPressOversamp)<<2 | uint8(d.ctrlTempOversamp)<<5
-	if err := d.connection.WriteByteData(bmp280RegCtrl, ctrlReg); err != nil {
+	if err := d.writeByteData(bmp280RegCtrl, ctrlReg); err != nil {
 		return err
 	}
 
 	confReg := uint8(bmp280ConfStandBy0005)<<2 | uint8(d.confFilter)<<5
-	return d.connection.WriteByteData(bmp280RegConf, confReg & ^uint8(bmp280ConfSPIBit))
+	return d.writeByteData(bmp280RegConf, confReg & ^uint8(bmp280ConfSPIBit))
 }
 
 func (d *BMP280Driver) rawTemp() (int32, error) {
 	var tp0, tp1, tp2 byte
 
 	data := make([]byte, 3)
-	if err := d.connection.ReadBlockData(bmp280RegTempData, data); err != nil {
+	if err := d.readBlockData(bmp280RegTempData, data); err != nil {
 		return 0, err
 	}
 	buf := bytes.NewBuffer(data)
@@ -286,7 +286,7 @@ func (d *BMP280Driver) rawPressure() (int32, error) {
 	var tp0, tp1, tp2 byte
 
 	data := make([]byte, 3)
-	if err := d.connection.ReadBlockData(bmp280RegPressureData, data); err != nil {
+	if err := d.readBlockData(bmp280RegPressureData, data); err != nil {
 		return 0, err
 	}
 	buf := bytes.NewBuffer(data)

--- a/drivers/i2c/bmp280_driver_test.go
+++ b/drivers/i2c/bmp280_driver_test.go
@@ -37,6 +37,15 @@ func TestNewBMP280Driver(t *testing.T) {
 	assert.NotNil(t, d.calCoeffs)
 }
 
+func TestBMP280Halt(t *testing.T) {
+	// arrange
+	d := NewBMP280Driver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestBMP280Options(t *testing.T) {
 	// This is a general test, that options are applied in constructor by using the common WithBus() option and
 	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".

--- a/drivers/i2c/bmp388_driver.go
+++ b/drivers/i2c/bmp388_driver.go
@@ -138,12 +138,12 @@ func (d *BMP388Driver) Temperature(accuracy BMP388Accuracy) (float32, error) {
 	defer d.mutex.Unlock()
 
 	mode := d.ctrlPwrMode<<4 | bmp388PWRCTRLPressEnableBit | bmp388PWRCTRLTempEnableBit
-	if err := d.connection.WriteByteData(bmp388RegPWRCTRL, mode); err != nil {
+	if err := d.writeByteData(bmp388RegPWRCTRL, mode); err != nil {
 		return 0, err
 	}
 
 	// Set Accuracy for temperature
-	if err := d.connection.WriteByteData(bmp388RegOSR, uint8(accuracy<<3)); err != nil {
+	if err := d.writeByteData(bmp388RegOSR, uint8(accuracy<<3)); err != nil {
 		return 0, err
 	}
 
@@ -163,12 +163,12 @@ func (d *BMP388Driver) Pressure(accuracy BMP388Accuracy) (float32, error) {
 	defer d.mutex.Unlock()
 
 	mode := d.ctrlPwrMode<<4 | bmp388PWRCTRLPressEnableBit | bmp388PWRCTRLTempEnableBit
-	if err := d.connection.WriteByteData(bmp388RegPWRCTRL, mode); err != nil {
+	if err := d.writeByteData(bmp388RegPWRCTRL, mode); err != nil {
 		return 0, err
 	}
 
 	// Set Standard Accuracy for pressure
-	if err := d.connection.WriteByteData(bmp388RegOSR, uint8(accuracy)); err != nil {
+	if err := d.writeByteData(bmp388RegOSR, uint8(accuracy)); err != nil {
 		return 0, err
 	}
 
@@ -202,7 +202,7 @@ func (d *BMP388Driver) Altitude(accuracy BMP388Accuracy) (float32, error) {
 
 // initialization reads the calibration coefficients.
 func (d *BMP388Driver) initialization() error {
-	chipID, err := d.connection.ReadByteData(bmp388RegChipID)
+	chipID, err := d.readByteData(bmp388RegChipID)
 	if err != nil {
 		return err
 	}
@@ -229,7 +229,7 @@ func (d *BMP388Driver) initialization() error {
 	)
 
 	coefficients := make([]byte, 24)
-	if err = d.connection.ReadBlockData(bmp388RegCalib00, coefficients); err != nil {
+	if err = d.readBlockData(bmp388RegCalib00, coefficients); err != nil {
 		return err
 	}
 	buf := bytes.NewBuffer(coefficients)
@@ -292,18 +292,18 @@ func (d *BMP388Driver) initialization() error {
 	d.calCoeffs.p10 = float32(float64(p10) / math.Pow(2, 48))
 	d.calCoeffs.p11 = float32(float64(p11) / math.Pow(2, 65))
 
-	if err := d.connection.WriteByteData(bmp388RegCMD, bmp388CMDSoftReset); err != nil {
+	if err := d.writeByteData(bmp388RegCMD, bmp388CMDSoftReset); err != nil {
 		return err
 	}
 
-	return d.connection.WriteByteData(bmp388RegConf, uint8(d.confFilter)<<1)
+	return d.writeByteData(bmp388RegConf, uint8(d.confFilter)<<1)
 }
 
 func (d *BMP388Driver) rawTemp() (int32, error) {
 	var tp0, tp1, tp2 byte
 
 	data := make([]byte, 3)
-	if err := d.connection.ReadBlockData(bmp388RegTempData, data); err != nil {
+	if err := d.readBlockData(bmp388RegTempData, data); err != nil {
 		return 0, err
 	}
 	buf := bytes.NewBuffer(data)
@@ -327,7 +327,7 @@ func (d *BMP388Driver) rawPressure() (int32, error) {
 	var tp0, tp1, tp2 byte
 
 	data := make([]byte, 3)
-	if err := d.connection.ReadBlockData(bmp388RegPressureData, data); err != nil {
+	if err := d.readBlockData(bmp388RegPressureData, data); err != nil {
 		return 0, err
 	}
 	buf := bytes.NewBuffer(data)

--- a/drivers/i2c/bmp388_driver_test.go
+++ b/drivers/i2c/bmp388_driver_test.go
@@ -54,6 +54,15 @@ func TestNewBMP388Driver(t *testing.T) {
 	assert.NotNil(t, d.calCoeffs)
 }
 
+func TestBMP388Halt(t *testing.T) {
+	// arrange
+	d, _ := initTestBMP388WithStubbedAdaptor()
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestBMP388Options(t *testing.T) {
 	// This is a general test, that options are applied in constructor by using the common WithBus() option and
 	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".

--- a/drivers/i2c/ccs811_driver.go
+++ b/drivers/i2c/ccs811_driver.go
@@ -163,7 +163,7 @@ func (d *CCS811Driver) GetHardwareVersion() (uint8, error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	v, err := d.connection.ReadByteData(ccs811RegHwVersion)
+	v, err := d.readByteData(ccs811RegHwVersion)
 	if err != nil {
 		return 0, err
 	}
@@ -176,7 +176,7 @@ func (d *CCS811Driver) GetFirmwareBootVersion() (uint16, error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	v, err := d.connection.ReadWordData(ccs811RegFwBootVersion)
+	v, err := d.readWordData(ccs811RegFwBootVersion)
 	if err != nil {
 		return 0, err
 	}
@@ -189,7 +189,7 @@ func (d *CCS811Driver) GetFirmwareAppVersion() (uint16, error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	v, err := d.connection.ReadWordData(ccs811RegFwAppVersion)
+	v, err := d.readWordData(ccs811RegFwAppVersion)
 	if err != nil {
 		return 0, err
 	}
@@ -202,7 +202,7 @@ func (d *CCS811Driver) GetStatus() (*CCS811Status, error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	s, err := d.connection.ReadByteData(ccs811RegStatus)
+	s, err := d.readByteData(ccs811RegStatus)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func (d *CCS811Driver) GetTemperature() (float32, error) {
 	defer d.mutex.Unlock()
 
 	buf := make([]byte, 4)
-	err := d.connection.ReadBlockData(ccs811RegNtc, buf)
+	err := d.readBlockData(ccs811RegNtc, buf)
 	if err != nil {
 		return 0, err
 	}
@@ -243,7 +243,7 @@ func (d *CCS811Driver) GetGasData() (uint16, uint16, error) {
 	defer d.mutex.Unlock()
 
 	data := make([]byte, 4)
-	err := d.connection.ReadBlockData(ccs811RegAlgResultData, data)
+	err := d.readBlockData(ccs811RegAlgResultData, data)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -276,7 +276,7 @@ func (d *CCS811Driver) EnableExternalInterrupt() error {
 	defer d.mutex.Unlock()
 
 	d.measMode.intDataRdy = 1
-	return d.connection.WriteByteData(ccs811RegMeasMode, d.measMode.GetMeasMode())
+	return d.writeByteData(ccs811RegMeasMode, d.measMode.GetMeasMode())
 }
 
 // DisableExternalInterrupt disables the external output hardware interrupt pin 3.
@@ -285,11 +285,11 @@ func (d *CCS811Driver) DisableExternalInterrupt() error {
 	defer d.mutex.Unlock()
 
 	d.measMode.intDataRdy = 0
-	return d.connection.WriteByteData(ccs811RegMeasMode, d.measMode.GetMeasMode())
+	return d.writeByteData(ccs811RegMeasMode, d.measMode.GetMeasMode())
 }
 
 func (d *CCS811Driver) initialize() error {
-	deviceID, err := d.connection.ReadByteData(ccs811RegHwID)
+	deviceID, err := d.readByteData(ccs811RegHwID)
 	if err != nil {
 		return fmt.Errorf("failed to get the device id from ccs811RegHwID with error: %s", err.Error())
 	}
@@ -320,18 +320,18 @@ func (d *CCS811Driver) initialize() error {
 // ResetDevice does a software reset of the device. After this operation is done,
 // the user must start the app code before the sensor can take any measurements
 func (d *CCS811Driver) resetDevice() error {
-	return d.connection.WriteBlockData(ccs811RegSwReset, ccs811SwResetSequence)
+	return d.writeBlockData(ccs811RegSwReset, ccs811SwResetSequence)
 }
 
 // startApp starts the app code in the device. This operation has to be done after a
 // software reset to start taking sensor measurements.
 func (d *CCS811Driver) startApp() error {
 	// Write without data is needed to start the app code
-	_, err := d.connection.Write([]byte{ccs811RegAppStart})
+	_, err := d.write([]byte{ccs811RegAppStart})
 	return err
 }
 
 // updateMeasMode writes the current value of measMode to the measurement mode register.
 func (d *CCS811Driver) updateMeasMode() error {
-	return d.connection.WriteByteData(ccs811RegMeasMode, d.measMode.GetMeasMode())
+	return d.writeByteData(ccs811RegMeasMode, d.measMode.GetMeasMode())
 }

--- a/drivers/i2c/ccs811_driver_test.go
+++ b/drivers/i2c/ccs811_driver_test.go
@@ -17,6 +17,11 @@ var _ gobot.Driver = (*CCS811Driver)(nil)
 
 func initTestCCS811WithStubbedAdaptor() (*CCS811Driver, *i2cTestAdaptor) {
 	a := newI2cTestAdaptor()
+	// mandatory for a successful start
+	a.i2cReadImpl = func(b []byte) (int, error) {
+		b[0] = ccs811HwIDCode
+		return len(b), nil
+	}
 	return NewCCS811Driver(a), a
 }
 
@@ -31,6 +36,15 @@ func TestNewCCS811Driver(t *testing.T) {
 	assert.Equal(t, 0x5A, d.defaultAddress)
 	assert.NotNil(t, d.measMode)
 	assert.Equal(t, uint32(100000), d.ntcResistanceValue)
+}
+
+func TestCCS811Halt(t *testing.T) {
+	// arrange
+	d, _ := initTestCCS811WithStubbedAdaptor()
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
 }
 
 func TestCCS811Options(t *testing.T) {
@@ -88,7 +102,7 @@ func TestCCS811GetGasData(t *testing.T) {
 			d, a := initTestCCS811WithStubbedAdaptor()
 			// Create stub function as it is needed by read submethod in driver code
 			a.i2cWriteImpl = func([]byte) (int, error) { return 0, nil }
-			_ = d.Start()
+			require.NoError(t, d.Start())
 			a.i2cReadImpl = tc.readReturn
 			// act
 			eco2, tvoc, err := d.GetGasData()
@@ -145,7 +159,7 @@ func TestCCS811GetTemperature(t *testing.T) {
 			d, a := initTestCCS811WithStubbedAdaptor()
 			// Create stub function as it is needed by read submethod in driver code
 			a.i2cWriteImpl = func([]byte) (int, error) { return 0, nil }
-			_ = d.Start()
+			require.NoError(t, d.Start())
 			a.i2cReadImpl = tc.readReturn
 			// act
 			temp, err := d.GetTemperature()
@@ -209,7 +223,7 @@ func TestCCS811HasData(t *testing.T) {
 			d, a := initTestCCS811WithStubbedAdaptor()
 			// Create stub function as it is needed by read submethod in driver code
 			a.i2cWriteImpl = func([]byte) (int, error) { return 0, nil }
-			_ = d.Start()
+			require.NoError(t, d.Start())
 			a.i2cReadImpl = tc.readReturn
 			// act
 			result, err := d.HasData()

--- a/drivers/i2c/drv2605l_driver.go
+++ b/drivers/i2c/drv2605l_driver.go
@@ -99,7 +99,7 @@ func NewDRV2605LDriver(c Connector, options ...func(Config)) *DRV2605LDriver {
 // SetMode sets the device in one of the eight modes as described in the
 // datasheet. Defaults to mode 0, internal trig.
 func (d *DRV2605LDriver) SetMode(newMode DRV2605Mode) error {
-	mode, err := d.connection.ReadByteData(drv2605RegMode)
+	mode, err := d.readByteData(drv2605RegMode)
 	if err != nil {
 		return err
 	}
@@ -109,14 +109,14 @@ func (d *DRV2605LDriver) SetMode(newMode DRV2605Mode) error {
 	// set new mode bits
 	mode |= uint8(newMode)
 
-	err = d.connection.WriteByteData(drv2605RegMode, mode)
+	err = d.writeByteData(drv2605RegMode, mode)
 
 	return err
 }
 
 // SetStandbyMode controls device low power mode
 func (d *DRV2605LDriver) SetStandbyMode(standby bool) error {
-	modeVal, err := d.connection.ReadByteData(drv2605RegMode)
+	modeVal, err := d.readByteData(drv2605RegMode)
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func (d *DRV2605LDriver) SetStandbyMode(standby bool) error {
 		modeVal &= 0xFF ^ drv2605Standby
 	}
 
-	err = d.connection.WriteByteData(drv2605RegMode, modeVal)
+	err = d.writeByteData(drv2605RegMode, modeVal)
 
 	return err
 }
@@ -134,7 +134,7 @@ func (d *DRV2605LDriver) SetStandbyMode(standby bool) error {
 // SelectLibrary selects which waveform library to play from, 1-7.
 // See datasheet for more info.
 func (d *DRV2605LDriver) SelectLibrary(library uint8) error {
-	return d.connection.WriteByteData(drv2605RegLibrary, library&0x7)
+	return d.writeByteData(drv2605RegLibrary, library&0x7)
 }
 
 // GetPauseWaveform returns a special waveform ID used in SetSequence() to encode
@@ -164,7 +164,7 @@ func (d *DRV2605LDriver) SetSequence(waveforms []uint8) error {
 	}
 	for i, w := range waveforms {
 		//nolint:gosec // TODO: fix later
-		if err := d.connection.WriteByteData(uint8(drv2605RegWaveSeq1+i), w); err != nil {
+		if err := d.writeByteData(uint8(drv2605RegWaveSeq1+i), w); err != nil {
 			return err
 		}
 	}
@@ -174,12 +174,12 @@ func (d *DRV2605LDriver) SetSequence(waveforms []uint8) error {
 
 // Go plays the current sequence of waveforms.
 func (d *DRV2605LDriver) Go() error {
-	return d.connection.WriteByteData(drv2605RegGo, 1)
+	return d.writeByteData(drv2605RegGo, 1)
 }
 
 func (d *DRV2605LDriver) writeByteRegisters(regValPairs []struct{ reg, val uint8 }) error {
 	for _, rv := range regValPairs {
-		if err := d.connection.WriteByteData(rv.reg, rv.val); err != nil {
+		if err := d.writeByteData(rv.reg, rv.val); err != nil {
 			return err
 		}
 	}
@@ -187,12 +187,12 @@ func (d *DRV2605LDriver) writeByteRegisters(regValPairs []struct{ reg, val uint8
 }
 
 func (d *DRV2605LDriver) initialize() error {
-	feedback, err := d.connection.ReadByteData(drv2605RegFeedback)
+	feedback, err := d.readByteData(drv2605RegFeedback)
 	if err != nil {
 		return err
 	}
 
-	control, err := d.connection.ReadByteData(drv2605RegControl3)
+	control, err := d.readByteData(drv2605RegControl3)
 	if err != nil {
 		return err
 	}
@@ -218,7 +218,7 @@ func (d *DRV2605LDriver) initialize() error {
 func (d *DRV2605LDriver) shutdown() error {
 	if d.connection != nil {
 		// stop playback
-		if err := d.connection.WriteByteData(drv2605RegGo, 0); err != nil {
+		if err := d.writeByteData(drv2605RegGo, 0); err != nil {
 			return err
 		}
 

--- a/drivers/i2c/drv2605l_driver_test.go
+++ b/drivers/i2c/drv2605l_driver_test.go
@@ -56,7 +56,17 @@ func TestDRV2605LStart(t *testing.T) {
 	require.NoError(t, d.Start())
 }
 
+func TestDRV2605LHaltIdempotent(t *testing.T) {
+	// arrange
+	d := NewDRV2605LDriver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestDRV2605LHalt(t *testing.T) {
+	// arrange
 	writeStopPlaybackData := []byte{drv2605RegGo, 0}
 	// single-byte-read starts with a write operation to set the register for reading
 	// see section 8.5.3.5 of data sheet
@@ -64,7 +74,9 @@ func TestDRV2605LHalt(t *testing.T) {
 	writeNewStandbyModeData := []byte{drv2605RegMode, 42 | drv2605Standby}
 	d, a := initTestDRV2605LDriverWithStubbedAdaptor()
 	a.written = []byte{}
+	// act
 	require.NoError(t, d.Halt())
+	// assert
 	assert.Equal(t, append(append(writeStopPlaybackData, readCurrentStandbyModeData), writeNewStandbyModeData...),
 		a.written)
 }

--- a/drivers/i2c/generic_driver.go
+++ b/drivers/i2c/generic_driver.go
@@ -20,7 +20,7 @@ func (d *GenericDriver) WriteByte(val byte) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	return d.connection.WriteByte(val)
+	return d.writeByte(val)
 }
 
 // WriteByteData writes the given byte value to the given register of an i2c device.
@@ -28,7 +28,7 @@ func (d *GenericDriver) WriteByteData(reg uint8, val byte) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	return d.connection.WriteByteData(reg, val)
+	return d.writeByteData(reg, val)
 }
 
 // WriteWordData writes the given 16 bit value to the given register of an i2c device.
@@ -36,7 +36,7 @@ func (d *GenericDriver) WriteWordData(reg uint8, val uint16) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	return d.connection.WriteWordData(reg, val)
+	return d.writeWordData(reg, val)
 }
 
 // WriteBlockData writes the given buffer to the given register of an i2c device.
@@ -44,7 +44,7 @@ func (d *GenericDriver) WriteBlockData(reg uint8, data []byte) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	return d.connection.WriteBlockData(reg, data)
+	return d.writeBlockData(reg, data)
 }
 
 // WriteData writes the given buffer to the given register of an i2c device.
@@ -73,7 +73,7 @@ func (d *GenericDriver) ReadByte() (byte, error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	return d.connection.ReadByte()
+	return d.readByte()
 }
 
 // ReadByteData reads a byte from the given register of an i2c device.
@@ -81,7 +81,7 @@ func (d *GenericDriver) ReadByteData(reg uint8) (byte, error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	return d.connection.ReadByteData(reg)
+	return d.readByteData(reg)
 }
 
 // ReadWordData reads a 16 bit value starting from the given register of an i2c device.
@@ -89,7 +89,7 @@ func (d *GenericDriver) ReadWordData(reg uint8) (uint16, error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	return d.connection.ReadWordData(reg)
+	return d.readWordData(reg)
 }
 
 // ReadBlockData fills the given buffer with reads starting from the given register of an i2c device.
@@ -97,7 +97,7 @@ func (d *GenericDriver) ReadBlockData(reg uint8, data []byte) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	return d.connection.ReadBlockData(reg, data)
+	return d.readBlockData(reg, data)
 }
 
 // ReadData fills the given buffer with reads from the given register of an i2c device.
@@ -106,7 +106,7 @@ func (d *GenericDriver) ReadData(reg uint8, data []byte) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	if err := d.connection.WriteByte(reg); err != nil {
+	if err := d.writeByte(reg); err != nil {
 		return err
 	}
 
@@ -126,7 +126,7 @@ func (d *GenericDriver) Read(data []byte) error {
 }
 
 func (d *GenericDriver) writeAndCheckCount(data []byte) error {
-	n, err := d.connection.Write(data)
+	n, err := d.write(data)
 	if err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func (d *GenericDriver) writeAndCheckCount(data []byte) error {
 }
 
 func (d *GenericDriver) readAndCheckCount(data []byte) error {
-	n, err := d.connection.Read(data)
+	n, err := d.read(data)
 	if err != nil {
 		return err
 	}

--- a/drivers/i2c/grovepi_driver.go
+++ b/drivers/i2c/grovepi_driver.go
@@ -81,7 +81,7 @@ func (d *GrovePiDriver) AnalogRead(pin string) (int, error) {
 	}
 
 	buf := []byte{commandReadAnalog, byte(pinNum), 0, 0}
-	if _, err := d.connection.Write(buf); err != nil {
+	if _, err := d.write(buf); err != nil {
 		return 0, err
 	}
 
@@ -106,7 +106,7 @@ func (d *GrovePiDriver) DigitalRead(pin string) (int, error) {
 	}
 
 	buf := []byte{commandReadDigital, byte(pinNum), 0, 0}
-	if _, err := d.connection.Write(buf); err != nil {
+	if _, err := d.write(buf); err != nil {
 		return 0, err
 	}
 
@@ -135,7 +135,7 @@ func (d *GrovePiDriver) UltrasonicRead(pin string, duration int) (int, error) {
 	}
 
 	buf := []byte{commandReadUltrasonic, byte(pinNum), 0, 0}
-	if _, err = d.connection.Write(buf); err != nil {
+	if _, err = d.write(buf); err != nil {
 		return 0, err
 	}
 
@@ -155,7 +155,7 @@ func (d *GrovePiDriver) FirmwareVersionRead() (string, error) {
 	defer d.mutex.Unlock()
 
 	buf := []byte{commandReadFirmwareVersion, 0, 0, 0}
-	if _, err := d.connection.Write(buf); err != nil {
+	if _, err := d.write(buf); err != nil {
 		return "", err
 	}
 
@@ -188,7 +188,7 @@ func (d *GrovePiDriver) DHTRead(pin string, sensorType byte, duration int) (temp
 	}
 
 	buf := []byte{commandReadDHT, byte(pinNum), sensorType, 0}
-	if _, err = d.connection.Write(buf); err != nil {
+	if _, err = d.write(buf); err != nil {
 		return 0, 0, err
 	}
 	time.Sleep(time.Duration(duration) * time.Millisecond)
@@ -228,13 +228,13 @@ func (d *GrovePiDriver) DigitalWrite(pin string, val byte) error {
 	}
 
 	buf := []byte{commandWriteDigital, byte(pinNum), val, 0}
-	if _, err := d.connection.Write(buf); err != nil {
+	if _, err := d.write(buf); err != nil {
 		return err
 	}
 
 	time.Sleep(2 * time.Millisecond)
 
-	_, err = d.connection.ReadByte()
+	_, err = d.readByte()
 	return err
 }
 
@@ -249,13 +249,13 @@ func (d *GrovePiDriver) AnalogWrite(pin string, val int) error {
 	}
 
 	buf := []byte{commandWriteAnalog, byte(pinNum), byte(val), 0}
-	if _, err := d.connection.Write(buf); err != nil {
+	if _, err := d.write(buf); err != nil {
 		return err
 	}
 
 	time.Sleep(2 * time.Millisecond)
 
-	_, err = d.connection.ReadByte()
+	_, err = d.readByte()
 	return err
 }
 
@@ -284,13 +284,13 @@ func (d *GrovePiDriver) setPinMode(pin byte, mode string) error {
 	} else {
 		b = []byte{commandSetPinMode, pin, 0, 0}
 	}
-	if _, err := d.connection.Write(b); err != nil {
+	if _, err := d.write(b); err != nil {
 		return err
 	}
 
 	time.Sleep(2 * time.Millisecond)
 
-	_, err := d.connection.ReadByte()
+	_, err := d.readByte()
 	return err
 }
 
@@ -319,7 +319,7 @@ func (d *GrovePiDriver) preparePin(pin string, mode string) (int, error) {
 }
 
 func (d *GrovePiDriver) readForCommand(command byte, data []byte) error {
-	cnt, err := d.connection.Read(data)
+	cnt, err := d.read(data)
 	if err != nil {
 		return err
 	}

--- a/drivers/i2c/hmc5883l_driver.go
+++ b/drivers/i2c/hmc5883l_driver.go
@@ -122,7 +122,7 @@ var hmc5883lGainBits = map[float64]int{
 //	   i2c.WithHMC5883LMeasurementFlow(int)
 //	   i2c.WithHMC5883LGain(int)
 func NewHMC5883LDriver(c Connector, options ...func(Config)) *HMC5883LDriver {
-	h := &HMC5883LDriver{
+	d := &HMC5883LDriver{
 		Driver:          NewDriver(c, "HMC5883L", hmc5883lDefaultAddress),
 		samplesAvg:      8,
 		outputRate:      15000,
@@ -130,13 +130,13 @@ func NewHMC5883LDriver(c Connector, options ...func(Config)) *HMC5883LDriver {
 		measurementMode: hmc5883lRegM_Continuous,
 		gain:            390,
 	}
-	h.afterStart = h.initialize
+	d.afterStart = d.initialize
 
 	for _, option := range options {
-		option(h)
+		option(d)
 	}
 
-	return h
+	return d
 }
 
 // WithHMC5883LSamplesAveraged option sets the number of samples averaged per measurement.
@@ -206,23 +206,23 @@ func WithHMC5883LGain(val int) func(Config) {
 // Read reads the values X, Y, Z in Gauss
 //
 //nolint:nonamedreturns // is sufficient here
-func (h *HMC5883LDriver) Read() (x float64, y float64, z float64, err error) {
-	h.mutex.Lock()
-	defer h.mutex.Unlock()
+func (d *HMC5883LDriver) Read() (x float64, y float64, z float64, err error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
-	xr, yr, zr, err := h.readRawData()
+	xr, yr, zr, err := d.readRawData()
 	if err != nil {
 		return
 	}
-	return float64(xr) / h.gain, float64(yr) / h.gain, float64(zr) / h.gain, nil
+	return float64(xr) / d.gain, float64(yr) / d.gain, float64(zr) / d.gain, nil
 }
 
 // Heading returns the current heading in radians
-func (h *HMC5883LDriver) Heading() (float64, error) {
-	h.mutex.Lock()
-	defer h.mutex.Unlock()
+func (d *HMC5883LDriver) Heading() (float64, error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
-	x, y, _, err := h.readRawData()
+	x, y, _, err := d.readRawData()
 	if err != nil {
 		return 0, err
 	}
@@ -239,10 +239,10 @@ func (h *HMC5883LDriver) Heading() (float64, error) {
 // readRawData reads the raw values from the X, Y, and Z registers
 //
 //nolint:nonamedreturns // sufficient here
-func (h *HMC5883LDriver) readRawData() (x int16, y int16, z int16, err error) {
+func (d *HMC5883LDriver) readRawData() (x int16, y int16, z int16, err error) {
 	// read the data, starting from the initial register
 	data := make([]byte, 6)
-	if err = h.connection.ReadBlockData(hmc5883lAxisX, data); err != nil {
+	if err = d.readBlockData(hmc5883lAxisX, data); err != nil {
 		return
 	}
 
@@ -253,21 +253,21 @@ func (h *HMC5883LDriver) readRawData() (x int16, y int16, z int16, err error) {
 	return twosComplement16Bit(unsignedX), twosComplement16Bit(unsignedY), twosComplement16Bit(unsignedZ), nil
 }
 
-func (h *HMC5883LDriver) initialize() error {
-	regA := hmc5883lMeasurementFlowBits[h.applyBias]
-	regA |= hmc5883lOutputRateBits[h.outputRate] << 2
-	regA |= hmc5883lSamplesAvgBits[h.samplesAvg] << 5
+func (d *HMC5883LDriver) initialize() error {
+	regA := hmc5883lMeasurementFlowBits[d.applyBias]
+	regA |= hmc5883lOutputRateBits[d.outputRate] << 2
+	regA |= hmc5883lSamplesAvgBits[d.samplesAvg] << 5
 	//nolint:gosec // TODO: fix later
-	if err := h.connection.WriteByteData(hmc5883lRegA, uint8(regA)); err != nil {
+	if err := d.writeByteData(hmc5883lRegA, uint8(regA)); err != nil {
 		return err
 	}
-	regB := hmc5883lGainBits[h.gain] << 5
+	regB := hmc5883lGainBits[d.gain] << 5
 	//nolint:gosec // TODO: fix later
-	if err := h.connection.WriteByteData(hmc5883lRegB, uint8(regB)); err != nil {
+	if err := d.writeByteData(hmc5883lRegB, uint8(regB)); err != nil {
 		return err
 	}
 	//nolint:gosec // TODO: fix later
-	return h.connection.WriteByteData(hmc5883lRegMode, uint8(h.measurementMode))
+	return d.writeByteData(hmc5883lRegMode, uint8(d.measurementMode))
 }
 
 func hmc5883lValidateSamplesAveraged(samplesAvg int) error {

--- a/drivers/i2c/hmc5883l_driver_test.go
+++ b/drivers/i2c/hmc5883l_driver_test.go
@@ -35,6 +35,15 @@ func TestNewHMC5883LDriver(t *testing.T) {
 	assert.InDelta(t, 390.0, d.gain, 0.0)
 }
 
+func TestHMC5883LHalt(t *testing.T) {
+	// arrange
+	d := NewHMC5883LDriver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestHMC5883LOptions(t *testing.T) {
 	// This is a general test, that options are applied in constructor by using the common WithBus() option and
 	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".

--- a/drivers/i2c/hmc6352_driver.go
+++ b/drivers/i2c/hmc6352_driver.go
@@ -17,25 +17,25 @@ type HMC6352Driver struct {
 //	i2c.WithBus(int):	bus to use with this driver
 //	i2c.WithAddress(int):	address to use with this driver
 func NewHMC6352Driver(c Connector, options ...func(Config)) *HMC6352Driver {
-	h := &HMC6352Driver{
+	d := &HMC6352Driver{
 		Driver: NewDriver(c, "HMC6352", hmc6352DefaultAddress),
 	}
-	h.afterStart = h.initialize
+	d.afterStart = d.initialize
 
 	for _, option := range options {
-		option(h)
+		option(d)
 	}
 
-	return h
+	return d
 }
 
 // Heading returns the current heading
-func (h *HMC6352Driver) Heading() (uint16, error) {
-	if _, err := h.connection.Write([]byte("A")); err != nil {
+func (d *HMC6352Driver) Heading() (uint16, error) {
+	if _, err := d.write([]byte("A")); err != nil {
 		return 0, err
 	}
 	buf := []byte{0, 0}
-	bytesRead, err := h.connection.Read(buf)
+	bytesRead, err := d.read(buf)
 	if err != nil {
 		return 0, err
 	}
@@ -47,8 +47,8 @@ func (h *HMC6352Driver) Heading() (uint16, error) {
 	return 0, ErrNotEnoughBytes
 }
 
-func (h *HMC6352Driver) initialize() error {
-	if _, err := h.connection.Write([]byte("A")); err != nil {
+func (d *HMC6352Driver) initialize() error {
+	if _, err := d.write([]byte("A")); err != nil {
 		return err
 	}
 	return nil

--- a/drivers/i2c/hmc6352_driver_test.go
+++ b/drivers/i2c/hmc6352_driver_test.go
@@ -48,7 +48,11 @@ func TestHMC6352Start(t *testing.T) {
 }
 
 func TestHMC6352Halt(t *testing.T) {
-	d, _ := initTestHMC6352DriverWithStubbedAdaptor()
+	// arrange
+	d := NewHMC6352Driver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
 	require.NoError(t, d.Halt())
 }
 

--- a/drivers/i2c/i2c_driver.go
+++ b/drivers/i2c/i2c_driver.go
@@ -81,7 +81,7 @@ func (d *Driver) SetName(name string) {
 	d.name = name
 }
 
-// Connection returns the connection of the i2c device.
+// Connection returns the gobot connection of the i2c device.
 func (d *Driver) Connection() gobot.Connection {
 	if conn, ok := d.connector.(gobot.Connection); ok {
 		return conn
@@ -116,7 +116,8 @@ func (d *Driver) Halt() error {
 		return err
 	}
 
-	// currently there is nothing to do here for the driver
+	d.connection = nil
+
 	return nil
 }
 
@@ -124,6 +125,10 @@ func (d *Driver) Halt() error {
 func (d *Driver) Write(pin string, val int) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
+
+	if d.connection == nil {
+		return fmt.Errorf("i2c driver not started")
+	}
 
 	register, err := driverParseRegister(pin)
 	if err != nil {
@@ -146,6 +151,10 @@ func (d *Driver) Read(pin string) (int, error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
+	if d.connection == nil {
+		return 0, fmt.Errorf("i2c driver not started")
+	}
+
 	register, err := driverParseRegister(pin)
 	if err != nil {
 		return 0, err
@@ -157,6 +166,86 @@ func (d *Driver) Read(pin string) (int, error) {
 	}
 
 	return int(val), nil
+}
+
+func (d *Driver) write(data []byte) (int, error) {
+	if d.connection == nil {
+		return 0, fmt.Errorf("i2c driver not started")
+	}
+
+	return d.connection.Write(data)
+}
+
+func (d *Driver) writeByte(val byte) error {
+	if d.connection == nil {
+		return fmt.Errorf("i2c driver not started")
+	}
+
+	return d.connection.WriteByte(val)
+}
+
+func (d *Driver) writeByteData(reg uint8, val byte) error {
+	if d.connection == nil {
+		return fmt.Errorf("i2c driver not started")
+	}
+
+	return d.connection.WriteByteData(reg, val)
+}
+
+func (d *Driver) writeWordData(reg uint8, val uint16) error {
+	if d.connection == nil {
+		return fmt.Errorf("i2c driver not started")
+	}
+
+	return d.connection.WriteWordData(reg, val)
+}
+
+func (d *Driver) writeBlockData(reg uint8, data []byte) error {
+	if d.connection == nil {
+		return fmt.Errorf("i2c driver not started")
+	}
+
+	return d.connection.WriteBlockData(reg, data)
+}
+
+func (d *Driver) read(data []byte) (int, error) {
+	if d.connection == nil {
+		return 0, fmt.Errorf("i2c driver not started")
+	}
+
+	return d.connection.Read(data)
+}
+
+func (d *Driver) readByte() (byte, error) {
+	if d.connection == nil {
+		return 0, fmt.Errorf("i2c driver not started")
+	}
+
+	return d.connection.ReadByte()
+}
+
+func (d *Driver) readByteData(reg uint8) (byte, error) {
+	if d.connection == nil {
+		return 0, fmt.Errorf("i2c driver not started")
+	}
+
+	return d.connection.ReadByteData(reg)
+}
+
+func (d *Driver) readWordData(reg uint8) (uint16, error) {
+	if d.connection == nil {
+		return 0, fmt.Errorf("i2c driver not started")
+	}
+
+	return d.connection.ReadWordData(reg)
+}
+
+func (d *Driver) readBlockData(reg uint8, data []byte) error {
+	if d.connection == nil {
+		return fmt.Errorf("i2c driver not started")
+	}
+
+	return d.connection.ReadBlockData(reg, data)
 }
 
 func driverParseRegister(pin string) (uint8, error) {

--- a/drivers/i2c/i2c_driver_test.go
+++ b/drivers/i2c/i2c_driver_test.go
@@ -79,6 +79,8 @@ func TestHalt(t *testing.T) {
 	// arrange
 	d := initTestDriver()
 	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
 	require.NoError(t, d.Halt())
 }
 

--- a/drivers/i2c/ina3221_driver.go
+++ b/drivers/i2c/ina3221_driver.go
@@ -3,7 +3,7 @@ package i2c
 // INA3221Driver is a driver for the Texas Instruments INA3221 device. The INA3221 is a three-channel
 // current and bus voltage monitor with an I2C and SMBUS compatible interface.
 //
-// INA3221 data sheet and specifications can be found at http://www.ti.com/product/INA3221
+// INA3221 data sheet and specifications can be found at http://www.td.com/product/INA3221
 //
 // This module was tested with SwitchDoc Labs INA3221 breakout board found at http://www.switchdoc.com/
 
@@ -54,21 +54,21 @@ type INA3221Driver struct {
 //	i2c.WithBus(int):		bus to use with this driver
 //	i2c.WithAddress(int):		address to use with this driver
 func NewINA3221Driver(c Connector, options ...func(Config)) *INA3221Driver {
-	i := &INA3221Driver{
+	d := &INA3221Driver{
 		Driver: NewDriver(c, "INA3221", ina3221DefaultAddress),
 	}
-	i.afterStart = i.initialize
+	d.afterStart = d.initialize
 
 	for _, option := range options {
-		option(i)
+		option(d)
 	}
 
-	return i
+	return d
 }
 
 // GetBusVoltage gets the bus voltage in Volts
-func (i *INA3221Driver) GetBusVoltage(channel INA3221Channel) (float64, error) {
-	value, err := i.getBusVoltageRaw(channel)
+func (d *INA3221Driver) GetBusVoltage(channel INA3221Channel) (float64, error) {
+	value, err := d.getBusVoltageRaw(channel)
 	if err != nil {
 		return 0, err
 	}
@@ -77,8 +77,8 @@ func (i *INA3221Driver) GetBusVoltage(channel INA3221Channel) (float64, error) {
 }
 
 // GetShuntVoltage Gets the shunt voltage in mV
-func (i *INA3221Driver) GetShuntVoltage(channel INA3221Channel) (float64, error) {
-	value, err := i.getShuntVoltageRaw(channel)
+func (d *INA3221Driver) GetShuntVoltage(channel INA3221Channel) (float64, error) {
+	value, err := d.getShuntVoltageRaw(channel)
 	if err != nil {
 		return 0, err
 	}
@@ -87,8 +87,8 @@ func (i *INA3221Driver) GetShuntVoltage(channel INA3221Channel) (float64, error)
 }
 
 // GetCurrent gets the current value in mA, taking into account the config settings and current LSB
-func (i *INA3221Driver) GetCurrent(channel INA3221Channel) (float64, error) {
-	value, err := i.GetShuntVoltage(channel)
+func (d *INA3221Driver) GetCurrent(channel INA3221Channel) (float64, error) {
+	value, err := d.GetShuntVoltage(channel)
 	if err != nil {
 		return 0, err
 	}
@@ -98,13 +98,13 @@ func (i *INA3221Driver) GetCurrent(channel INA3221Channel) (float64, error) {
 }
 
 // GetLoadVoltage gets the load voltage in mV
-func (i *INA3221Driver) GetLoadVoltage(channel INA3221Channel) (float64, error) {
-	bv, err := i.GetBusVoltage(channel)
+func (d *INA3221Driver) GetLoadVoltage(channel INA3221Channel) (float64, error) {
+	bv, err := d.GetBusVoltage(channel)
 	if err != nil {
 		return 0, err
 	}
 
-	sv, err := i.GetShuntVoltage(channel)
+	sv, err := d.GetShuntVoltage(channel)
 	if err != nil {
 		return 0, err
 	}
@@ -113,8 +113,8 @@ func (i *INA3221Driver) GetLoadVoltage(channel INA3221Channel) (float64, error) 
 }
 
 // getBusVoltageRaw gets the raw bus voltage (16-bit signed integer, so +-32767)
-func (i *INA3221Driver) getBusVoltageRaw(channel INA3221Channel) (int16, error) {
-	val, err := i.readWordFromRegister(ina3221RegBusVoltage1 + (uint8(channel)-1)*2)
+func (d *INA3221Driver) getBusVoltageRaw(channel INA3221Channel) (int16, error) {
+	val, err := d.readWordFromRegister(ina3221RegBusVoltage1 + (uint8(channel)-1)*2)
 	if err != nil {
 		return 0, err
 	}
@@ -128,8 +128,8 @@ func (i *INA3221Driver) getBusVoltageRaw(channel INA3221Channel) (int16, error) 
 }
 
 // getShuntVoltageRaw gets the raw shunt voltage (16-bit signed integer, so +-32767)
-func (i *INA3221Driver) getShuntVoltageRaw(channel INA3221Channel) (int16, error) {
-	val, err := i.readWordFromRegister(ina3221RegShuntVoltage1 + (uint8(channel)-1)*2)
+func (d *INA3221Driver) getShuntVoltageRaw(channel INA3221Channel) (int16, error) {
+	val, err := d.readWordFromRegister(ina3221RegShuntVoltage1 + (uint8(channel)-1)*2)
 	if err != nil {
 		return 0, err
 	}
@@ -143,8 +143,8 @@ func (i *INA3221Driver) getShuntVoltageRaw(channel INA3221Channel) (int16, error
 }
 
 // reads word from supplied register address
-func (i *INA3221Driver) readWordFromRegister(reg uint8) (uint16, error) {
-	val, err := i.connection.ReadWordData(reg)
+func (d *INA3221Driver) readWordFromRegister(reg uint8) (uint16, error) {
+	val, err := d.readWordData(reg)
 	if err != nil {
 		return 0, err
 	}
@@ -153,7 +153,7 @@ func (i *INA3221Driver) readWordFromRegister(reg uint8) (uint16, error) {
 }
 
 // initialize initializes the INA3221 device
-func (i *INA3221Driver) initialize() error {
+func (d *INA3221Driver) initialize() error {
 	config := ina3221ConfigEnableChan1 |
 		ina3221ConfigEnableChan2 |
 		ina3221ConfigEnableChan3 |
@@ -164,5 +164,5 @@ func (i *INA3221Driver) initialize() error {
 		ina3221ConfigMode1 |
 		ina3221ConfigMode0
 
-	return i.connection.WriteBlockData(ina3221RegConfig, []byte{byte(config >> 8), byte(config & 0x00FF)})
+	return d.writeBlockData(ina3221RegConfig, []byte{byte(config >> 8), byte(config & 0x00FF)})
 }

--- a/drivers/i2c/ina3221_driver_test.go
+++ b/drivers/i2c/ina3221_driver_test.go
@@ -48,7 +48,11 @@ func TestINA3221Start(t *testing.T) {
 }
 
 func TestINA3221Halt(t *testing.T) {
-	d, _ := initTestINA3221DriverWithStubbedAdaptor()
+	// arrange
+	d := NewINA3221Driver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
 	require.NoError(t, d.Halt())
 }
 

--- a/drivers/i2c/jhd1313m1_driver_test.go
+++ b/drivers/i2c/jhd1313m1_driver_test.go
@@ -74,8 +74,11 @@ func TestJHD1313MDriverStartWriteError(t *testing.T) {
 }
 
 func TestJHD1313MDriverHalt(t *testing.T) {
+	// arrange
 	d := initTestJHD1313M1Driver()
-	_ = d.Start()
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
 	require.NoError(t, d.Halt())
 }
 

--- a/drivers/i2c/l3gd20h_driver.go
+++ b/drivers/i2c/l3gd20h_driver.go
@@ -67,14 +67,14 @@ type L3GD20HDriver struct {
 //	i2c.WithBus(int):	bus to use with this driver
 //	i2c.WithAddress(int):	address to use with this driver
 func NewL3GD20HDriver(c Connector, options ...func(Config)) *L3GD20HDriver {
-	l := &L3GD20HDriver{
+	d := &L3GD20HDriver{
 		Driver: NewDriver(c, "L3GD20H", l3gd20hDefaultAddress, options...),
 		scale:  L3GD20HScale250dps,
 	}
-	l.afterStart = l.initialize
+	d.afterStart = d.initialize
 
 	// TODO: add commands to API
-	return l
+	return d
 }
 
 // WithL3GD20HFullScaleRange option sets the full scale range for the gyroscope.
@@ -105,7 +105,7 @@ func (d *L3GD20HDriver) FullScaleRange() (uint8, error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	val, err := d.connection.ReadByteData(l3gd20hReg_Ctl4)
+	val, err := d.readByteData(l3gd20hReg_Ctl4)
 	if err != nil {
 		return 0, err
 	}
@@ -121,7 +121,7 @@ func (d *L3GD20HDriver) XYZ() (x float32, y float32, z float32, err error) {
 
 	measurements := make([]byte, 6)
 	reg := l3gd20hReg_OutXLSB | 0x80 // set auto-increment bit
-	if err := d.connection.ReadBlockData(uint8(reg), measurements); err != nil {
+	if err := d.readBlockData(uint8(reg), measurements); err != nil {
 		return 0, 0, 0, err
 	}
 
@@ -146,16 +146,16 @@ func (d *L3GD20HDriver) XYZ() (x float32, y float32, z float32, err error) {
 
 func (d *L3GD20HDriver) initialize() error {
 	// reset the gyroscope.
-	if err := d.connection.WriteByteData(l3gd20hReg_Ctl1, 0x00); err != nil {
+	if err := d.writeByteData(l3gd20hReg_Ctl1, 0x00); err != nil {
 		return err
 	}
 	// Enable Z, Y and X axis.
 	ctl1 := l3gd20hCtl1_NormalModeBit | l3gd20hCtl1_EnableZBit | l3gd20hCtl1_EnableYBit | l3gd20hCtl1_EnableXBit
-	if err := d.connection.WriteByteData(l3gd20hReg_Ctl1, uint8(ctl1)); err != nil {
+	if err := d.writeByteData(l3gd20hReg_Ctl1, uint8(ctl1)); err != nil {
 		return err
 	}
 	// Set the sensitivity scale.
-	if err := d.connection.WriteByteData(l3gd20hReg_Ctl4, byte(d.scale)); err != nil {
+	if err := d.writeByteData(l3gd20hReg_Ctl4, byte(d.scale)); err != nil {
 		return err
 	}
 	return nil

--- a/drivers/i2c/l3gd20h_driver_test.go
+++ b/drivers/i2c/l3gd20h_driver_test.go
@@ -41,6 +41,15 @@ func TestNewL3GD20HDriver(t *testing.T) {
 	assert.Equal(t, L3GD20HScale250dps, d.Scale())
 }
 
+func TestL3GD20HHalt(t *testing.T) {
+	// arrange
+	d := NewL3GD20HDriver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestL3GD20HOptions(t *testing.T) {
 	// This is a general test, that options are applied in constructor by using the common WithBus() option.
 	// Further tests for options can also be done by call of "WithOption(val)(d)".

--- a/drivers/i2c/lidarlite_driver.go
+++ b/drivers/i2c/lidarlite_driver.go
@@ -22,31 +22,31 @@ type LIDARLiteDriver struct {
 //	i2c.WithBus(int):	bus to use with this driver
 //	i2c.WithAddress(int):	address to use with this driver
 func NewLIDARLiteDriver(c Connector, options ...func(Config)) *LIDARLiteDriver {
-	l := &LIDARLiteDriver{
+	d := &LIDARLiteDriver{
 		Driver: NewDriver(c, "LIDARLite", lidarliteDefaultAddress),
 	}
 
 	for _, option := range options {
-		option(l)
+		option(d)
 	}
 
 	// TODO: add commands to API
-	return l
+	return d
 }
 
 // Distance returns the current distance in cm
-func (h *LIDARLiteDriver) Distance() (int, error) {
-	if _, err := h.connection.Write([]byte{0x00, 0x04}); err != nil {
+func (d *LIDARLiteDriver) Distance() (int, error) {
+	if _, err := d.write([]byte{0x00, 0x04}); err != nil {
 		return 0, err
 	}
 	time.Sleep(20 * time.Millisecond)
 
-	if _, err := h.connection.Write([]byte{0x0F}); err != nil {
+	if _, err := d.write([]byte{0x0F}); err != nil {
 		return 0, err
 	}
 
 	upper := []byte{0}
-	bytesRead, err := h.connection.Read(upper)
+	bytesRead, err := d.read(upper)
 	if err != nil {
 		return 0, err
 	}
@@ -55,12 +55,12 @@ func (h *LIDARLiteDriver) Distance() (int, error) {
 		return 0, ErrNotEnoughBytes
 	}
 
-	if _, err := h.connection.Write([]byte{0x10}); err != nil {
+	if _, err := d.write([]byte{0x10}); err != nil {
 		return 0, err
 	}
 
 	lower := []byte{0}
-	bytesRead, err = h.connection.Read(lower)
+	bytesRead, err = d.read(lower)
 	if err != nil {
 		return 0, err
 	}

--- a/drivers/i2c/lidarlite_driver_test.go
+++ b/drivers/i2c/lidarlite_driver_test.go
@@ -16,11 +16,6 @@ import (
 // and tests all implementations, so no further tests needed here for gobot.Driver interface
 var _ gobot.Driver = (*LIDARLiteDriver)(nil)
 
-func initTestLIDARLiteDriver() *LIDARLiteDriver {
-	d, _ := initTestLIDARLiteDriverWithStubbedAdaptor()
-	return d
-}
-
 func initTestLIDARLiteDriverWithStubbedAdaptor() (*LIDARLiteDriver, *i2cTestAdaptor) {
 	a := newI2cTestAdaptor()
 	d := NewLIDARLiteDriver(a)
@@ -54,7 +49,11 @@ func TestLIDARLiteDriverStart(t *testing.T) {
 }
 
 func TestLIDARLiteDriverHalt(t *testing.T) {
-	d := initTestLIDARLiteDriver()
+	// arrange
+	d := NewLIDARLiteDriver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
 	require.NoError(t, d.Halt())
 }
 

--- a/drivers/i2c/mcp23017_driver_test.go
+++ b/drivers/i2c/mcp23017_driver_test.go
@@ -38,7 +38,9 @@ func initTestMCP23017WithStubbedAdaptor(b uint8) (*MCP23017Driver, *i2cTestAdapt
 	// create the driver, ready to use for tests
 	a := newI2cTestAdaptor()
 	d := NewMCP23017Driver(a, WithMCP23017Bank(b))
-	_ = d.Start()
+	if err := d.Start(); err != nil {
+		panic(err)
+	}
 	return d, a
 }
 
@@ -53,6 +55,13 @@ func TestNewMCP23017Driver(t *testing.T) {
 	assert.Equal(t, 0x20, d.defaultAddress)
 	assert.NotNil(t, d.mcpConf)
 	assert.NotNil(t, d.mcpBehav)
+}
+
+func TestMCP23017Halt(t *testing.T) {
+	d := NewMCP23017Driver(newI2cTestAdaptor())
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
 }
 
 func TestWithMCP23017Bank(t *testing.T) {

--- a/drivers/i2c/mma7660_driver.go
+++ b/drivers/i2c/mma7660_driver.go
@@ -65,7 +65,7 @@ func (d *MMA7660Driver) Acceleration(x, y, z float64) (ax, ay, az float64) {
 //nolint:nonamedreturns // is sufficient here
 func (d *MMA7660Driver) XYZ() (x float64, y float64, z float64, err error) {
 	buf := []byte{0, 0, 0}
-	bytesRead, err := d.connection.Read(buf)
+	bytesRead, err := d.read(buf)
 	if err != nil {
 		return
 	}
@@ -90,15 +90,15 @@ func (d *MMA7660Driver) XYZ() (x float64, y float64, z float64, err error) {
 }
 
 func (d *MMA7660Driver) initialize() error {
-	if _, err := d.connection.Write([]byte{MMA7660_MODE, MMA7660_STAND_BY}); err != nil {
+	if _, err := d.write([]byte{MMA7660_MODE, MMA7660_STAND_BY}); err != nil {
 		return err
 	}
 
-	if _, err := d.connection.Write([]byte{MMA7660_SR, MMA7660_AUTO_SLEEP_32}); err != nil {
+	if _, err := d.write([]byte{MMA7660_SR, MMA7660_AUTO_SLEEP_32}); err != nil {
 		return err
 	}
 
-	if _, err := d.connection.Write([]byte{MMA7660_MODE, MMA7660_ACTIVE}); err != nil {
+	if _, err := d.write([]byte{MMA7660_MODE, MMA7660_ACTIVE}); err != nil {
 		return err
 	}
 

--- a/drivers/i2c/mma7660_driver_test.go
+++ b/drivers/i2c/mma7660_driver_test.go
@@ -49,7 +49,11 @@ func TestMMA7660Start(t *testing.T) {
 }
 
 func TestMMA7660Halt(t *testing.T) {
-	d, _ := initTestMMA7660DriverWithStubbedAdaptor()
+	// arrange
+	d := NewMMA7660Driver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
 	require.NoError(t, d.Halt())
 }
 

--- a/drivers/i2c/mpl115a2_driver.go
+++ b/drivers/i2c/mpl115a2_driver.go
@@ -92,7 +92,7 @@ func (d *MPL115A2Driver) Temperature() (float32, error) {
 
 func (d *MPL115A2Driver) initialization() error {
 	data := make([]byte, 8)
-	if err := d.connection.ReadBlockData(mpl115A2Reg_A0_MSB, data); err != nil {
+	if err := d.readBlockData(mpl115A2Reg_A0_MSB, data); err != nil {
 		return err
 	}
 
@@ -133,13 +133,13 @@ func (d *MPL115A2Driver) getData() (p, t float32, err error) {
 	var pressure uint16
 	var pressureComp float32
 
-	if err = d.connection.WriteByteData(mpl115A2Reg_StartConversion, 0); err != nil {
+	if err = d.writeByteData(mpl115A2Reg_StartConversion, 0); err != nil {
 		return 0, 0, err
 	}
 	time.Sleep(5 * time.Millisecond)
 
 	data := []byte{0, 0, 0, 0}
-	if err = d.connection.ReadBlockData(mpl115A2Reg_PressureMSB, data); err != nil {
+	if err = d.readBlockData(mpl115A2Reg_PressureMSB, data); err != nil {
 		return 0, 0, err
 	}
 

--- a/drivers/i2c/mpl115a2_driver_test.go
+++ b/drivers/i2c/mpl115a2_driver_test.go
@@ -38,6 +38,15 @@ func TestMPL115A2Options(t *testing.T) {
 	assert.Equal(t, 2, d.GetBusOrDefault(1))
 }
 
+func TestMPL115A2Halt(t *testing.T) {
+	// arrange
+	d := NewMPL115A2Driver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestMPL115A2ReadData(t *testing.T) {
 	// sequence for read data
 	// * retrieve the coefficients for temperature compensation of pressure - see test for Start()

--- a/drivers/i2c/mpu6050_driver.go
+++ b/drivers/i2c/mpu6050_driver.go
@@ -131,7 +131,7 @@ var mpu6050GyroGain = map[MPU6050GyroFsConfig]float64{
 //	i2c.WithBus(int):	bus to use with this driver
 //	i2c.WithAddress(int):	address to use with this driver
 func NewMPU6050Driver(a Connector, options ...func(Config)) *MPU6050Driver {
-	m := &MPU6050Driver{
+	d := &MPU6050Driver{
 		Driver:    NewDriver(a, "MPU6050", mpu6050DefaultAddress),
 		dlpf:      MPU6050General_Dlpf260Hz,
 		frameSync: MPU6050General_FrameSyncDisabled,
@@ -140,14 +140,14 @@ func NewMPU6050Driver(a Connector, options ...func(Config)) *MPU6050Driver {
 		clock:     MPU6050Pwr1_ClockPllXGyro,
 		gravity:   mpu6050EarthStandardGravity,
 	}
-	m.afterStart = m.initialize
+	d.afterStart = d.initialize
 
 	for _, option := range options {
-		option(m)
+		option(d)
 	}
 
 	// TODO: add commands to API
-	return m
+	return d
 }
 
 // WithMPU6050DigitalFilter option sets the digital low pass filter bandwidth frequency.
@@ -223,12 +223,12 @@ func WithMPU6050Gravity(val float64) func(Config) {
 }
 
 // GetData fetches the latest data from the MPU6050
-func (m *MPU6050Driver) GetData() error {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
+func (d *MPU6050Driver) GetData() error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
 	data := make([]byte, 14)
-	if err := m.connection.ReadBlockData(mpu6050Reg_AccelXoutH, data); err != nil {
+	if err := d.readBlockData(mpu6050Reg_AccelXoutH, data); err != nil {
 		return err
 	}
 
@@ -255,69 +255,69 @@ func (m *MPU6050Driver) GetData() error {
 		return err
 	}
 
-	ag := float64(mpu6050AccelGain[m.accelFs]) / m.gravity
-	m.Accelerometer.X = float64(accel.X) / ag
-	m.Accelerometer.Y = float64(accel.Y) / ag
-	m.Accelerometer.Z = float64(accel.Z) / ag
+	ag := float64(mpu6050AccelGain[d.accelFs]) / d.gravity
+	d.Accelerometer.X = float64(accel.X) / ag
+	d.Accelerometer.Y = float64(accel.Y) / ag
+	d.Accelerometer.Z = float64(accel.Z) / ag
 
-	m.Temperature = float64(temp)/340 + 36.53
+	d.Temperature = float64(temp)/340 + 36.53
 
-	gg := mpu6050GyroGain[m.gyroFs]
-	m.Gyroscope.X = float64(gyro.X) / gg
-	m.Gyroscope.Y = float64(gyro.Y) / gg
-	m.Gyroscope.Z = float64(gyro.Z) / gg
+	gg := mpu6050GyroGain[d.gyroFs]
+	d.Gyroscope.X = float64(gyro.X) / gg
+	d.Gyroscope.Y = float64(gyro.Y) / gg
+	d.Gyroscope.Z = float64(gyro.Z) / gg
 
 	return nil
 }
 
-func (m *MPU6050Driver) waitForReset() error {
+func (d *MPU6050Driver) waitForReset() error {
 	wait := 100 * time.Millisecond
 	start := time.Now()
 	for {
 		if time.Since(start) > wait {
 			return fmt.Errorf("timeout on wait for reset is done")
 		}
-		if val, err := m.connection.ReadByteData(mpu6050Reg_PwrMgmt1); (val&mpu6050Pwr1_DeviceResetBit == 0) && (err == nil) {
+		if val, err := d.readByteData(mpu6050Reg_PwrMgmt1); (val&mpu6050Pwr1_DeviceResetBit == 0) && (err == nil) {
 			return nil
 		}
 		time.Sleep(wait / 10)
 	}
 }
 
-func (m *MPU6050Driver) initialize() error {
+func (d *MPU6050Driver) initialize() error {
 	// reset device and wait for reset is finished
-	if err := m.connection.WriteByteData(mpu6050Reg_PwrMgmt1, mpu6050Pwr1_DeviceResetBit); err != nil {
+	if err := d.writeByteData(mpu6050Reg_PwrMgmt1, mpu6050Pwr1_DeviceResetBit); err != nil {
 		return err
 	}
-	if err := m.waitForReset(); err != nil {
+	if err := d.waitForReset(); err != nil {
 		return err
 	}
 
 	// reset signal path register
 	reset := uint8(mpu6050SignalReset_TempBit | mpu6050SignalReset_AccelBit | mpu6050SignalReset_GyroBit)
-	if err := m.connection.WriteByteData(mpu6050Reg_SignalPathReset, reset); err != nil {
+	if err := d.writeByteData(mpu6050Reg_SignalPathReset, reset); err != nil {
 		return err
 	}
 	time.Sleep(100 * time.Millisecond)
 
 	// configure digital filter bandwidth and external frame synchronization (bits 3...5 are used)
-	generalConf := uint8(m.dlpf) | uint8(m.frameSync)<<3
-	if err := m.connection.WriteByteData(mpu6050Reg_GeneralConfig, generalConf); err != nil {
+	generalConf := uint8(d.dlpf) | uint8(d.frameSync)<<3
+	if err := d.writeByteData(mpu6050Reg_GeneralConfig, generalConf); err != nil {
 		return err
 	}
 
 	// set full scale range of gyroscope (bits 3 and 4 are used)
-	if err := m.connection.WriteByteData(mpu6050Reg_GyroConfig, uint8(m.gyroFs)<<3); err != nil {
+	if err := d.writeByteData(mpu6050Reg_GyroConfig, uint8(d.gyroFs)<<3); err != nil {
 		return err
 	}
 
 	// set full scale range of accelerometer (bits 3 and 4 are used)
-	if err := m.connection.WriteByteData(mpu6050Reg_AccelConfig, uint8(m.accelFs)<<3); err != nil {
+	if err := d.writeByteData(mpu6050Reg_AccelConfig, uint8(d.accelFs)<<3); err != nil {
 		return err
 	}
 
 	// set clock source and reset sleep
-	pwr1 := uint8(m.clock) & ^uint8(mpu6050Pwr1_SleepOnBit)
+	pwr1 := uint8(d.clock) & ^uint8(mpu6050Pwr1_SleepOnBit)
 
-	return m.connection.WriteByteData(mpu6050Reg_PwrMgmt1, pwr1)
+	return d.writeByteData(mpu6050Reg_PwrMgmt1, pwr1)
 }

--- a/drivers/i2c/mpu6050_driver_test.go
+++ b/drivers/i2c/mpu6050_driver_test.go
@@ -49,6 +49,15 @@ func TestMPU6050Options(t *testing.T) {
 	assert.Equal(t, MPU6050DlpfConfig(0x06), d.dlpf)
 }
 
+func TestMPU6050Halt(t *testing.T) {
+	// arrange
+	d := NewMPU6050Driver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestWithMPU6050FrameSync(t *testing.T) {
 	d := NewMPU6050Driver(newI2cTestAdaptor(), WithMPU6050FrameSync(0x07))
 	assert.Equal(t, MPU6050FrameSyncConfig(0x07), d.frameSync)

--- a/drivers/i2c/pca9501_driver.go
+++ b/drivers/i2c/pca9501_driver.go
@@ -34,63 +34,64 @@ type PCA9501Driver struct {
 //	i2c.WithBus(int):	bus to use with this driver
 //	i2c.WithAddress(int):	address to use with this driver
 func NewPCA9501Driver(a Connector, options ...func(Config)) *PCA9501Driver {
-	p := &PCA9501Driver{
+	d := &PCA9501Driver{
 		Driver: NewDriver(a, "PCA9501", pca9501DefaultAddress, options...),
 	}
-	p.afterStart = p.initialize
+	d.afterStart = d.initialize
 
 	// API commands
 	//nolint:forcetypeassert // ok here
-	p.AddCommand("WriteGPIO", func(params map[string]interface{}) interface{} {
+	d.AddCommand("WriteGPIO", func(params map[string]interface{}) interface{} {
 		pin := params["pin"].(uint8)
 		val := params["val"].(uint8)
-		err := p.WriteGPIO(pin, val)
+		err := d.WriteGPIO(pin, val)
 		return map[string]interface{}{"err": err}
 	})
 
 	//nolint:forcetypeassert // ok here
-	p.AddCommand("ReadGPIO", func(params map[string]interface{}) interface{} {
+	d.AddCommand("ReadGPIO", func(params map[string]interface{}) interface{} {
 		pin := params["pin"].(uint8)
-		val, err := p.ReadGPIO(pin)
+		val, err := d.ReadGPIO(pin)
 		return map[string]interface{}{"val": val, "err": err}
 	})
 
 	//nolint:forcetypeassert // ok here
-	p.AddCommand("WriteEEPROM", func(params map[string]interface{}) interface{} {
+	d.AddCommand("WriteEEPROM", func(params map[string]interface{}) interface{} {
 		address := params["address"].(uint8)
 		val := params["val"].(uint8)
-		err := p.WriteEEPROM(address, val)
+		err := d.WriteEEPROM(address, val)
 		return map[string]interface{}{"err": err}
 	})
 
 	//nolint:forcetypeassert // ok here
-	p.AddCommand("ReadEEPROM", func(params map[string]interface{}) interface{} {
+	d.AddCommand("ReadEEPROM", func(params map[string]interface{}) interface{} {
 		address := params["address"].(uint8)
-		val, err := p.ReadEEPROM(address)
+		val, err := d.ReadEEPROM(address)
 		return map[string]interface{}{"val": val, "err": err}
 	})
-	return p
+
+	return d
 }
 
 // WriteGPIO writes a value to a gpio pin (0-7)
-func (p *PCA9501Driver) WriteGPIO(pin uint8, val uint8) error {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
+func (d *PCA9501Driver) WriteGPIO(pin uint8, val uint8) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
 	// read current value of CTRL register, 0 is output, 1 is no output
-	iodir, err := p.connection.ReadByte()
+	iodir, err := d.readByte()
 	if err != nil {
 		return err
 	}
 	// set pin as output by clearing bit
 	iodirVal := bit.Clear(int(iodir), pin)
 	// write CTRL register
-	err = p.connection.WriteByte(uint8(iodirVal)) //nolint:gosec // TODO: fix later
+	err = d.writeByte(uint8(iodirVal)) //nolint:gosec // TODO: fix later
 	if err != nil {
 		return err
 	}
 	// read current value of port
-	cVal, err := p.connection.ReadByte()
+	cVal, err := d.readByte()
 	if err != nil {
 		return err
 	}
@@ -102,7 +103,7 @@ func (p *PCA9501Driver) WriteGPIO(pin uint8, val uint8) error {
 		nVal = bit.Set(int(cVal), pin)
 	}
 	// write new value to port
-	err = p.connection.WriteByte(uint8(nVal)) //nolint:gosec // TODO: fix later
+	err = d.writeByte(uint8(nVal)) //nolint:gosec // TODO: fix later
 	if err != nil {
 		return err
 	}
@@ -110,24 +111,24 @@ func (p *PCA9501Driver) WriteGPIO(pin uint8, val uint8) error {
 }
 
 // ReadGPIO reads a value from a given gpio pin (0-7)
-func (p *PCA9501Driver) ReadGPIO(pin uint8) (uint8, error) {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
+func (d *PCA9501Driver) ReadGPIO(pin uint8) (uint8, error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
 	// read current value of CTRL register, 0 is no input, 1 is an input
-	iodir, err := p.connection.ReadByte()
+	iodir, err := d.readByte()
 	if err != nil {
 		return 0, err
 	}
 	// set pin as input by setting bit
 	iodirVal := bit.Set(int(iodir), pin)
 	// write CTRL register
-	err = p.connection.WriteByte(uint8(iodirVal)) //nolint:gosec // TODO: fix later
+	err = d.writeByte(uint8(iodirVal)) //nolint:gosec // TODO: fix later
 	if err != nil {
 		return 0, err
 	}
 	// read port and create return bit
-	val, err := p.connection.ReadByte()
+	val, err := d.readByte()
 	if err != nil {
 		return val, err
 	}
@@ -141,26 +142,26 @@ func (p *PCA9501Driver) ReadGPIO(pin uint8) (uint8, error) {
 // ReadEEPROM reads a value from a given address (0x00-0xFF)
 // Note: only this sequence for memory read is supported: "STARTW-DATA1-STARTR-DATA2-STOP"
 // DATA1: EEPROM address, DATA2: read value
-func (p *PCA9501Driver) ReadEEPROM(address uint8) (uint8, error) {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
+func (d *PCA9501Driver) ReadEEPROM(address uint8) (uint8, error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
-	return p.connectionMem.ReadByteData(address)
+	return d.connectionMem.ReadByteData(address)
 }
 
 // WriteEEPROM writes a value to a given address in memory (0x00-0xFF)
-func (p *PCA9501Driver) WriteEEPROM(address uint8, val uint8) error {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
+func (d *PCA9501Driver) WriteEEPROM(address uint8, val uint8) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
-	return p.connectionMem.WriteByteData(address, val)
+	return d.connectionMem.WriteByteData(address, val)
 }
 
-func (p *PCA9501Driver) initialize() error {
+func (d *PCA9501Driver) initialize() error {
 	// initialize the EEPROM connection
-	bus := p.GetBusOrDefault(p.connector.DefaultI2cBus())
-	addressMem := p.GetAddressOrDefault(pca9501DefaultAddress) | 0x40
+	bus := d.GetBusOrDefault(d.connector.DefaultI2cBus())
+	addressMem := d.GetAddressOrDefault(pca9501DefaultAddress) | 0x40
 	var err error
-	p.connectionMem, err = p.connector.GetI2cConnection(addressMem, bus)
+	d.connectionMem, err = d.connector.GetI2cConnection(addressMem, bus)
 	return err
 }

--- a/drivers/i2c/pca9501_driver_test.go
+++ b/drivers/i2c/pca9501_driver_test.go
@@ -62,6 +62,15 @@ func TestPCA9501Options(t *testing.T) {
 	assert.Equal(t, 2, d.GetBusOrDefault(1))
 }
 
+func TestPCA9501Halt(t *testing.T) {
+	// arrange
+	d := NewPCA9501Driver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestPCA9501CommandsWriteGPIO(t *testing.T) {
 	// arrange
 	d, a := initPCA9501WithStubbedAdaptor()

--- a/drivers/i2c/pca953x_driver.go
+++ b/drivers/i2c/pca953x_driver.go
@@ -252,13 +252,13 @@ func (d *PCA953xDriver) writeRegister(regAddress pca953xRegister, val uint8) err
 	// ensure AI bit is not set
 	regAddress = regAddress &^ pca953xAiMask
 	// write content of requested register
-	return d.connection.WriteByteData(uint8(regAddress), val)
+	return d.writeByteData(uint8(regAddress), val)
 }
 
 func (d *PCA953xDriver) readRegister(regAddress pca953xRegister) (uint8, error) {
 	// ensure AI bit is not set
 	regAddress = regAddress &^ pca953xAiMask
-	return d.connection.ReadByteData(uint8(regAddress))
+	return d.readByteData(uint8(regAddress))
 }
 
 func pca953xCalcPsc(valSec float32) (uint8, error) {

--- a/drivers/i2c/pca953x_driver_test.go
+++ b/drivers/i2c/pca953x_driver_test.go
@@ -36,6 +36,15 @@ func TestNewPCA953xDriver(t *testing.T) {
 	assert.Equal(t, 0x63, d.defaultAddress)
 }
 
+func TestPCA953xHalt(t *testing.T) {
+	// arrange
+	d := NewPCA953xDriver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestPCA953xWriteGPIO(t *testing.T) {
 	// sequence to write:
 	// * choose LED select register according to the given GPIO index (0x05 for 0..3, 0x06 for 4..7)

--- a/drivers/i2c/pca9685_driver.go
+++ b/drivers/i2c/pca9685_driver.go
@@ -51,42 +51,42 @@ type PCA9685Driver struct {
 //	i2c.WithBus(int):	bus to use with this driver
 //	i2c.WithAddress(int):	address to use with this driver
 func NewPCA9685Driver(c Connector, options ...func(Config)) *PCA9685Driver {
-	p := &PCA9685Driver{
+	d := &PCA9685Driver{
 		Driver: NewDriver(c, "PCA9685", pca9685DefaultAddress),
 	}
-	p.afterStart = p.initialize
-	p.beforeHalt = p.shutdown
+	d.afterStart = d.initialize
+	d.beforeHalt = d.shutdown
 
 	for _, option := range options {
-		option(p)
+		option(d)
 	}
 
 	//nolint:forcetypeassert // ok here
-	p.AddCommand("PwmWrite", func(params map[string]interface{}) interface{} {
+	d.AddCommand("PwmWrite", func(params map[string]interface{}) interface{} {
 		pin := params["pin"].(string)
 		val, _ := strconv.Atoi(params["val"].(string))
-		return p.PwmWrite(pin, byte(val))
+		return d.PwmWrite(pin, byte(val))
 	})
 	//nolint:forcetypeassert // ok here
-	p.AddCommand("ServoWrite", func(params map[string]interface{}) interface{} {
+	d.AddCommand("ServoWrite", func(params map[string]interface{}) interface{} {
 		pin := params["pin"].(string)
 		val, _ := strconv.Atoi(params["val"].(string))
-		return p.ServoWrite(pin, byte(val))
+		return d.ServoWrite(pin, byte(val))
 	})
 	//nolint:forcetypeassert // ok here
-	p.AddCommand("SetPWM", func(params map[string]interface{}) interface{} {
+	d.AddCommand("SetPWM", func(params map[string]interface{}) interface{} {
 		channel, _ := strconv.Atoi(params["channel"].(string))
 		on, _ := strconv.Atoi(params["on"].(string))
 		off, _ := strconv.Atoi(params["off"].(string))
-		return p.SetPWM(channel, uint16(on), uint16(off)) //nolint:gosec // TODO: fix later
+		return d.SetPWM(channel, uint16(on), uint16(off)) //nolint:gosec // TODO: fix later
 	})
 	//nolint:forcetypeassert // ok here
-	p.AddCommand("SetPWMFreq", func(params map[string]interface{}) interface{} {
+	d.AddCommand("SetPWMFreq", func(params map[string]interface{}) interface{} {
 		freq, _ := strconv.ParseFloat(params["freq"].(string), 32)
-		return p.SetPWMFreq(float32(freq))
+		return d.SetPWMFreq(float32(freq))
 	})
 
-	return p
+	return d
 }
 
 // SetPWM sets a specific channel to a pwm value from 0-4095.
@@ -97,20 +97,20 @@ func NewPCA9685Driver(c Connector, options ...func(Config)) *PCA9685Driver {
 //	off uint16 - the time to stop the pulse
 //
 // Most typically you set "on" to a zero value, and then set "off" to your desired duty.
-func (p *PCA9685Driver) SetPWM(channel int, on uint16, off uint16) error {
-	if _, err := p.connection.Write([]byte{byte(pca9685Led0OnLReg + 4*channel), byte(on) & 0xFF}); err != nil {
+func (d *PCA9685Driver) SetPWM(channel int, on uint16, off uint16) error {
+	if _, err := d.write([]byte{byte(pca9685Led0OnLReg + 4*channel), byte(on) & 0xFF}); err != nil {
 		return err
 	}
 
-	if _, err := p.connection.Write([]byte{byte(pca9685Led0OnHReg + 4*channel), byte(on >> 8)}); err != nil {
+	if _, err := d.write([]byte{byte(pca9685Led0OnHReg + 4*channel), byte(on >> 8)}); err != nil {
 		return err
 	}
 
-	if _, err := p.connection.Write([]byte{byte(pca9685Led0OffLReg + 4*channel), byte(off) & 0xFF}); err != nil {
+	if _, err := d.write([]byte{byte(pca9685Led0OffLReg + 4*channel), byte(off) & 0xFF}); err != nil {
 		return err
 	}
 
-	_, err := p.connection.Write([]byte{byte(pca9685Led0OffHReg + 4*channel), byte(off >> 8)})
+	_, err := d.write([]byte{byte(pca9685Led0OffHReg + 4*channel), byte(off >> 8)})
 	return err
 }
 
@@ -121,25 +121,25 @@ func (p *PCA9685Driver) SetPWM(channel int, on uint16, off uint16) error {
 //	off uint16 - the time to stop the pulse
 //
 // Most typically you set "on" to a zero value, and then set "off" to your desired duty.
-func (p *PCA9685Driver) SetAllPWM(on uint16, off uint16) error {
-	if _, err := p.connection.Write([]byte{byte(pca9685AllLedOnLReg), byte(on) & 0xFF}); err != nil {
+func (d *PCA9685Driver) SetAllPWM(on uint16, off uint16) error {
+	if _, err := d.write([]byte{byte(pca9685AllLedOnLReg), byte(on) & 0xFF}); err != nil {
 		return err
 	}
 
-	if _, err := p.connection.Write([]byte{byte(pca9685AllLedOnHReg), byte(on >> 8)}); err != nil {
+	if _, err := d.write([]byte{byte(pca9685AllLedOnHReg), byte(on >> 8)}); err != nil {
 		return err
 	}
 
-	if _, err := p.connection.Write([]byte{byte(pca9685AllLedOffLReg), byte(off) & 0xFF}); err != nil {
+	if _, err := d.write([]byte{byte(pca9685AllLedOffLReg), byte(off) & 0xFF}); err != nil {
 		return err
 	}
 
-	_, err := p.connection.Write([]byte{byte(pca9685AllLedOffHReg), byte(off >> 8)})
+	_, err := d.write([]byte{byte(pca9685AllLedOffHReg), byte(off >> 8)})
 	return err
 }
 
 // SetPWMFreq sets the PWM frequency in Hz between 24Hz and 1526Hz, the default is 200Hz.
-func (p *PCA9685Driver) SetPWMFreq(freq float32) error {
+func (d *PCA9685Driver) SetPWMFreq(freq float32) error {
 	// internal IC oscillator frequency is 25 MHz
 	var prescalevel float32 = 25000000
 	// find frequency of PWM waveform
@@ -150,26 +150,26 @@ func (p *PCA9685Driver) SetPWMFreq(freq float32) error {
 	// round value to nearest whole
 	prescale := byte(prescalevel + 0.5)
 
-	if _, err := p.connection.Write([]byte{byte(pca9685Mode1Reg)}); err != nil {
+	if _, err := d.write([]byte{byte(pca9685Mode1Reg)}); err != nil {
 		return err
 	}
-	oldmode, err := p.connection.ReadByte()
+	oldmode, err := d.readByte()
 	if err != nil {
 		return err
 	}
 
 	// put oscillator in sleep mode, clear the restart bit 7 here to prevent unneeded restart
 	sleepMode := (oldmode &^ pca9685Mode1RegRestartBit) | pca9685Mode1RegSleepBit
-	if _, err := p.connection.Write([]byte{byte(pca9685Mode1Reg), sleepMode}); err != nil {
+	if _, err := d.write([]byte{byte(pca9685Mode1Reg), sleepMode}); err != nil {
 		return err
 	}
 	// write prescaler value
-	if _, err := p.connection.Write([]byte{byte(pca9685PrescaleReg), prescale}); err != nil {
+	if _, err := d.write([]byte{byte(pca9685PrescaleReg), prescale}); err != nil {
 		return err
 	}
 	// put back to old settings, ensure no sleep
 	noSleepMode := oldmode &^ pca9685Mode1RegSleepBit
-	if _, err := p.connection.Write([]byte{byte(pca9685Mode1Reg), noSleepMode}); err != nil {
+	if _, err := d.write([]byte{byte(pca9685Mode1Reg), noSleepMode}); err != nil {
 		return err
 	}
 
@@ -178,66 +178,66 @@ func (p *PCA9685Driver) SetPWMFreq(freq float32) error {
 
 	// initiate a restart
 	restartMode := oldmode | pca9685Mode1RegRestartBit
-	_, err = p.connection.Write([]byte{byte(pca9685Mode1Reg), restartMode})
+	_, err = d.write([]byte{byte(pca9685Mode1Reg), restartMode})
 	return err
 }
 
 // PwmWrite writes a PWM signal to the specified channel aka "pin".
 // Value values are from 0-255, to conform to the PwmWriter interface.
 // If you need finer control, please look at SetPWM().
-func (p *PCA9685Driver) PwmWrite(pin string, val byte) error {
+func (d *PCA9685Driver) PwmWrite(pin string, val byte) error {
 	i, err := strconv.Atoi(pin)
 	if err != nil {
 		return err
 	}
 	v := gobot.ToScale(gobot.FromScale(float64(val), 0, 255), 0, 4095)
-	return p.SetPWM(i, 0, uint16(v))
+	return d.SetPWM(i, 0, uint16(v))
 }
 
 // ServoWrite writes a servo signal to the specified channel aka "pin".
 // Valid values are from 0-180, to conform to the ServoWriter interface.
 // If you need finer control, please look at SetPWM().
-func (p *PCA9685Driver) ServoWrite(pin string, val byte) error {
+func (d *PCA9685Driver) ServoWrite(pin string, val byte) error {
 	i, err := strconv.Atoi(pin)
 	if err != nil {
 		return err
 	}
 	v := gobot.ToScale(gobot.FromScale(float64(val), 0, 180), 200, 500)
-	return p.SetPWM(i, 0, uint16(v))
+	return d.SetPWM(i, 0, uint16(v))
 }
 
 // initialize the driver according to the data sheet section "7.3.1.1 Restart mode"
 // * ensure the sleep bit is unset
 // * wait > 500us
 // * write a logic 1 to bit 7 (RESTART) of register "MODE1"
-func (p *PCA9685Driver) initialize() error {
-	if err := p.SetAllPWM(0, 0); err != nil {
+func (d *PCA9685Driver) initialize() error {
+	if err := d.SetAllPWM(0, 0); err != nil {
 		return err
 	}
 
 	// set not inverted (default), outputs change on stop (default), OE reaction to 0 (default), totem-pole (default)
-	if _, err := p.connection.Write([]byte{pca9685Mode2Reg, pca9685Mode2RegOutdrvBit}); err != nil {
+	if _, err := d.write([]byte{pca9685Mode2Reg, pca9685Mode2RegOutdrvBit}); err != nil {
 		return err
 	}
 	// reset of sleep bit together with set of no restart (default), internal clock (default), no AI (default),
 	// no response to sub address 1, 2 or 3 (default), activate response to all-call (default)
-	if _, err := p.connection.Write([]byte{pca9685Mode1Reg, pca9685Mode1RegAllCallBit}); err != nil {
+	if _, err := d.write([]byte{pca9685Mode1Reg, pca9685Mode1RegAllCallBit}); err != nil {
 		return err
 	}
 
 	time.Sleep(5 * time.Millisecond)
 
 	// initiate the restart
-	if _, err := p.connection.Write([]byte{byte(pca9685Mode1Reg)}); err != nil {
+	if _, err := d.write([]byte{byte(pca9685Mode1Reg)}); err != nil {
 		return err
 	}
-	oldmode, err := p.connection.ReadByte()
+	oldmode, err := d.readByte()
 	if err != nil {
 		return err
 	}
 	oldmode = oldmode | byte(pca9685Mode1RegRestartBit)
 
-	if _, err := p.connection.Write([]byte{pca9685Mode1Reg, oldmode}); err != nil {
+	if _, err := d.write([]byte{pca9685Mode1Reg, oldmode}); err != nil {
 		return err
 	}
 
@@ -246,7 +246,11 @@ func (p *PCA9685Driver) initialize() error {
 	return nil
 }
 
-func (p *PCA9685Driver) shutdown() error {
-	_, err := p.connection.Write([]byte{pca9685AllLedOffHReg, pca9685AllLedOffHRegShutDown})
+func (d *PCA9685Driver) shutdown() error {
+	if d.connection == nil {
+		return nil
+	}
+
+	_, err := d.write([]byte{pca9685AllLedOffHReg, pca9685AllLedOffHRegShutDown})
 	return err
 }

--- a/drivers/i2c/pca9685_driver_test.go
+++ b/drivers/i2c/pca9685_driver_test.go
@@ -96,6 +96,15 @@ func TestPCA9685HaltError(t *testing.T) {
 	require.ErrorContains(t, d.Halt(), "write error")
 }
 
+func TestPCA9685HaltIdempotent(t *testing.T) {
+	// arrange
+	d := NewPCA9685Driver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestPCA9685SetPWM(t *testing.T) {
 	// sequence to set PWM for PCA9685:
 	// * set LEDn ON-time register (n=0: 0x06, 0x07, n=1: 0x0A, 0x0B ... n=14: 0x3E, 0x3F, n=15: 0x42, 0x43)

--- a/drivers/i2c/pcf8583_driver.go
+++ b/drivers/i2c/pcf8583_driver.go
@@ -141,7 +141,7 @@ func (d *PCF8583Driver) WriteTime(val time.Time) error {
 
 	// according to chapter 7.11 of the product data sheet, the stop counting flag of the control/status register
 	// must be set before, so we read the control byte before and only set/reset the stop
-	ctrlRegVal, err := d.connection.ReadByteData(uint8(pcf8583Reg_CTRL))
+	ctrlRegVal, err := d.readByteData(uint8(pcf8583Reg_CTRL))
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func (d *PCF8583Driver) WriteTime(val time.Time) error {
 		return fmt.Errorf("%s: can't write time because the device is in wrong mode 0x%02x", d.name, ctrlRegVal)
 	}
 	year, month, day := val.Date()
-	err = d.connection.WriteBlockData(uint8(pcf8583Reg_CTRL),
+	err = d.writeBlockData(uint8(pcf8583Reg_CTRL),
 		[]byte{
 			ctrlRegVal | uint8(pcf8583CtrlStopCounting),
 			// sub seconds in 1/10th seconds
@@ -176,7 +176,7 @@ func (d *PCF8583Driver) ReadTime() (time.Time, error) {
 
 	// according to chapter 7.1 of the product data sheet, the setting of "hold last count" flag
 	// is not needed when reading with auto increment
-	ctrlRegVal, err := d.connection.ReadByteData(uint8(pcf8583Reg_CTRL))
+	ctrlRegVal, err := d.readByteData(uint8(pcf8583Reg_CTRL))
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -186,7 +186,7 @@ func (d *PCF8583Driver) ReadTime() (time.Time, error) {
 	// auto increment feature is used
 	clockDataSize := 6
 	data := make([]byte, clockDataSize)
-	read, err := d.connection.Read(data)
+	read, err := d.read(data)
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -213,14 +213,14 @@ func (d *PCF8583Driver) WriteCounter(val int32) error {
 	// we don't care of negative values here
 	// according to chapter 7.11 of the product data sheet, the stop counting flag of the control/status register
 	// must be set before, so we read the control byte before and only set/reset the stop
-	ctrlRegVal, err := d.connection.ReadByteData(uint8(pcf8583Reg_CTRL))
+	ctrlRegVal, err := d.readByteData(uint8(pcf8583Reg_CTRL))
 	if err != nil {
 		return err
 	}
 	if !PCF8583Control(ctrlRegVal).isCounterMode() {
 		return fmt.Errorf("%s: can't write counter because the device is in wrong mode 0x%02x", d.name, ctrlRegVal)
 	}
-	err = d.connection.WriteBlockData(uint8(pcf8583Reg_CTRL),
+	err = d.writeBlockData(uint8(pcf8583Reg_CTRL),
 		[]byte{
 			ctrlRegVal | uint8(pcf8583CtrlStopCounting), // stop
 			//nolint:gosec // TODO: fix later
@@ -243,7 +243,7 @@ func (d *PCF8583Driver) ReadCounter() (int32, error) {
 
 	// according to chapter 7.1 of the product data sheet, the setting of "hold last count" flag
 	// is not needed when reading with auto increment
-	ctrlRegVal, err := d.connection.ReadByteData(uint8(pcf8583Reg_CTRL))
+	ctrlRegVal, err := d.readByteData(uint8(pcf8583Reg_CTRL))
 	if err != nil {
 		return 0, err
 	}
@@ -253,7 +253,7 @@ func (d *PCF8583Driver) ReadCounter() (int32, error) {
 	// auto increment feature is used
 	counterDataSize := 3
 	data := make([]byte, counterDataSize)
-	read, err := d.connection.Read(data)
+	read, err := d.read(data)
 	if err != nil {
 		return 0, err
 	}
@@ -274,7 +274,7 @@ func (d *PCF8583Driver) WriteRAM(address uint8, val uint8) error {
 	if realAddress > 0xFF {
 		return fmt.Errorf("%s: RAM address overflow %d", d.name, realAddress)
 	}
-	return d.connection.WriteByteData(uint8(realAddress), val)
+	return d.writeByteData(uint8(realAddress), val)
 }
 
 // ReadRAM reads a value from a given address (0x00-0xFF)
@@ -286,23 +286,23 @@ func (d *PCF8583Driver) ReadRAM(address uint8) (uint8, error) {
 	if realAddress > 0xFF {
 		return 0, fmt.Errorf("%s: RAM address overflow %d", d.name, realAddress)
 	}
-	return d.connection.ReadByteData(uint8(realAddress))
+	return d.readByteData(uint8(realAddress))
 }
 
 func (d *PCF8583Driver) run(ctrlRegVal uint8) error {
 	ctrlRegVal = ctrlRegVal & ^uint8(pcf8583CtrlStopCounting) // reset stop bit
-	return d.connection.WriteByteData(uint8(pcf8583Reg_CTRL), ctrlRegVal)
+	return d.writeByteData(uint8(pcf8583Reg_CTRL), ctrlRegVal)
 }
 
 func (d *PCF8583Driver) initialize() error {
 	// switch to configured mode
-	ctrlRegVal, err := d.connection.ReadByteData(uint8(pcf8583Reg_CTRL))
+	ctrlRegVal, err := d.readByteData(uint8(pcf8583Reg_CTRL))
 	if err != nil {
 		return err
 	}
 	if d.mode.isModeDiffer(PCF8583Control(ctrlRegVal)) {
 		ctrlRegVal = ctrlRegVal&^uint8(PCF8583CtrlModeTest) | uint8(d.mode)
-		if err = d.connection.WriteByteData(uint8(pcf8583Reg_CTRL), ctrlRegVal); err != nil {
+		if err = d.writeByteData(uint8(pcf8583Reg_CTRL), ctrlRegVal); err != nil {
 			return err
 		}
 		if pcf8583Debug {

--- a/drivers/i2c/pcf8583_driver_test.go
+++ b/drivers/i2c/pcf8583_driver_test.go
@@ -37,6 +37,15 @@ func TestNewPCF8583Driver(t *testing.T) {
 	assert.Equal(t, uint8(0x10), d.ramOffset)
 }
 
+func TestPCF8583Halt(t *testing.T) {
+	// arrange
+	d := NewPCF8583Driver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestPCF8583Options(t *testing.T) {
 	// This is a general test, that options are applied in constructor by using the common WithBus() option and
 	// least one of this driver. Further tests for options can also be done by call of "WithOption(val)(d)".

--- a/drivers/i2c/pcf8591_driver.go
+++ b/drivers/i2c/pcf8591_driver.go
@@ -120,23 +120,23 @@ type PCF8591Driver struct {
 //	i2c.WithAddress(int): address to use with this driver
 //	i2c.WithPCF8591With400kbitStabilization(uint8, uint8): stabilize read in 400 kbit mode
 func NewPCF8591Driver(c Connector, options ...func(Config)) *PCF8591Driver {
-	p := &PCF8591Driver{
+	d := &PCF8591Driver{
 		Driver: NewDriver(c, "PCF8591", pcf8591DefaultAddress),
 	}
-	p.afterStart = p.initialize
-	p.beforeHalt = p.shutdown
+	d.afterStart = d.initialize
+	d.beforeHalt = d.shutdown
 
 	for _, option := range options {
-		option(p)
+		option(d)
 	}
 
-	return p
+	return d
 }
 
 // WithPCF8591With400kbitStabilization option sets the PCF8591 additionalReadWrite and additionalRead value
 func WithPCF8591With400kbitStabilization(additionalReadWrite, additionalRead int) func(Config) {
 	return func(c Config) {
-		p, ok := c.(*PCF8591Driver)
+		d, ok := c.(*PCF8591Driver)
 		if ok {
 			if additionalReadWrite < 0 {
 				additionalReadWrite = 1 // works in most cases
@@ -144,10 +144,10 @@ func WithPCF8591With400kbitStabilization(additionalReadWrite, additionalRead int
 			if additionalRead < 0 {
 				additionalRead = 2 // works in most cases
 			}
-			p.additionalReadWrite = uint8(additionalReadWrite) //nolint:gosec // checked before
-			p.additionalRead = uint8(additionalRead)           //nolint:gosec // checked before
+			d.additionalReadWrite = uint8(additionalReadWrite) //nolint:gosec // checked before
+			d.additionalRead = uint8(additionalRead)           //nolint:gosec // checked before
 			if pcf8591Debug {
-				log.Printf("400 kbit stabilization for PCF8591Driver set rw: %d, r: %d", p.additionalReadWrite, p.additionalRead)
+				log.Printf("400 kbit stabilization for PCF8591Driver set rw: %d, r: %d", d.additionalReadWrite, d.additionalRead)
 			}
 		} else if pcf8591Debug {
 			log.Printf("trying to set 400 kbit stabilization for non-PCF8591Driver %v", c)
@@ -192,9 +192,9 @@ func WithPCF8591ForceRefresh(val uint8) func(Config) {
 //     because some missing integration steps in each conversion (each byte value is a little bit lower than expected)
 //
 // So, for default, we drop the first three bytes to get the right value.
-func (p *PCF8591Driver) AnalogRead(description string) (int, error) {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
+func (d *PCF8591Driver) AnalogRead(description string) (int, error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
 	mc, err := PCF8591ParseModeChan(description)
 	if err != nil {
@@ -202,20 +202,20 @@ func (p *PCF8591Driver) AnalogRead(description string) (int, error) {
 	}
 
 	// reset channel and mode
-	ctrlByte := p.lastCtrlByte & ^uint8(pcf8591_ADMASK)
+	ctrlByte := d.lastCtrlByte & ^uint8(pcf8591_ADMASK)
 	// set to current channel and mode, AI must be off, because we need reading twice
 	ctrlByte = ctrlByte | uint8(mc.mode) | uint8(mc.channel) & ^uint8(pcf8591_AION)
 
 	var uval byte
-	p.LastRead = make([][]byte, p.additionalReadWrite+1)
+	d.LastRead = make([][]byte, d.additionalReadWrite+1)
 	// repeated write and read cycle to stabilize value in 400 kbit mode
-	for writeReadCycle := uint8(1); writeReadCycle <= p.additionalReadWrite+1; writeReadCycle++ {
-		if err = p.writeCtrlByte(ctrlByte, p.forceRefresh || writeReadCycle > 1); err != nil {
+	for writeReadCycle := uint8(1); writeReadCycle <= d.additionalReadWrite+1; writeReadCycle++ {
+		if err = d.writeCtrlByte(ctrlByte, d.forceRefresh || writeReadCycle > 1); err != nil {
 			return 0, err
 		}
 
 		// initiate read but skip some bytes
-		if err := p.readBuf(writeReadCycle, 1+p.additionalRead); err != nil {
+		if err := d.readBuf(writeReadCycle, 1+d.additionalRead); err != nil {
 			return 0, err
 		}
 
@@ -223,12 +223,12 @@ func (p *PCF8591Driver) AnalogRead(description string) (int, error) {
 		time.Sleep(1 * time.Millisecond)
 
 		// real used read
-		if uval, err = p.connection.ReadByte(); err != nil {
+		if uval, err = d.readByte(); err != nil {
 			return 0, err
 		}
 
 		if pcf8591Debug {
-			p.LastRead[writeReadCycle-1] = append(p.LastRead[writeReadCycle-1], uval)
+			d.LastRead[writeReadCycle-1] = append(d.LastRead[writeReadCycle-1], uval)
 		}
 	}
 
@@ -247,26 +247,26 @@ func (p *PCF8591Driver) AnalogRead(description string) (int, error) {
 // AnalogWrite writes the given value to the analog output (DAC)
 // Vlsb = (Vref-Vagnd)/256, Vaout = Vagnd+Vlsb*value
 // implements the aio.AnalogWriter interface, pin is unused here
-func (p *PCF8591Driver) AnalogWrite(pin string, value int) error {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
+func (d *PCF8591Driver) AnalogWrite(pin string, value int) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
 	byteVal := byte(value)
 
-	if p.lastAnaOut == byteVal {
+	if d.lastAnaOut == byteVal {
 		if pcf8591Debug {
 			log.Printf("write skipped because value unchanged: 0x%X\n", byteVal)
 		}
 		return nil
 	}
 
-	ctrlByte := p.lastCtrlByte | byte(pcf8591_ANAON)
-	if err := p.connection.WriteByteData(ctrlByte, byteVal); err != nil {
+	ctrlByte := d.lastCtrlByte | byte(pcf8591_ANAON)
+	if err := d.writeByteData(ctrlByte, byteVal); err != nil {
 		return err
 	}
 
-	p.lastCtrlByte = ctrlByte
-	p.lastAnaOut = byteVal
+	d.lastCtrlByte = ctrlByte
+	d.lastAnaOut = byteVal
 	return nil
 }
 
@@ -274,11 +274,11 @@ func (p *PCF8591Driver) AnalogWrite(pin string, value int) error {
 // Please note that in case of using the internal oscillator
 // and the auto increment mode the output should not switched off.
 // Otherwise conversion errors could occur.
-func (p *PCF8591Driver) AnalogOutputState(state bool) error {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
+func (d *PCF8591Driver) AnalogOutputState(state bool) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
-	return p.analogOutputState(state)
+	return d.analogOutputState(state)
 }
 
 // PCF8591ParseModeChan is used to get a working combination between mode (single, mixed, 2 differential,
@@ -297,21 +297,21 @@ func PCF8591ParseModeChan(description string) (*pcf8591ModeChan, error) {
 	return &mc, nil
 }
 
-func (p *PCF8591Driver) writeCtrlByte(ctrlByte uint8, forceRefresh bool) error {
-	if p.lastCtrlByte != ctrlByte || forceRefresh {
-		if err := p.connection.WriteByte(ctrlByte); err != nil {
+func (d *PCF8591Driver) writeCtrlByte(ctrlByte uint8, forceRefresh bool) error {
+	if d.lastCtrlByte != ctrlByte || forceRefresh {
+		if err := d.writeByte(ctrlByte); err != nil {
 			return err
 		}
-		p.lastCtrlByte = ctrlByte
+		d.lastCtrlByte = ctrlByte
 	} else if pcf8591Debug {
 		log.Printf("write skipped because control byte unchanged: 0x%X\n", ctrlByte)
 	}
 	return nil
 }
 
-func (p *PCF8591Driver) readBuf(nr uint8, cntBytes uint8) error {
+func (d *PCF8591Driver) readBuf(nr uint8, cntBytes uint8) error {
 	buf := make([]byte, cntBytes)
-	cntRead, err := p.connection.Read(buf)
+	cntRead, err := d.read(buf)
 	if err != nil {
 		return err
 	}
@@ -319,7 +319,7 @@ func (p *PCF8591Driver) readBuf(nr uint8, cntBytes uint8) error {
 		return fmt.Errorf("not enough bytes (%d of %d) read", cntRead, len(buf))
 	}
 	if pcf8591Debug {
-		p.LastRead[nr-1] = buf
+		d.LastRead[nr-1] = buf
 	}
 	return nil
 }
@@ -337,23 +337,23 @@ func (mc pcf8591ModeChan) pcf8591IsDiff() bool {
 	}
 }
 
-func (p *PCF8591Driver) initialize() error {
-	return p.analogOutputState(false)
+func (d *PCF8591Driver) initialize() error {
+	return d.analogOutputState(false)
 }
 
-func (p *PCF8591Driver) shutdown() error {
-	return p.analogOutputState(false)
+func (d *PCF8591Driver) shutdown() error {
+	return d.analogOutputState(false)
 }
 
-func (p *PCF8591Driver) analogOutputState(state bool) error {
+func (d *PCF8591Driver) analogOutputState(state bool) error {
 	var ctrlByte uint8
 	if state {
-		ctrlByte = p.lastCtrlByte | byte(pcf8591_ANAON)
+		ctrlByte = d.lastCtrlByte | byte(pcf8591_ANAON)
 	} else {
-		ctrlByte = p.lastCtrlByte & ^uint8(pcf8591_ANAON)
+		ctrlByte = d.lastCtrlByte & ^uint8(pcf8591_ANAON)
 	}
 
-	if err := p.writeCtrlByte(ctrlByte, p.forceRefresh); err != nil {
+	if err := d.writeCtrlByte(ctrlByte, d.forceRefresh); err != nil {
 		return err
 	}
 	return nil

--- a/drivers/i2c/pcf8591_driver_test.go
+++ b/drivers/i2c/pcf8591_driver_test.go
@@ -41,7 +41,11 @@ func TestPCF8591Start(t *testing.T) {
 }
 
 func TestPCF8591Halt(t *testing.T) {
+	// arrange
 	d := NewPCF8591Driver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
 	require.NoError(t, d.Halt())
 }
 

--- a/drivers/i2c/sht2x_driver.go
+++ b/drivers/i2c/sht2x_driver.go
@@ -123,7 +123,7 @@ func (d *SHT2xDriver) SetAccuracy(acc byte) error {
 
 // Reset does a software reset of the device
 func (d *SHT2xDriver) Reset() error {
-	if err := d.connection.WriteByte(SHT2xSoftReset); err != nil {
+	if err := d.writeByte(SHT2xSoftReset); err != nil {
 		return err
 	}
 
@@ -162,7 +162,7 @@ func (d *SHT2xDriver) Humidity() (float32, error) {
 
 // sendCommandDelayGetResponse is a helper function to reduce duplicated code
 func (d *SHT2xDriver) readSensor(cmd byte) (uint16, error) {
-	if err := d.connection.WriteByte(cmd); err != nil {
+	if err := d.writeByte(cmd); err != nil {
 		return 0, err
 	}
 
@@ -173,7 +173,7 @@ func (d *SHT2xDriver) readSensor(cmd byte) (uint16, error) {
 	buf := make([]byte, 3)
 	counter := 0
 	for {
-		got, err := d.connection.Read(buf)
+		got, err := d.read(buf)
 		counter++
 		if counter > 50 {
 			return 0, err
@@ -207,10 +207,10 @@ func (d *SHT2xDriver) initialize() error {
 }
 
 func (d *SHT2xDriver) sendAccuracy() error {
-	if err := d.connection.WriteByte(SHT2xReadUserReg); err != nil {
+	if err := d.writeByte(SHT2xReadUserReg); err != nil {
 		return err
 	}
-	userRegister, err := d.connection.ReadByte()
+	userRegister, err := d.readByte()
 	if err != nil {
 		return err
 	}
@@ -221,10 +221,10 @@ func (d *SHT2xDriver) sendAccuracy() error {
 	userRegister |= acc // Mask in the requested resolution bits
 
 	// Request a write to user register
-	if _, err := d.connection.Write([]byte{SHT2xWriteUserReg, userRegister}); err != nil {
+	if _, err := d.write([]byte{SHT2xWriteUserReg, userRegister}); err != nil {
 		return err
 	}
 
-	_, err = d.connection.ReadByte()
+	_, err = d.readByte()
 	return err
 }

--- a/drivers/i2c/sht2x_driver_test.go
+++ b/drivers/i2c/sht2x_driver_test.go
@@ -48,7 +48,11 @@ func TestSHT2xStart(t *testing.T) {
 }
 
 func TestSHT2xHalt(t *testing.T) {
-	d, _ := initTestSHT2xDriverWithStubbedAdaptor()
+	// arrange
+	d := NewSHT2xDriver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
 	require.NoError(t, d.Halt())
 }
 

--- a/drivers/i2c/sht3x_driver.go
+++ b/drivers/i2c/sht3x_driver.go
@@ -72,46 +72,46 @@ type SHT3xDriver struct {
 //	i2c.WithBus(int):	bus to use with this driver
 //	i2c.WithAddress(int):	address to use with this driver
 func NewSHT3xDriver(c Connector, options ...func(Config)) *SHT3xDriver {
-	s := &SHT3xDriver{
+	d := &SHT3xDriver{
 		Driver:   NewDriver(c, "SHT3x", SHT3xAddressA),
 		Units:    "C",
 		crcTable: crc8.MakeTable(crc8Params),
 	}
-	if err := s.SetAccuracy(SHT3xAccuracyHigh); err != nil {
+	if err := d.SetAccuracy(SHT3xAccuracyHigh); err != nil {
 		panic(err)
 	}
 
 	for _, option := range options {
-		option(s)
+		option(d)
 	}
 
-	return s
+	return d
 }
 
 // Accuracy returns the accuracy of the sampling
-func (s *SHT3xDriver) Accuracy() byte { return s.accuracy }
+func (d *SHT3xDriver) Accuracy() byte { return d.accuracy }
 
 // SetAccuracy sets the accuracy of the sampling
-func (s *SHT3xDriver) SetAccuracy(a byte) error {
+func (d *SHT3xDriver) SetAccuracy(a byte) error {
 	switch a {
 	case SHT3xAccuracyLow:
-		s.delay = 5 * time.Millisecond // Actual max is 4, wait 1 ms longer
+		d.delay = 5 * time.Millisecond // Actual max is 4, wait 1 ms longer
 	case SHT3xAccuracyMedium:
-		s.delay = 7 * time.Millisecond // Actual max is 6, wait 1 ms longer
+		d.delay = 7 * time.Millisecond // Actual max is 6, wait 1 ms longer
 	case SHT3xAccuracyHigh:
-		s.delay = 16 * time.Millisecond // Actual max is 15, wait 1 ms longer
+		d.delay = 16 * time.Millisecond // Actual max is 15, wait 1 ms longer
 	default:
 		return ErrInvalidAccuracy
 	}
 
-	s.accuracy = a
+	d.accuracy = a
 
 	return nil
 }
 
 // SerialNumber returns the serial number of the chip
-func (s *SHT3xDriver) SerialNumber() (uint32, error) {
-	ret, err := s.sendCommandDelayGetResponse([]byte{0x37, 0x80}, nil, 2)
+func (d *SHT3xDriver) SerialNumber() (uint32, error) {
+	ret, err := d.sendCommandDelayGetResponse([]byte{0x37, 0x80}, nil, 2)
 	if err != nil {
 		return 0, err
 	}
@@ -122,8 +122,8 @@ func (s *SHT3xDriver) SerialNumber() (uint32, error) {
 }
 
 // Heater returns true if the heater is enabled
-func (s *SHT3xDriver) Heater() (bool, error) {
-	sr, err := s.getStatusRegister()
+func (d *SHT3xDriver) Heater() (bool, error) {
+	sr, err := d.getStatusRegister()
 	if err != nil {
 		return false, err
 	}
@@ -136,20 +136,20 @@ func (s *SHT3xDriver) Heater() (bool, error) {
 }
 
 // SetHeater enables or disables the heater on the device
-func (s *SHT3xDriver) SetHeater(enabled bool) error {
+func (d *SHT3xDriver) SetHeater(enabled bool) error {
 	out := []byte{0x30, 0x66}
 	if enabled {
 		out[1] = 0x6d
 	}
-	_, err := s.connection.Write(out)
+	_, err := d.write(out)
 	return err
 }
 
 // Sample returns the temperature in celsius and relative humidity for one sample
 //
 //nolint:nonamedreturns // is sufficient here
-func (s *SHT3xDriver) Sample() (temp float32, rh float32, err error) {
-	ret, err := s.sendCommandDelayGetResponse([]byte{0x24, s.accuracy}, &s.delay, 2)
+func (d *SHT3xDriver) Sample() (temp float32, rh float32, err error) {
+	ret, err := d.sendCommandDelayGetResponse([]byte{0x24, d.accuracy}, &d.delay, 2)
 	if nil != err {
 		return
 	}
@@ -160,7 +160,7 @@ func (s *SHT3xDriver) Sample() (temp float32, rh float32, err error) {
 	rh = float32((uint64(1000000)*rhSample)/uint64(0xffff)) / 10000.0
 
 	tempSample := uint64(ret[0])
-	switch s.Units {
+	switch d.Units {
 	case "C":
 		// From the datasheet:
 		// T[C] = -45 + 175 * (St / (2^16 - 1))
@@ -177,8 +177,8 @@ func (s *SHT3xDriver) Sample() (temp float32, rh float32, err error) {
 }
 
 // getStatusRegister returns the device status register
-func (s *SHT3xDriver) getStatusRegister() (uint16, error) {
-	ret, err := s.sendCommandDelayGetResponse([]byte{0xf3, 0x2d}, nil, 1)
+func (d *SHT3xDriver) getStatusRegister() (uint16, error) {
+	ret, err := d.sendCommandDelayGetResponse([]byte{0xf3, 0x2d}, nil, 1)
 	if err != nil {
 		return 0, err
 	}
@@ -187,8 +187,8 @@ func (s *SHT3xDriver) getStatusRegister() (uint16, error) {
 }
 
 // sendCommandDelayGetResponse is a helper function to reduce duplicated code
-func (s *SHT3xDriver) sendCommandDelayGetResponse(send []byte, delay *time.Duration, expect int) ([]uint16, error) {
-	if _, err := s.connection.Write(send); err != nil {
+func (d *SHT3xDriver) sendCommandDelayGetResponse(send []byte, delay *time.Duration, expect int) ([]uint16, error) {
+	if _, err := d.write(send); err != nil {
 		return nil, err
 	}
 
@@ -197,7 +197,7 @@ func (s *SHT3xDriver) sendCommandDelayGetResponse(send []byte, delay *time.Durat
 	}
 
 	buf := make([]byte, 3*expect)
-	got, err := s.connection.Read(buf)
+	got, err := d.read(buf)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +207,7 @@ func (s *SHT3xDriver) sendCommandDelayGetResponse(send []byte, delay *time.Durat
 
 	read := make([]uint16, expect)
 	for i := 0; i < expect; i++ {
-		crc := crc8.Checksum(buf[i*3:i*3+2], s.crcTable)
+		crc := crc8.Checksum(buf[i*3:i*3+2], d.crcTable)
 		if buf[i*3+2] != crc {
 			return nil, ErrInvalidCrc
 		}

--- a/drivers/i2c/sht3x_driver_test.go
+++ b/drivers/i2c/sht3x_driver_test.go
@@ -48,7 +48,11 @@ func TestSHT3xStart(t *testing.T) {
 }
 
 func TestSHT3xHalt(t *testing.T) {
-	d, _ := initTestSHT3xDriverWithStubbedAdaptor()
+	// arrange
+	d := NewSHT3xDriver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
 	require.NoError(t, d.Halt())
 }
 

--- a/drivers/i2c/ssd1306_driver.go
+++ b/drivers/i2c/ssd1306_driver.go
@@ -202,54 +202,54 @@ type SSD1306Driver struct {
 //	WithSSD1306DisplayHeight(int): 	height of display (defaults to 64)
 //	WithSSD1306ExternalVCC:          set true when using an external OLED supply (defaults to false)
 func NewSSD1306Driver(c Connector, options ...func(Config)) *SSD1306Driver {
-	s := &SSD1306Driver{
+	d := &SSD1306Driver{
 		Driver:        NewDriver(c, "SSD1306", ssd1306DefaultAddress),
 		displayHeight: ssd1306Height,
 		displayWidth:  ssd1306Width,
 		externalVCC:   ssd1306ExternalVCC,
 	}
-	s.afterStart = s.initialize
+	d.afterStart = d.initialize
 
 	// set options
 	for _, option := range options {
-		option(s)
+		option(d)
 	}
 	// set page size
-	s.pageSize = 8
+	d.pageSize = 8
 	// set display buffer
-	s.buffer = NewDisplayBuffer(s.displayWidth, s.displayHeight, s.pageSize)
+	d.buffer = NewDisplayBuffer(d.displayWidth, d.displayHeight, d.pageSize)
 	// add commands
-	s.AddCommand("Display", func(_ map[string]interface{}) interface{} {
-		err := s.Display()
+	d.AddCommand("Display", func(_ map[string]interface{}) interface{} {
+		err := d.Display()
 		return map[string]interface{}{"err": err}
 	})
-	s.AddCommand("On", func(_ map[string]interface{}) interface{} {
-		err := s.On()
+	d.AddCommand("On", func(_ map[string]interface{}) interface{} {
+		err := d.On()
 		return map[string]interface{}{"err": err}
 	})
-	s.AddCommand("Off", func(_ map[string]interface{}) interface{} {
-		err := s.Off()
+	d.AddCommand("Off", func(_ map[string]interface{}) interface{} {
+		err := d.Off()
 		return map[string]interface{}{"err": err}
 	})
-	s.AddCommand("Clear", func(_ map[string]interface{}) interface{} {
-		s.Clear()
+	d.AddCommand("Clear", func(_ map[string]interface{}) interface{} {
+		d.Clear()
 		return map[string]interface{}{}
 	})
 	//nolint:forcetypeassert // ok here
-	s.AddCommand("SetContrast", func(params map[string]interface{}) interface{} {
+	d.AddCommand("SetContrast", func(params map[string]interface{}) interface{} {
 		contrast := params["contrast"].(byte)
-		err := s.SetContrast(contrast)
+		err := d.SetContrast(contrast)
 		return map[string]interface{}{"err": err}
 	})
 	//nolint:forcetypeassert // ok here
-	s.AddCommand("Set", func(params map[string]interface{}) interface{} {
+	d.AddCommand("Set", func(params map[string]interface{}) interface{} {
 		x := params["x"].(int)
 		y := params["y"].(int)
 		c := params["c"].(int)
-		s.Set(x, y, c)
+		d.Set(x, y, c)
 		return nil
 	})
-	return s
+	return d
 }
 
 // WithSSD1306DisplayWidth option sets the SSD1306Driver DisplayWidth option.
@@ -283,118 +283,118 @@ func WithSSD1306ExternalVCC(val bool) func(Config) {
 }
 
 // Init initializes the ssd1306 display.
-func (s *SSD1306Driver) Init() error {
+func (d *SSD1306Driver) Init() error {
 	// turn off screen
-	if err := s.Off(); err != nil {
+	if err := d.Off(); err != nil {
 		return err
 	}
 	// run through initialization commands
-	if err := s.commands(s.initSequence.GetSequence()); err != nil {
+	if err := d.commands(d.initSequence.GetSequence()); err != nil {
 		return err
 	}
-	if err := s.commands([]byte{ssd1306ColumnAddr, 0, byte(s.buffer.width) - 1}); err != nil {
+	if err := d.commands([]byte{ssd1306ColumnAddr, 0, byte(d.buffer.width) - 1}); err != nil {
 		return err
 	}
 
-	return s.commands([]byte{ssd1306PageAddr, 0, (byte(s.buffer.height / s.pageSize)) - 1})
+	return d.commands([]byte{ssd1306PageAddr, 0, (byte(d.buffer.height / d.pageSize)) - 1})
 }
 
 // On turns on the display.
-func (s *SSD1306Driver) On() error {
-	return s.command(ssd1306SetDisplayOn)
+func (d *SSD1306Driver) On() error {
+	return d.command(ssd1306SetDisplayOn)
 }
 
 // Off turns off the display.
-func (s *SSD1306Driver) Off() error {
-	return s.command(ssd1306SetDisplayOff)
+func (d *SSD1306Driver) Off() error {
+	return d.command(ssd1306SetDisplayOff)
 }
 
 // Clear clears the display buffer.
-func (s *SSD1306Driver) Clear() {
-	s.buffer.Clear()
+func (d *SSD1306Driver) Clear() {
+	d.buffer.Clear()
 }
 
 // Set sets a pixel in the buffer.
-func (s *SSD1306Driver) Set(x, y, c int) {
-	s.buffer.SetPixel(x, y, c)
+func (d *SSD1306Driver) Set(x, y, c int) {
+	d.buffer.SetPixel(x, y, c)
 }
 
 // Reset clears display.
-func (s *SSD1306Driver) Reset() error {
-	if err := s.Off(); err != nil {
+func (d *SSD1306Driver) Reset() error {
+	if err := d.Off(); err != nil {
 		return err
 	}
-	s.Clear()
+	d.Clear()
 
-	return s.On()
+	return d.On()
 }
 
 // SetContrast sets the display contrast.
-func (s *SSD1306Driver) SetContrast(contrast byte) error {
-	return s.commands([]byte{ssd1306SetContrast, contrast})
+func (d *SSD1306Driver) SetContrast(contrast byte) error {
+	return d.commands([]byte{ssd1306SetContrast, contrast})
 }
 
 // Display sends the memory buffer to the display.
-func (s *SSD1306Driver) Display() error {
-	_, err := s.connection.Write(append([]byte{0x40}, s.buffer.buffer...))
+func (d *SSD1306Driver) Display() error {
+	_, err := d.write(append([]byte{0x40}, d.buffer.buffer...))
 	return err
 }
 
 // ShowImage takes a standard Go image and displays it in monochrome.
-func (s *SSD1306Driver) ShowImage(img image.Image) error {
-	if img.Bounds().Dx() != s.displayWidth || img.Bounds().Dy() != s.displayHeight {
-		return fmt.Errorf("image must match display width and height: %dx%d", s.displayWidth, s.displayHeight)
+func (d *SSD1306Driver) ShowImage(img image.Image) error {
+	if img.Bounds().Dx() != d.displayWidth || img.Bounds().Dy() != d.displayHeight {
+		return fmt.Errorf("image must match display width and height: %dx%d", d.displayWidth, d.displayHeight)
 	}
-	s.Clear()
+	d.Clear()
 	for y, w, h := 0, img.Bounds().Dx(), img.Bounds().Dy(); y < h; y++ {
 		for x := 0; x < w; x++ {
 			c := img.At(x, y)
 			if r, g, b, _ := c.RGBA(); r > 0 || g > 0 || b > 0 {
-				s.Set(x, y, 1)
+				d.Set(x, y, 1)
 			}
 		}
 	}
-	return s.Display()
+	return d.Display()
 }
 
 // command sends a command to the ssd1306
-func (s *SSD1306Driver) command(b byte) error {
-	_, err := s.connection.Write([]byte{0x80, b})
+func (d *SSD1306Driver) command(b byte) error {
+	_, err := d.write([]byte{0x80, b})
 	return err
 }
 
 // commands sends a command sequence to the ssd1306
-func (s *SSD1306Driver) commands(commands []byte) error {
+func (d *SSD1306Driver) commands(commands []byte) error {
 	var command []byte
 	for _, d := range commands {
 		command = append(command, []byte{0x80, d}...)
 	}
-	_, err := s.connection.Write(command)
+	_, err := d.write(command)
 	return err
 }
 
-func (s *SSD1306Driver) initialize() error {
+func (d *SSD1306Driver) initialize() error {
 	// check device size for supported resolutions
 	switch {
-	case s.displayWidth == 128 && s.displayHeight == 64:
-		s.initSequence = ssd1306Init128x64
-	case s.displayWidth == 128 && s.displayHeight == 32:
-		s.initSequence = ssd1306Init128x32
-	case s.displayWidth == 96 && s.displayHeight == 16:
-		s.initSequence = ssd1306Init96x16
+	case d.displayWidth == 128 && d.displayHeight == 64:
+		d.initSequence = ssd1306Init128x64
+	case d.displayWidth == 128 && d.displayHeight == 32:
+		d.initSequence = ssd1306Init128x32
+	case d.displayWidth == 96 && d.displayHeight == 16:
+		d.initSequence = ssd1306Init96x16
 	default:
 		return fmt.Errorf("%dx%d resolution is unsupported, supported resolutions: 128x64, 128x32, 96x16",
-			s.displayWidth, s.displayHeight)
+			d.displayWidth, d.displayHeight)
 	}
 	// check for external vcc
-	if s.externalVCC {
-		s.initSequence.chargePumpSetting = 0x10
-		s.initSequence.contrast = 0x9F
-		s.initSequence.prechargePeriod = 0x22
+	if d.externalVCC {
+		d.initSequence.chargePumpSetting = 0x10
+		d.initSequence.contrast = 0x9F
+		d.initSequence.prechargePeriod = 0x22
 	}
-	if err := s.Init(); err != nil {
+	if err := d.Init(); err != nil {
 		return err
 	}
 
-	return s.On()
+	return d.On()
 }

--- a/drivers/i2c/ssd1306_driver_test.go
+++ b/drivers/i2c/ssd1306_driver_test.go
@@ -98,8 +98,13 @@ func TestSSD1306StartSizeError(t *testing.T) {
 }
 
 func TestSSD1306Halt(t *testing.T) {
-	s, _ := initTestSSD1306DriverWithStubbedAdaptor(128, 64, false)
-	require.NoError(t, s.Halt())
+	// arrange
+	d := NewSSD1306Driver(newI2cTestAdaptor(), WithSSD1306DisplayWidth(128), WithSSD1306DisplayHeight(64),
+		WithSSD1306ExternalVCC(false))
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
 }
 
 func TestSSD1306Options(t *testing.T) {

--- a/drivers/i2c/th02_driver.go
+++ b/drivers/i2c/th02_driver.go
@@ -77,7 +77,7 @@ type TH02Driver struct {
 //	i2c.WithBus(int):	bus to use with this driver
 //	i2c.WithAddress(int):	address to use with this driver
 func NewTH02Driver(a Connector, options ...func(Config)) *TH02Driver {
-	s := &TH02Driver{
+	d := &TH02Driver{
 		Driver:   NewDriver(a, "TH02", th02DefaultAddress, options...),
 		Units:    "C",
 		heating:  false,
@@ -85,10 +85,10 @@ func NewTH02Driver(a Connector, options ...func(Config)) *TH02Driver {
 	}
 
 	for _, option := range options {
-		option(s)
+		option(d)
 	}
 
-	return s
+	return d
 }
 
 // WithTH02FastMode option sets the fast mode (leads to lower accuracy).
@@ -105,8 +105,8 @@ func WithTH02FastMode(val int) func(Config) {
 }
 
 // Accuracy returns the accuracy of the sampling (deprecated, use FastMode() instead)
-func (s *TH02Driver) Accuracy() byte {
-	if s.fastMode {
+func (d *TH02Driver) Accuracy() byte {
+	if d.fastMode {
 		return TH02LowAccuracy
 	}
 	return TH02HighAccuracy
@@ -114,105 +114,105 @@ func (s *TH02Driver) Accuracy() byte {
 
 // SetAccuracy sets the accuracy of the sampling. (deprecated, use WithFastMode() instead)
 // It will only be used on the next measurement request.  Invalid value will use the default of High
-func (s *TH02Driver) SetAccuracy(a byte) {
-	s.fastMode = (a == TH02LowAccuracy)
+func (d *TH02Driver) SetAccuracy(a byte) {
+	d.fastMode = (a == TH02LowAccuracy)
 }
 
 // SerialNumber returns the serial number of the chip
-func (s *TH02Driver) SerialNumber() (uint8, error) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+func (d *TH02Driver) SerialNumber() (uint8, error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
-	ret, err := s.connection.ReadByteData(th02Reg_ID)
+	ret, err := d.readByteData(th02Reg_ID)
 	return ret >> 4, err
 }
 
 // FastMode returns true if the fast mode is enabled in the device
-func (s *TH02Driver) FastMode() (bool, error) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+func (d *TH02Driver) FastMode() (bool, error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
-	cfg, err := s.connection.ReadByteData(th02Reg_Config)
+	cfg, err := d.readByteData(th02Reg_Config)
 	return (th02Config_FastBit & cfg) == th02Config_FastBit, err
 }
 
 // SetHeater sets the heater of the device to the given state.
-func (s *TH02Driver) SetHeater(state bool) error {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+func (d *TH02Driver) SetHeater(state bool) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
-	s.heating = state
-	return s.connection.WriteByteData(th02Reg_Config, s.createConfig(false, false))
+	d.heating = state
+	return d.writeByteData(th02Reg_Config, d.createConfig(false, false))
 }
 
 // Heater returns true if the heater is enabled in the device
-func (s *TH02Driver) Heater() (bool, error) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+func (d *TH02Driver) Heater() (bool, error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
-	cfg, err := s.connection.ReadByteData(th02Reg_Config)
+	cfg, err := d.readByteData(th02Reg_Config)
 	return (th02Config_HeatBit & cfg) == th02Config_HeatBit, err
 }
 
 // Sample returns the temperature in celsius and relative humidity for one sample
 //
 //nolint:nonamedreturns // is sufficient here
-func (s *TH02Driver) Sample() (temperature float32, relhumidity float32, _ error) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+func (d *TH02Driver) Sample() (temperature float32, relhumidity float32, _ error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
 	// read humidity
-	if err := s.connection.WriteByteData(th02Reg_Config, s.createConfig(true, false)); err != nil {
+	if err := d.writeByteData(th02Reg_Config, d.createConfig(true, false)); err != nil {
 		return 0, 0, err
 	}
 
-	rawrh, err := s.waitAndReadData()
+	rawrh, err := d.waitAndReadData()
 	if err != nil {
 		return 0, 0, err
 	}
 	relhumidity = float32(rawrh>>4)/16.0 - 24.0
 
 	// read temperature
-	if err := s.connection.WriteByteData(th02Reg_Config, s.createConfig(true, true)); err != nil {
+	if err := d.writeByteData(th02Reg_Config, d.createConfig(true, true)); err != nil {
 		return 0, relhumidity, err
 	}
-	rawt, err := s.waitAndReadData()
+	rawt, err := d.waitAndReadData()
 	if err != nil {
 		return 0, relhumidity, err
 	}
 	temperature = float32(rawt>>2)/32.0 - 50.0
 
-	if s.Units == "F" {
+	if d.Units == "F" {
 		temperature = 9.0/5.0*temperature + 32.0
 	}
 
 	return temperature, relhumidity, nil
 }
 
-func (s *TH02Driver) createConfig(measurement bool, readTemp bool) byte {
+func (d *TH02Driver) createConfig(measurement bool, readTemp bool) byte {
 	cfg := byte(0x00)
 	if measurement {
 		cfg = cfg | th02Config_StartBit
 		if readTemp {
 			cfg = cfg | th02Config_TempBit
 		}
-		if s.fastMode {
+		if d.fastMode {
 			cfg = cfg | th02Config_FastBit
 		}
 	}
-	if s.heating {
+	if d.heating {
 		cfg = cfg | th02Config_HeatBit
 	}
 	return cfg
 }
 
-func (s *TH02Driver) waitAndReadData() (uint16, error) {
-	if err := s.waitForReady(nil); err != nil {
+func (d *TH02Driver) waitAndReadData() (uint16, error) {
+	if err := d.waitForReady(nil); err != nil {
 		return 0, err
 	}
 
 	rcvd := make([]byte, 2)
-	err := s.connection.ReadBlockData(th02Reg_DataMSB, rcvd)
+	err := d.readBlockData(th02Reg_DataMSB, rcvd)
 	if err != nil {
 		return 0, err
 	}
@@ -221,7 +221,7 @@ func (s *TH02Driver) waitAndReadData() (uint16, error) {
 
 // waitForReady blocks for up to the passed duration (which defaults to 50mS if nil)
 // until the ~RDY bit is cleared, meaning a sample has been fully sampled and is ready for reading.
-func (s *TH02Driver) waitForReady(dur *time.Duration) error {
+func (d *TH02Driver) waitForReady(dur *time.Duration) error {
 	wait := 100 * time.Millisecond
 	if dur != nil {
 		wait = *dur
@@ -232,7 +232,7 @@ func (s *TH02Driver) waitForReady(dur *time.Duration) error {
 			return fmt.Errorf("timeout on \\RDY")
 		}
 
-		if reg, err := s.connection.ReadByteData(th02Reg_Status); (reg == 0) && (err == nil) {
+		if reg, err := d.readByteData(th02Reg_Status); (reg == 0) && (err == nil) {
 			return nil
 		}
 		time.Sleep(wait / 10)

--- a/drivers/i2c/th02_driver_test.go
+++ b/drivers/i2c/th02_driver_test.go
@@ -36,6 +36,15 @@ func TestNewTH02Driver(t *testing.T) {
 	assert.Equal(t, 0x40, d.defaultAddress)
 }
 
+func TestTH02Halt(t *testing.T) {
+	// arrange
+	d := NewTH02Driver(newI2cTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestTH02Options(t *testing.T) {
 	// This is a general test, that options are applied in constructor by using the common options.
 	// Further tests for options can also be done by call of "WithOption(val)(d)".

--- a/drivers/i2c/tsl2561_driver.go
+++ b/drivers/i2c/tsl2561_driver.go
@@ -217,7 +217,7 @@ func (d *TSL2561Driver) SetIntegrationTime(time TSL2561IntegrationTime) error {
 	}
 
 	timeGainVal := uint8(time) | uint8(d.gain) //nolint:gosec // TODO: fix later
-	if err := d.connection.WriteByteData(tsl2561CommandBit|tsl2561RegisterTiming, timeGainVal); err != nil {
+	if err := d.writeByteData(tsl2561CommandBit|tsl2561RegisterTiming, timeGainVal); err != nil {
 		return err
 	}
 	d.integrationTime = time
@@ -232,7 +232,7 @@ func (d *TSL2561Driver) SetGain(gain TSL2561Gain) error {
 	}
 
 	timeGainVal := uint8(d.integrationTime) | uint8(gain) //nolint:gosec // TODO: fix later
-	if err := d.connection.WriteByteData(tsl2561CommandBit|tsl2561RegisterTiming, timeGainVal); err != nil {
+	if err := d.writeByteData(tsl2561CommandBit|tsl2561RegisterTiming, timeGainVal); err != nil {
 		return err
 	}
 	d.gain = gain
@@ -346,11 +346,11 @@ func (d *TSL2561Driver) CalculateLux(broadband uint16, ir uint16) uint32 {
 }
 
 func (d *TSL2561Driver) enable() error {
-	return d.connection.WriteByteData(uint8(tsl2561CommandBit|tsl2561RegisterControl), tsl2561ControlPowerOn)
+	return d.writeByteData(uint8(tsl2561CommandBit|tsl2561RegisterControl), tsl2561ControlPowerOn)
 }
 
 func (d *TSL2561Driver) disable() error {
-	return d.connection.WriteByteData(uint8(tsl2561CommandBit|tsl2561RegisterControl), tsl2561ControlPowerOff)
+	return d.writeByteData(uint8(tsl2561CommandBit|tsl2561RegisterControl), tsl2561ControlPowerOff)
 }
 
 func (d *TSL2561Driver) getData() (uint16, uint16, error) {
@@ -361,13 +361,13 @@ func (d *TSL2561Driver) getData() (uint16, uint16, error) {
 	d.waitForADC()
 
 	// Reads a two byte value from channel 0 (visible + infrared)
-	broadband, err := d.connection.ReadWordData(tsl2561CommandBit | tsl2561WordBit | tsl2561RegisterChan0Low)
+	broadband, err := d.readWordData(tsl2561CommandBit | tsl2561WordBit | tsl2561RegisterChan0Low)
 	if err != nil {
 		return 0, 0, err
 	}
 
 	// Reads a two byte value from channel 1 (infrared)
-	ir, err := d.connection.ReadWordData(tsl2561CommandBit | tsl2561WordBit | tsl2561RegisterChan1Low)
+	ir, err := d.readWordData(tsl2561CommandBit | tsl2561WordBit | tsl2561RegisterChan1Low)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -456,7 +456,7 @@ func (d *TSL2561Driver) initialize() error {
 		return err
 	}
 
-	if initialized, err := d.connection.ReadByteData(tsl2561RegisterID); err != nil {
+	if initialized, err := d.readByteData(tsl2561RegisterID); err != nil {
 		return err
 	} else if (initialized & 0x0A) == 0 {
 		return fmt.Errorf("TSL2561 device not found (0x%X)", initialized)

--- a/drivers/i2c/tsl2561_driver_test.go
+++ b/drivers/i2c/tsl2561_driver_test.go
@@ -17,20 +17,23 @@ import (
 // and tests all implementations, so no further tests needed here for gobot.Driver interface
 var _ gobot.Driver = (*TSL2561Driver)(nil)
 
-func testIDReader(b []byte) (int, error) {
-	buf := new(bytes.Buffer)
-	// Mock device responding 0xA
-	_ = binary.Write(buf, binary.LittleEndian, uint8(0x0A))
-	copy(b, buf.Bytes())
-	return buf.Len(), nil
+func initTestTSL2561DriverStarted() (*TSL2561Driver, *i2cTestAdaptor) {
+	d, a := initTestTSL2561Driver()
+	if err := d.Start(); err != nil {
+		panic(err)
+	}
+	return d, a
 }
 
 func initTestTSL2561Driver() (*TSL2561Driver, *i2cTestAdaptor) {
 	a := newI2cTestAdaptor()
-	d := NewTSL2561Driver(a)
-	a.i2cReadImpl = testIDReader
-	if err := d.Start(); err != nil {
-		panic(err)
+	d := NewTSL2561Driver(a, WithTSL2561IntegrationTime13MS) // to reduce sleep time to minimum
+	a.i2cReadImpl = func(b []byte) (int, error) {
+		buf := new(bytes.Buffer)
+		// Mock device responding 0xA
+		_ = binary.Write(buf, binary.LittleEndian, uint8(0x0A))
+		copy(b, buf.Bytes())
+		return buf.Len(), nil
 	}
 	return d, a
 }
@@ -58,16 +61,14 @@ func TestTSL2561DriverOptions(t *testing.T) {
 }
 
 func TestTSL2561DriverStart(t *testing.T) {
-	a := newI2cTestAdaptor()
-	d := NewTSL2561Driver(a)
-	a.i2cReadImpl = testIDReader
-
+	// arrange
+	d, _ := initTestTSL2561Driver()
+	// act, assert
 	require.NoError(t, d.Start())
 }
 
 func TestTSL2561DriverStartNotFound(t *testing.T) {
-	a := newI2cTestAdaptor()
-	d := NewTSL2561Driver(a)
+	d, a := initTestTSL2561Driver()
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		buf := new(bytes.Buffer)
 		buf.Write([]byte{1})
@@ -78,25 +79,12 @@ func TestTSL2561DriverStartNotFound(t *testing.T) {
 }
 
 func TestTSL2561DriverHalt(t *testing.T) {
+	// arrange
 	d, _ := initTestTSL2561Driver()
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
 	require.NoError(t, d.Halt())
-}
-
-func TestTSL2561DriverRead16(t *testing.T) {
-	d, a := initTestTSL2561Driver()
-	a.i2cReadImpl = testIDReader
-	a.i2cReadImpl = func(b []byte) (int, error) {
-		buf := new(bytes.Buffer)
-		// send low
-		_ = binary.Write(buf, binary.LittleEndian, uint8(0xEA))
-		// send high
-		_ = binary.Write(buf, binary.LittleEndian, uint8(0xAE))
-		copy(b, buf.Bytes())
-		return buf.Len(), nil
-	}
-	val, err := d.connection.ReadWordData(1)
-	require.NoError(t, err)
-	assert.Equal(t, uint16(0xAEEA), val)
 }
 
 func TestTSL2561DriverValidOptions(t *testing.T) {
@@ -153,7 +141,7 @@ func TestTSL2561DriverYetEvenMoreOptions(t *testing.T) {
 }
 
 func TestTSL2561DriverGetDataWriteError(t *testing.T) {
-	d, a := initTestTSL2561Driver()
+	d, a := initTestTSL2561DriverStarted()
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
@@ -163,7 +151,7 @@ func TestTSL2561DriverGetDataWriteError(t *testing.T) {
 }
 
 func TestTSL2561DriverGetDataReadError(t *testing.T) {
-	d, a := initTestTSL2561Driver()
+	d, a := initTestTSL2561DriverStarted()
 	a.i2cReadImpl = func([]byte) (int, error) {
 		return 0, errors.New("read error")
 	}
@@ -173,7 +161,7 @@ func TestTSL2561DriverGetDataReadError(t *testing.T) {
 }
 
 func TestTSL2561DriverGetLuminocity(t *testing.T) {
-	d, a := initTestTSL2561Driver()
+	d, a := initTestTSL2561DriverStarted()
 	// TODO: obtain real sensor data here for testing
 	a.i2cReadImpl = func(b []byte) (int, error) {
 		buf := new(bytes.Buffer)
@@ -185,13 +173,14 @@ func TestTSL2561DriverGetLuminocity(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint16(12365), bb)
 	assert.Equal(t, uint16(12365), ir)
+	d.integrationTime = TSL2561IntegrationTime402MS
 	assert.Equal(t, uint32(72), d.CalculateLux(bb, ir))
 }
 
 func TestTSL2561DriverGetLuminocityAutoGain(t *testing.T) {
 	a := newI2cTestAdaptor()
 	d := NewTSL2561Driver(a,
-		WithTSL2561IntegrationTime402MS,
+		WithTSL2561IntegrationTime13MS, // to reduce sleep time to minimum
 		WithAddress(TSL2561AddressLow),
 		WithTSL2561AutoGain)
 	// TODO: obtain real sensor data here for testing
@@ -201,17 +190,17 @@ func TestTSL2561DriverGetLuminocityAutoGain(t *testing.T) {
 		copy(b, buf.Bytes())
 		return buf.Len(), nil
 	}
-
-	_ = d.Start()
+	_ = d.Start() // because we override start procedure
 	bb, ir, err := d.GetLuminocity()
 	require.NoError(t, err)
 	assert.Equal(t, uint16(12365), bb)
 	assert.Equal(t, uint16(12365), ir)
+	d.integrationTime = TSL2561IntegrationTime402MS
 	assert.Equal(t, uint32(72), d.CalculateLux(bb, ir))
 }
 
 func TestTSL2561SetIntegrationTimeError(t *testing.T) {
-	d, a := initTestTSL2561Driver()
+	d, a := initTestTSL2561DriverStarted()
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}
@@ -219,7 +208,7 @@ func TestTSL2561SetIntegrationTimeError(t *testing.T) {
 }
 
 func TestTSL2561SetGainError(t *testing.T) {
-	d, a := initTestTSL2561Driver()
+	d, a := initTestTSL2561DriverStarted()
 	a.i2cWriteImpl = func([]byte) (int, error) {
 		return 0, errors.New("write error")
 	}

--- a/drivers/i2c/wiichuck_driver.go
+++ b/drivers/i2c/wiichuck_driver.go
@@ -178,18 +178,18 @@ func (d *WiichuckDriver) initialize() error {
 				}
 				return
 			default:
-				if _, err := d.connection.Write([]byte{0x40, 0x00}); err != nil {
+				if _, err := d.write([]byte{0x40, 0x00}); err != nil {
 					d.Publish(d.Event(Error), err)
 					continue
 				}
 				time.Sleep(d.pauseTime)
-				if _, err := d.connection.Write([]byte{0x00}); err != nil {
+				if _, err := d.write([]byte{0x00}); err != nil {
 					d.Publish(d.Event(Error), err)
 					continue
 				}
 				time.Sleep(d.pauseTime)
 				newValue := make([]byte, 6)
-				bytesRead, err := d.connection.Read(newValue)
+				bytesRead, err := d.read(newValue)
 				if err != nil {
 					d.Publish(d.Event(Error), err)
 					continue

--- a/drivers/i2c/yl40_driver_test.go
+++ b/drivers/i2c/yl40_driver_test.go
@@ -17,7 +17,7 @@ func initTestYL40DriverWithStubbedAdaptor() (*YL40Driver, *i2cTestAdaptor) {
 	return yl, adaptor
 }
 
-func TestYL40Driver(t *testing.T) {
+func TestNewYL40Driver(t *testing.T) {
 	// arrange, act
 	yl := NewYL40Driver(newI2cTestAdaptor())
 	// assert
@@ -252,6 +252,8 @@ func TestYL40DriverStart(t *testing.T) {
 
 func TestYL40DriverHalt(t *testing.T) {
 	yl := NewYL40Driver(newI2cTestAdaptor())
+	require.NoError(t, yl.Halt()) // must be idempotent
+	require.NoError(t, yl.Start())
 	require.NoError(t, yl.Halt())
 }
 


### PR DESCRIPTION
## Solved issues and/or description of the change

see #1170 

The fix is done in a generic way by adding unexposed wrapper functions in "i2c_driver.go". Those functions check for connection is nil before calling the "connection.Func()". Additionally on "driver.Halt()" the connection is set to nil explicitly, so potential users of "d.beforeHalt" (normally functions are named "shutdown") can decide on this variable what to do.

## Manual test

none

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test_race`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code