### PR TITLE
i2c(bme280): fix default name

### DIFF
--- a/drivers/i2c/bme280_driver.go
+++ b/drivers/i2c/bme280_driver.go
@@ -5,6 +5,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"log"
+
+	"gobot.io/x/gobot/v2"
 )
 
 const bme280Debug = true
@@ -63,6 +65,7 @@ func NewBME280Driver(c Connector, options ...func(Config)) *BME280Driver {
 		humCalCoeffs:    &bmeHumidityCalibrationCoefficients{},
 		ctrlHumOversamp: BME280CtrlHumidityOversampling16,
 	}
+	d.name = gobot.DefaultName("BME280")
 	d.afterStart = d.initializationBME280
 
 	// this loop is for options of this class, all options of base class BMP280Driver

--- a/drivers/i2c/bme280_driver_test.go
+++ b/drivers/i2c/bme280_driver_test.go
@@ -28,7 +28,7 @@ func TestNewBME280Driver(t *testing.T) {
 		require.Fail(t, "NewBME280Driver() should have returned a *BME280Driver")
 	}
 	assert.NotNil(t, d.Driver)
-	assert.True(t, strings.HasPrefix(d.Name(), "BMP280"))
+	assert.True(t, strings.HasPrefix(d.Name(), "BME280"))
 	assert.Equal(t, 0x77, d.defaultAddress)
 	assert.Equal(t, uint8(0x03), d.ctrlPwrMode)
 	assert.Equal(t, BMP280PressureOversampling(0x05), d.ctrlPressOversamp)


### PR DESCRIPTION
## Solved issues and/or description of the change

The default name of BM280 was BMP280.

## Manual test

none

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test_race`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code