### PR TITLE
spi(all): ensure halt is idempotent

### DIFF
--- a/drivers/spi/apa102.go
+++ b/drivers/spi/apa102.go
@@ -86,5 +86,5 @@ func (d *APA102Driver) Draw() error {
 		tx[i] = 0xff
 	}
 
-	return d.connection.WriteBytes(tx)
+	return d.writeBytes(tx)
 }

--- a/drivers/spi/apa102_test.go
+++ b/drivers/spi/apa102_test.go
@@ -34,6 +34,15 @@ func TestNewAPA102Driver(t *testing.T) {
 	assert.True(t, strings.HasPrefix(d.Name(), "APA102"))
 }
 
+func TestAPA102Halt(t *testing.T) {
+	// arrange
+	d := NewAPA102Driver(newSpiTestAdaptor(), 10, 31)
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestDriverLEDs(t *testing.T) {
 	d := initTestAPA102DriverWithStubbedAdaptor()
 

--- a/drivers/spi/mcp3002.go
+++ b/drivers/spi/mcp3002.go
@@ -48,7 +48,7 @@ func (d *MCP3002Driver) Read(channel int) (int, error) {
 
 	rx := make([]byte, 2)
 
-	if err := d.connection.ReadCommandData(tx, rx); err != nil {
+	if err := d.readCommandData(tx, rx); err != nil {
 		return 0, err
 	}
 

--- a/drivers/spi/mcp3002_test.go
+++ b/drivers/spi/mcp3002_test.go
@@ -38,6 +38,15 @@ func TestNewMCP3002Driver(t *testing.T) {
 	assert.True(t, strings.HasPrefix(d.Name(), "MCP3002"))
 }
 
+func TestMCP3002Halt(t *testing.T) {
+	// arrange
+	d := NewMCP3002Driver(newSpiTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestMCP3002Read(t *testing.T) {
 	tests := map[string]struct {
 		chanNum     int

--- a/drivers/spi/mcp3004.go
+++ b/drivers/spi/mcp3004.go
@@ -49,7 +49,7 @@ func (d *MCP3004Driver) Read(channel int) (int, error) {
 
 	rx := make([]byte, 3)
 
-	if err := d.connection.ReadCommandData(tx, rx); err != nil || len(rx) != 3 {
+	if err := d.readCommandData(tx, rx); err != nil || len(rx) != 3 {
 		return 0, err
 	}
 

--- a/drivers/spi/mcp3004_test.go
+++ b/drivers/spi/mcp3004_test.go
@@ -38,6 +38,15 @@ func TestNewMCP3004Driver(t *testing.T) {
 	assert.True(t, strings.HasPrefix(d.Name(), "MCP3004"))
 }
 
+func TestMCP3004Halt(t *testing.T) {
+	// arrange
+	d := NewMCP3004Driver(newSpiTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestMCP3004Read(t *testing.T) {
 	tests := map[string]struct {
 		chanNum     int

--- a/drivers/spi/mcp3008.go
+++ b/drivers/spi/mcp3008.go
@@ -49,7 +49,7 @@ func (d *MCP3008Driver) Read(channel int) (int, error) {
 
 	rx := make([]byte, 3)
 
-	if err := d.connection.ReadCommandData(tx, rx); err != nil || len(rx) != 3 {
+	if err := d.readCommandData(tx, rx); err != nil || len(rx) != 3 {
 		return 0, err
 	}
 

--- a/drivers/spi/mcp3008_test.go
+++ b/drivers/spi/mcp3008_test.go
@@ -38,6 +38,15 @@ func TestNewMCP3008Driver(t *testing.T) {
 	assert.True(t, strings.HasPrefix(d.Name(), "MCP3008"))
 }
 
+func TestMCP3008Halt(t *testing.T) {
+	// arrange
+	d := NewMCP3008Driver(newSpiTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestMCP3008Read(t *testing.T) {
 	tests := map[string]struct {
 		chanNum     int

--- a/drivers/spi/mcp3202.go
+++ b/drivers/spi/mcp3202.go
@@ -51,7 +51,7 @@ func (d *MCP3202Driver) Read(channel int) (int, error) {
 
 	rx := make([]byte, 3)
 
-	if err := d.connection.ReadCommandData(tx, rx); err != nil || len(rx) != 3 {
+	if err := d.readCommandData(tx, rx); err != nil || len(rx) != 3 {
 		return 0, err
 	}
 

--- a/drivers/spi/mcp3202_test.go
+++ b/drivers/spi/mcp3202_test.go
@@ -38,6 +38,15 @@ func TestNewMCP3202Driver(t *testing.T) {
 	assert.True(t, strings.HasPrefix(d.Name(), "MCP3202"))
 }
 
+func TestMCP3202Halt(t *testing.T) {
+	// arrange
+	d := NewMCP3202Driver(newSpiTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestMCP3202Read(t *testing.T) {
 	tests := map[string]struct {
 		chanNum     int

--- a/drivers/spi/mcp3204.go
+++ b/drivers/spi/mcp3204.go
@@ -51,7 +51,7 @@ func (d *MCP3204Driver) Read(channel int) (int, error) {
 
 	rx := make([]byte, 3)
 
-	if err := d.connection.ReadCommandData(tx, rx); err != nil || len(rx) != 3 {
+	if err := d.readCommandData(tx, rx); err != nil || len(rx) != 3 {
 		return 0, err
 	}
 

--- a/drivers/spi/mcp3204_test.go
+++ b/drivers/spi/mcp3204_test.go
@@ -38,6 +38,15 @@ func TestNewMCP3204Driver(t *testing.T) {
 	assert.True(t, strings.HasPrefix(d.Name(), "MCP3204"))
 }
 
+func TestMCP3204Halt(t *testing.T) {
+	// arrange
+	d := NewMCP3204Driver(newSpiTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestMCP3204Read(t *testing.T) {
 	tests := map[string]struct {
 		chanNum     int

--- a/drivers/spi/mcp3208.go
+++ b/drivers/spi/mcp3208.go
@@ -51,7 +51,7 @@ func (d *MCP3208Driver) Read(channel int) (int, error) {
 
 	rx := make([]byte, 3)
 
-	if err := d.connection.ReadCommandData(tx, rx); err != nil || len(rx) != 3 {
+	if err := d.readCommandData(tx, rx); err != nil || len(rx) != 3 {
 		return 0, err
 	}
 

--- a/drivers/spi/mcp3208_test.go
+++ b/drivers/spi/mcp3208_test.go
@@ -38,6 +38,15 @@ func TestNewMCP3208Driver(t *testing.T) {
 	assert.True(t, strings.HasPrefix(d.Name(), "MCP3208"))
 }
 
+func TestMCP3208Halt(t *testing.T) {
+	// arrange
+	d := NewMCP3208Driver(newSpiTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestMCP3208Read(t *testing.T) {
 	tests := map[string]struct {
 		chanNum     int

--- a/drivers/spi/mcp3304.go
+++ b/drivers/spi/mcp3304.go
@@ -51,7 +51,7 @@ func (d *MCP3304Driver) Read(channel int) (int, error) {
 
 	rx := make([]byte, 3)
 
-	if err := d.connection.ReadCommandData(tx, rx); err != nil || len(rx) != 3 {
+	if err := d.readCommandData(tx, rx); err != nil || len(rx) != 3 {
 		return 0, err
 	}
 

--- a/drivers/spi/mcp3304_test.go
+++ b/drivers/spi/mcp3304_test.go
@@ -38,6 +38,15 @@ func TestNewMCP3304Driver(t *testing.T) {
 	assert.True(t, strings.HasPrefix(d.Name(), "MCP3304"))
 }
 
+func TestMCP3304Halt(t *testing.T) {
+	// arrange
+	d := NewMCP3304Driver(newSpiTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestMCP3304Read(t *testing.T) {
 	tests := map[string]struct {
 		chanNum     int

--- a/drivers/spi/mfrc522_driver_test.go
+++ b/drivers/spi/mfrc522_driver_test.go
@@ -35,6 +35,15 @@ func TestNewMFRC522Driver(t *testing.T) {
 	assert.True(t, strings.HasPrefix(d.Name(), "MFRC522"))
 }
 
+func TestMFRC522Halt(t *testing.T) {
+	// arrange
+	d := NewMFRC522Driver(newSpiTestAdaptor())
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
+	require.NoError(t, d.Halt())
+}
+
 func TestMFRC522WriteByteData(t *testing.T) {
 	// arrange
 	d, a := initTestMFRC522DriverWithStubbedAdaptor()

--- a/drivers/spi/spi_connection.go
+++ b/drivers/spi/spi_connection.go
@@ -24,6 +24,14 @@ func NewConnection(spiSystem gobot.SpiSystemDevicer) *spiConnection {
 	return &spiConnection{spiSystem: spiSystem}
 }
 
+// Close connection to underlying SPI device.
+func (c *spiConnection) Close() error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	return c.spiSystem.Close()
+}
+
 // ReadCommandData uses the SPI device TX to send/receive data. Implements gobot.SpiOperations
 // On write command, the first byte normally contains the address and mode.
 // On read data, the return value is most likely one byte behind the command.
@@ -33,14 +41,6 @@ func (c *spiConnection) ReadCommandData(command []byte, data []byte) error {
 	defer c.mutex.Unlock()
 
 	return c.txRxAndCheckReadLength(command, data)
-}
-
-// Close connection to underlying SPI device.
-func (c *spiConnection) Close() error {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	return c.spiSystem.Close()
 }
 
 // ReadByteData reads a byte from the given register of SPI device. Implements gobot.BusOperations.

--- a/drivers/spi/spi_driver.go
+++ b/drivers/spi/spi_driver.go
@@ -1,6 +1,7 @@
 package spi
 
 import (
+	"fmt"
 	"log"
 	"sync"
 
@@ -103,13 +104,13 @@ func NewDriver(a Connector, name string, options ...func(Config)) *Driver {
 	return d
 }
 
-// Name returns the name of the device.
+// Name returns the name of the SPI device.
 func (d *Driver) Name() string { return d.name }
 
-// SetName sets the name of the device.
+// SetName sets the name of the SPI device.
 func (d *Driver) SetName(n string) { d.name = n }
 
-// Connection returns the Connection of the device.
+// Connection returns the gobot connection of the SPI device.
 func (d *Driver) Connection() gobot.Connection {
 	if conn, ok := d.connector.(gobot.Connection); ok {
 		return conn
@@ -147,7 +148,68 @@ func (d *Driver) Halt() error {
 		return err
 	}
 
+	d.connection = nil
+
 	// currently there is nothing to do here for the driver, the connection is cached on adaptor side
 	// and will be closed on adaptor Finalize()
 	return nil
+}
+
+func (d *Driver) readCommandData(command []byte, data []byte) error {
+	if d.connection == nil {
+		return fmt.Errorf("spi driver not started")
+	}
+
+	return d.connection.ReadCommandData(command, data)
+}
+
+//nolint:unused // ok for now
+func (d *Driver) readByteData(reg uint8) (uint8, error) {
+	if d.connection == nil {
+		return 0, fmt.Errorf("spi driver not started")
+	}
+
+	return d.connection.ReadByteData(reg)
+}
+
+//nolint:unused // ok for now
+func (d *Driver) readBlockData(reg uint8, data []byte) error {
+	if d.connection == nil {
+		return fmt.Errorf("spi driver not started")
+	}
+
+	return d.connection.ReadBlockData(reg, data)
+}
+
+func (d *Driver) writeByte(val byte) error {
+	if d.connection == nil {
+		return fmt.Errorf("spi driver not started")
+	}
+
+	return d.connection.WriteByte(val)
+}
+
+//nolint:unused // ok for now
+func (d *Driver) writeByteData(reg byte, data byte) error {
+	if d.connection == nil {
+		return fmt.Errorf("spi driver not started")
+	}
+
+	return d.connection.WriteByteData(reg, data)
+}
+
+func (d *Driver) writeBlockData(reg byte, data []byte) error {
+	if d.connection == nil {
+		return fmt.Errorf("spi driver not started")
+	}
+
+	return d.connection.WriteBlockData(reg, data)
+}
+
+func (d *Driver) writeBytes(data []byte) error {
+	if d.connection == nil {
+		return fmt.Errorf("spi driver not started")
+	}
+
+	return d.connection.WriteBytes(data)
 }

--- a/drivers/spi/spi_driver_test.go
+++ b/drivers/spi/spi_driver_test.go
@@ -36,7 +36,11 @@ func TestStart(t *testing.T) {
 }
 
 func TestHalt(t *testing.T) {
-	d, _ := initTestDriverWithStubbedAdaptor()
+	// arrange
+	d := NewDriver(newSpiTestAdaptor(), "SPI_BASIC")
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
 	require.NoError(t, d.Halt())
 }
 

--- a/drivers/spi/ssd1306_driver.go
+++ b/drivers/spi/ssd1306_driver.go
@@ -62,13 +62,13 @@ type DisplayBuffer struct {
 
 // NewDisplayBuffer creates a new DisplayBuffer
 func NewDisplayBuffer(width, height, pageSize int) *DisplayBuffer {
-	s := &DisplayBuffer{
+	d := &DisplayBuffer{
 		width:    width,
 		height:   height,
 		pageSize: pageSize,
 	}
-	s.buffer = make([]byte, s.Size())
-	return s
+	d.buffer = make([]byte, d.Size())
+	return d
 }
 
 // Size returns the memory size of the display buffer
@@ -136,7 +136,7 @@ func NewSSD1306Driver(a gobot.Adaptor, options ...func(Config)) *SSD1306Driver {
 	if !ok {
 		panic("unable to get gobot connector for ssd1306")
 	}
-	s := &SSD1306Driver{
+	d := &SSD1306Driver{
 		Driver:        NewDriver(b, "SSD1306"),
 		DisplayWidth:  ssd1306Width,
 		DisplayHeight: ssd1306Height,
@@ -144,47 +144,47 @@ func NewSSD1306Driver(a gobot.Adaptor, options ...func(Config)) *SSD1306Driver {
 		RSTPin:        ssd1306RstPin,
 		ExternalVcc:   ssd1306ExternalVcc,
 	}
-	s.afterStart = s.initialize
-	s.beforeHalt = s.shutdown
+	d.afterStart = d.initialize
+	d.beforeHalt = d.shutdown
 
 	for _, option := range options {
-		option(s)
+		option(d)
 	}
-	s.dcDriver = gpio.NewDirectPinDriver(a, s.DCPin)
-	s.rstDriver = gpio.NewDirectPinDriver(a, s.RSTPin)
-	s.pageSize = s.DisplayHeight / 8
-	s.buffer = NewDisplayBuffer(s.DisplayWidth, s.DisplayHeight, s.pageSize)
-	s.AddCommand("Display", func(_ map[string]interface{}) interface{} {
-		err := s.Display()
+	d.dcDriver = gpio.NewDirectPinDriver(a, d.DCPin)
+	d.rstDriver = gpio.NewDirectPinDriver(a, d.RSTPin)
+	d.pageSize = d.DisplayHeight / 8
+	d.buffer = NewDisplayBuffer(d.DisplayWidth, d.DisplayHeight, d.pageSize)
+	d.AddCommand("Display", func(_ map[string]interface{}) interface{} {
+		err := d.Display()
 		return map[string]interface{}{"err": err}
 	})
-	s.AddCommand("On", func(_ map[string]interface{}) interface{} {
-		err := s.On()
+	d.AddCommand("On", func(_ map[string]interface{}) interface{} {
+		err := d.On()
 		return map[string]interface{}{"err": err}
 	})
-	s.AddCommand("Off", func(_ map[string]interface{}) interface{} {
-		err := s.Off()
+	d.AddCommand("Off", func(_ map[string]interface{}) interface{} {
+		err := d.Off()
 		return map[string]interface{}{"err": err}
 	})
-	s.AddCommand("Clear", func(_ map[string]interface{}) interface{} {
-		err := s.Clear()
+	d.AddCommand("Clear", func(_ map[string]interface{}) interface{} {
+		err := d.Clear()
 		return map[string]interface{}{"err": err}
 	})
 	//nolint:forcetypeassert // ok here
-	s.AddCommand("SetContrast", func(params map[string]interface{}) interface{} {
+	d.AddCommand("SetContrast", func(params map[string]interface{}) interface{} {
 		contrast := params["contrast"].(byte)
-		err := s.SetContrast(contrast)
+		err := d.SetContrast(contrast)
 		return map[string]interface{}{"err": err}
 	})
 	//nolint:forcetypeassert // ok here
-	s.AddCommand("Set", func(params map[string]interface{}) interface{} {
+	d.AddCommand("Set", func(params map[string]interface{}) interface{} {
 		x := params["x"].(int)
 		y := params["y"].(int)
 		c := params["c"].(int)
-		s.Set(x, y, c)
+		d.Set(x, y, c)
 		return nil
 	})
-	return s
+	return d
 }
 
 // WithDisplayWidth option sets the SSD1306Driver DisplayWidth option.
@@ -248,238 +248,243 @@ func WithExternalVCC(val bool) func(Config) {
 }
 
 // On turns on the display.
-func (s *SSD1306Driver) On() error {
-	return s.command(ssd1306SetDisplayOn)
+func (d *SSD1306Driver) On() error {
+	return d.command(ssd1306SetDisplayOn)
 }
 
 // Off turns off the display.
-func (s *SSD1306Driver) Off() error {
-	return s.command(ssd1306SetDisplayOff)
+func (d *SSD1306Driver) Off() error {
+	return d.command(ssd1306SetDisplayOff)
 }
 
 // Clear clears the display buffer.
-func (s *SSD1306Driver) Clear() error {
-	s.buffer.Clear()
+func (d *SSD1306Driver) Clear() error {
+	d.buffer.Clear()
 	return nil
 }
 
 // Set sets a pixel in the display buffer.
-func (s *SSD1306Driver) Set(x, y, c int) {
-	s.buffer.SetPixel(x, y, c)
+func (d *SSD1306Driver) Set(x, y, c int) {
+	d.buffer.SetPixel(x, y, c)
 }
 
 // Reset re-initializes the device to a clean state.
-func (s *SSD1306Driver) Reset() error {
-	if err := s.rstDriver.DigitalWrite(1); err != nil {
+func (d *SSD1306Driver) Reset() error {
+	if err := d.rstDriver.DigitalWrite(1); err != nil {
 		return err
 	}
 	time.Sleep(10 * time.Millisecond)
-	if err := s.rstDriver.DigitalWrite(0); err != nil {
+	if err := d.rstDriver.DigitalWrite(0); err != nil {
 		return err
 	}
 	time.Sleep(10 * time.Millisecond)
-	if err := s.rstDriver.DigitalWrite(1); err != nil {
+	if err := d.rstDriver.DigitalWrite(1); err != nil {
 		return err
 	}
 	return nil
 }
 
 // SetBufferAndDisplay sets the display buffer with the given buffer and displays the image.
-func (s *SSD1306Driver) SetBufferAndDisplay(buf []byte) error {
-	s.buffer.Set(buf)
-	return s.Display()
+func (d *SSD1306Driver) SetBufferAndDisplay(buf []byte) error {
+	d.buffer.Set(buf)
+	return d.Display()
 }
 
 // SetContrast sets the display contrast (0-255).
-func (s *SSD1306Driver) SetContrast(contrast byte) error {
-	if err := s.command(ssd1306SetContrast); err != nil {
+func (d *SSD1306Driver) SetContrast(contrast byte) error {
+	if err := d.command(ssd1306SetContrast); err != nil {
 		return err
 	}
-	return s.command(contrast)
+	return d.command(contrast)
 }
 
 // Display sends the memory buffer to the display.
-func (s *SSD1306Driver) Display() error {
-	if err := s.command(ssd1306ColumnAddr); err != nil {
+func (d *SSD1306Driver) Display() error {
+	if err := d.command(ssd1306ColumnAddr); err != nil {
 		return err
 	}
-	if err := s.command(0); err != nil {
-		return err
-	}
-	//nolint:gosec // TODO: fix later
-	if err := s.command(uint8(s.DisplayWidth) - 1); err != nil {
-		return err
-	}
-	if err := s.command(ssd1306PageAddr); err != nil {
-		return err
-	}
-	if err := s.command(0); err != nil {
+	if err := d.command(0); err != nil {
 		return err
 	}
 	//nolint:gosec // TODO: fix later
-	if err := s.command(uint8(s.pageSize) - 1); err != nil {
+	if err := d.command(uint8(d.DisplayWidth) - 1); err != nil {
 		return err
 	}
-	if err := s.dcDriver.DigitalWrite(1); err != nil {
+	if err := d.command(ssd1306PageAddr); err != nil {
 		return err
 	}
-	return s.connection.WriteBlockData(0x40, s.buffer.buffer)
+	if err := d.command(0); err != nil {
+		return err
+	}
+	//nolint:gosec // TODO: fix later
+	if err := d.command(uint8(d.pageSize) - 1); err != nil {
+		return err
+	}
+	if err := d.dcDriver.DigitalWrite(1); err != nil {
+		return err
+	}
+	return d.writeBlockData(0x40, d.buffer.buffer)
 }
 
 // ShowImage takes a standard Go image and shows it on the display in monochrome.
-func (s *SSD1306Driver) ShowImage(img image.Image) error {
-	if img.Bounds().Dx() != s.DisplayWidth || img.Bounds().Dy() != s.DisplayHeight {
+func (d *SSD1306Driver) ShowImage(img image.Image) error {
+	if img.Bounds().Dx() != d.DisplayWidth || img.Bounds().Dy() != d.DisplayHeight {
 		return fmt.Errorf("image must match the display width and height")
 	}
 
-	if err := s.Clear(); err != nil {
+	if err := d.Clear(); err != nil {
 		return err
 	}
 	for y, w, h := 0, img.Bounds().Dx(), img.Bounds().Dy(); y < h; y++ {
 		for x := 0; x < w; x++ {
 			c := img.At(x, y)
 			if r, g, b, _ := c.RGBA(); r > 0 || g > 0 || b > 0 {
-				s.Set(x, y, 1)
+				d.Set(x, y, 1)
 			}
 		}
 	}
-	return s.Display()
+	return d.Display()
 }
 
 // command sends a unique command
-func (s *SSD1306Driver) command(b byte) error {
-	if err := s.dcDriver.DigitalWrite(0); err != nil {
+func (d *SSD1306Driver) command(b byte) error {
+	if err := d.dcDriver.DigitalWrite(0); err != nil {
 		return err
 	}
-	return s.connection.WriteByte(b)
+	return d.writeByte(b)
 }
 
 // initialize configures the ssd1306 based on the options passed in when the driver was created
-func (s *SSD1306Driver) initialize() error {
-	if err := s.command(ssd1306SetDisplayOff); err != nil {
+func (d *SSD1306Driver) initialize() error {
+	if err := d.command(ssd1306SetDisplayOff); err != nil {
 		return err
 	}
-	if err := s.command(ssd1306SetDisplayClock); err != nil {
+	if err := d.command(ssd1306SetDisplayClock); err != nil {
 		return err
 	}
-	if s.DisplayHeight == 16 {
-		if err := s.command(0x60); err != nil {
+	if d.DisplayHeight == 16 {
+		if err := d.command(0x60); err != nil {
 			return err
 		}
 	} else {
-		if err := s.command(0x80); err != nil {
+		if err := d.command(0x80); err != nil {
 			return err
 		}
 	}
-	if err := s.command(ssd1306SetMultiplexRatio); err != nil {
+	if err := d.command(ssd1306SetMultiplexRatio); err != nil {
 		return err
 	}
 	//nolint:gosec // TODO: fix later
-	if err := s.command(uint8(s.DisplayHeight) - 1); err != nil {
+	if err := d.command(uint8(d.DisplayHeight) - 1); err != nil {
 		return err
 	}
-	if err := s.command(ssd1306SetDisplayOffset); err != nil {
+	if err := d.command(ssd1306SetDisplayOffset); err != nil {
 		return err
 	}
-	if err := s.command(0x0); err != nil {
+	if err := d.command(0x0); err != nil {
 		return err
 	}
-	if err := s.command(ssd1306SetStartLine); err != nil {
+	if err := d.command(ssd1306SetStartLine); err != nil {
 		return err
 	}
-	if err := s.command(0x0); err != nil {
+	if err := d.command(0x0); err != nil {
 		return err
 	}
-	if err := s.command(ssd1306ChargePumpSetting); err != nil {
+	if err := d.command(ssd1306ChargePumpSetting); err != nil {
 		return err
 	}
-	if s.ExternalVcc {
-		if err := s.command(0x10); err != nil {
+	if d.ExternalVcc {
+		if err := d.command(0x10); err != nil {
 			return err
 		}
 	} else {
-		if err := s.command(0x14); err != nil {
+		if err := d.command(0x14); err != nil {
 			return err
 		}
 	}
-	if err := s.command(ssd1306SetMemoryAddressingMode); err != nil {
+	if err := d.command(ssd1306SetMemoryAddressingMode); err != nil {
 		return err
 	}
-	if err := s.command(0x00); err != nil {
+	if err := d.command(0x00); err != nil {
 		return err
 	}
-	if err := s.command(ssd1306SetSegmentRemap0); err != nil {
+	if err := d.command(ssd1306SetSegmentRemap0); err != nil {
 		return err
 	}
-	if err := s.command(0x01); err != nil {
+	if err := d.command(0x01); err != nil {
 		return err
 	}
-	if err := s.command(ssd1306ComScanInc); err != nil {
+	if err := d.command(ssd1306ComScanInc); err != nil {
 		return err
 	}
-	if err := s.command(ssd1306SetComPins); err != nil {
+	if err := d.command(ssd1306SetComPins); err != nil {
 		return err
 	}
-	if s.DisplayHeight == 64 {
-		if err := s.command(0x12); err != nil {
+	if d.DisplayHeight == 64 {
+		if err := d.command(0x12); err != nil {
 			return err
 		}
 	} else {
-		if err := s.command(0x02); err != nil {
+		if err := d.command(0x02); err != nil {
 			return err
 		}
 	}
-	if err := s.command(ssd1306SetContrast); err != nil {
+	if err := d.command(ssd1306SetContrast); err != nil {
 		return err
 	}
-	if s.DisplayHeight == 64 {
-		if s.ExternalVcc {
-			if err := s.command(0x9F); err != nil {
+	if d.DisplayHeight == 64 {
+		if d.ExternalVcc {
+			if err := d.command(0x9F); err != nil {
 				return err
 			}
 		} else {
-			if err := s.command(0xCF); err != nil {
+			if err := d.command(0xCF); err != nil {
 				return err
 			}
 		}
 	} else {
-		if err := s.command(0x8F); err != nil {
+		if err := d.command(0x8F); err != nil {
 			return err
 		}
 	}
-	if err := s.command(ssd1306SetPrechargePeriod); err != nil {
+	if err := d.command(ssd1306SetPrechargePeriod); err != nil {
 		return err
 	}
-	if s.ExternalVcc {
-		if err := s.command(0x22); err != nil {
+	if d.ExternalVcc {
+		if err := d.command(0x22); err != nil {
 			return err
 		}
 	} else {
-		if err := s.command(0xF1); err != nil {
+		if err := d.command(0xF1); err != nil {
 			return err
 		}
 	}
-	if err := s.command(ssd1306SetVComDeselectLevel); err != nil {
+	if err := d.command(ssd1306SetVComDeselectLevel); err != nil {
 		return err
 	}
-	if err := s.command(0x40); err != nil {
+	if err := d.command(0x40); err != nil {
 		return err
 	}
-	if err := s.command(ssd1306DisplayOnResumeToRAM); err != nil {
+	if err := d.command(ssd1306DisplayOnResumeToRAM); err != nil {
 		return err
 	}
-	if err := s.command(ssd1306SetDisplayNormal); err != nil {
+	if err := d.command(ssd1306SetDisplayNormal); err != nil {
 		return err
 	}
-	if err := s.command(ssd1306DeactivateScroll); err != nil {
+	if err := d.command(ssd1306DeactivateScroll); err != nil {
 		return err
 	}
-	return s.command(ssd1306SetDisplayOn)
+	return d.command(ssd1306SetDisplayOn)
 }
 
-func (s *SSD1306Driver) shutdown() error {
-	if err := s.Reset(); err != nil {
+func (d *SSD1306Driver) shutdown() error {
+	if d.connection == nil {
+		// not started yet
+		return nil
+	}
+
+	if err := d.Reset(); err != nil {
 		return err
 	}
-	return s.Off()
+	return d.Off()
 }

--- a/drivers/spi/ssd1306_driver_test.go
+++ b/drivers/spi/ssd1306_driver_test.go
@@ -24,8 +24,11 @@ func TestDriverSSDStart(t *testing.T) {
 }
 
 func TestDriverSSDHalt(t *testing.T) {
+	// arrange
 	d := initTestSSDDriver()
-	_ = d.Start()
+	// act, assert
+	require.NoError(t, d.Halt()) // must be idempotent
+	require.NoError(t, d.Start())
 	require.NoError(t, d.Halt())
 }
 


### PR DESCRIPTION
## Solved issues and/or description of the change

see #1170 

The fix is done in a generic way by adding unexposed wrapper functions in "spi_driver.go". Those functions check for connection is nil before calling the "connection.Func()". Additionally on "driver.Halt()" the connection is set to nil explicitly, so potential users of "d.beforeHalt" (normally functions are named "shutdown") can decide on this variable what to do.

## Manual test

none

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test_race`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code