### PR TITLE
drivers: fix nil connector check

### DIFF
--- a/drivers/aio/aio_driver.go
+++ b/drivers/aio/aio_driver.go
@@ -84,8 +84,13 @@ func (d *driver) SetName(name string) {
 	WithName(name).apply(d.driverCfg)
 }
 
-// Connection returns the connection of the driver.
+// Connection returns the gobot connection of the driver.
 func (d *driver) Connection() gobot.Connection {
+	if d.connection == nil {
+		log.Printf("%s has no connection\n", d.driverCfg.name)
+		return nil
+	}
+
 	if conn, ok := d.connection.(gobot.Connection); ok {
 		return conn
 	}

--- a/drivers/ble/ble_driver.go
+++ b/drivers/ble/ble_driver.go
@@ -77,8 +77,13 @@ func (d *Driver) SetName(name string) {
 	WithName(name).apply(d.driverCfg)
 }
 
-// Connection returns the connection of the driver.
+// Connection returns the gobot connection of the driver.
 func (d *Driver) Connection() gobot.Connection {
+	if d.connection == nil {
+		log.Printf("%s has no connection\n", d.driverCfg.name)
+		return nil
+	}
+
 	if conn, ok := d.connection.(gobot.Connection); ok {
 		return conn
 	}
@@ -109,6 +114,11 @@ func (d *Driver) Halt() error {
 
 // Adaptor returns the BLE adaptor
 func (d *Driver) Adaptor() gobot.BLEConnector {
+	if d.connection == nil {
+		log.Printf("%s has no connection\n", d.driverCfg.name)
+		return nil
+	}
+
 	if a, ok := d.connection.(gobot.BLEConnector); ok {
 		return a
 	}

--- a/drivers/gpio/gpio_driver.go
+++ b/drivers/gpio/gpio_driver.go
@@ -140,8 +140,13 @@ func (d *driver) Pin() string {
 	return d.driverCfg.pin
 }
 
-// Connection returns the connection of the gpio device.
+// Connection returns the gobot connection of the gpio device.
 func (d *driver) Connection() gobot.Connection {
+	if d.connection == nil {
+		log.Printf("%s has no connection\n", d.driverCfg.name)
+		return nil
+	}
+
 	if conn, ok := d.connection.(gobot.Connection); ok {
 		return conn
 	}
@@ -172,6 +177,10 @@ func (d *driver) Halt() error {
 
 // digitalRead is a helper function with check that the connection implements DigitalReader
 func (d *driver) digitalRead(pin string) (int, error) {
+	if d.connection == nil {
+		return 0, fmt.Errorf("%s has no connection", d.driverCfg.name)
+	}
+
 	if reader, ok := d.connection.(DigitalReader); ok {
 		return reader.DigitalRead(pin)
 	}
@@ -181,6 +190,10 @@ func (d *driver) digitalRead(pin string) (int, error) {
 
 // digitalWrite is a helper function with check that the connection implements DigitalWriter
 func (d *driver) digitalWrite(pin string, val byte) error {
+	if d.connection == nil {
+		return fmt.Errorf("%s has no connection", d.driverCfg.name)
+	}
+
 	if writer, ok := d.connection.(DigitalWriter); ok {
 		return writer.DigitalWrite(pin, val)
 	}
@@ -190,6 +203,10 @@ func (d *driver) digitalWrite(pin string, val byte) error {
 
 // pwmWrite is a helper function with check that the connection implements PwmWriter
 func (d *driver) pwmWrite(pin string, level byte) error {
+	if d.connection == nil {
+		return fmt.Errorf("%s has no connection", d.driverCfg.name)
+	}
+
 	if writer, ok := d.connection.(PwmWriter); ok {
 		return writer.PwmWrite(pin, level)
 	}
@@ -199,6 +216,10 @@ func (d *driver) pwmWrite(pin string, level byte) error {
 
 // servoWrite is a helper function with check that the connection implements ServoWriter
 func (d *driver) servoWrite(pin string, level byte) error {
+	if d.connection == nil {
+		return fmt.Errorf("%s has no connection", d.driverCfg.name)
+	}
+
 	if writer, ok := d.connection.(ServoWriter); ok {
 		return writer.ServoWrite(pin, level)
 	}

--- a/drivers/i2c/i2c_driver.go
+++ b/drivers/i2c/i2c_driver.go
@@ -83,6 +83,11 @@ func (d *Driver) SetName(name string) {
 
 // Connection returns the gobot connection of the i2c device.
 func (d *Driver) Connection() gobot.Connection {
+	if d.connector == nil {
+		log.Printf("%s has no connector\n", d.name)
+		return nil
+	}
+
 	if conn, ok := d.connector.(gobot.Connection); ok {
 		return conn
 	}
@@ -95,6 +100,10 @@ func (d *Driver) Connection() gobot.Connection {
 func (d *Driver) Start() error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
+
+	if d.connector == nil {
+		return fmt.Errorf("%s has no connector", d.name)
+	}
 
 	var err error
 	bus := d.GetBusOrDefault(d.connector.DefaultI2cBus())
@@ -127,7 +136,7 @@ func (d *Driver) Write(pin string, val int) error {
 	defer d.mutex.Unlock()
 
 	if d.connection == nil {
-		return fmt.Errorf("i2c driver not started")
+		return fmt.Errorf("i2c driver not started for '%s'", d.name)
 	}
 
 	register, err := driverParseRegister(pin)
@@ -152,7 +161,7 @@ func (d *Driver) Read(pin string) (int, error) {
 	defer d.mutex.Unlock()
 
 	if d.connection == nil {
-		return 0, fmt.Errorf("i2c driver not started")
+		return 0, fmt.Errorf("i2c driver not started for '%s'", d.name)
 	}
 
 	register, err := driverParseRegister(pin)
@@ -170,7 +179,7 @@ func (d *Driver) Read(pin string) (int, error) {
 
 func (d *Driver) write(data []byte) (int, error) {
 	if d.connection == nil {
-		return 0, fmt.Errorf("i2c driver not started")
+		return 0, fmt.Errorf("i2c driver not started for '%s'", d.name)
 	}
 
 	return d.connection.Write(data)
@@ -178,7 +187,7 @@ func (d *Driver) write(data []byte) (int, error) {
 
 func (d *Driver) writeByte(val byte) error {
 	if d.connection == nil {
-		return fmt.Errorf("i2c driver not started")
+		return fmt.Errorf("i2c driver not started for '%s'", d.name)
 	}
 
 	return d.connection.WriteByte(val)
@@ -186,7 +195,7 @@ func (d *Driver) writeByte(val byte) error {
 
 func (d *Driver) writeByteData(reg uint8, val byte) error {
 	if d.connection == nil {
-		return fmt.Errorf("i2c driver not started")
+		return fmt.Errorf("i2c driver not started for '%s'", d.name)
 	}
 
 	return d.connection.WriteByteData(reg, val)
@@ -194,7 +203,7 @@ func (d *Driver) writeByteData(reg uint8, val byte) error {
 
 func (d *Driver) writeWordData(reg uint8, val uint16) error {
 	if d.connection == nil {
-		return fmt.Errorf("i2c driver not started")
+		return fmt.Errorf("i2c driver not started for '%s'", d.name)
 	}
 
 	return d.connection.WriteWordData(reg, val)
@@ -202,7 +211,7 @@ func (d *Driver) writeWordData(reg uint8, val uint16) error {
 
 func (d *Driver) writeBlockData(reg uint8, data []byte) error {
 	if d.connection == nil {
-		return fmt.Errorf("i2c driver not started")
+		return fmt.Errorf("i2c driver not started for '%s'", d.name)
 	}
 
 	return d.connection.WriteBlockData(reg, data)
@@ -210,7 +219,7 @@ func (d *Driver) writeBlockData(reg uint8, data []byte) error {
 
 func (d *Driver) read(data []byte) (int, error) {
 	if d.connection == nil {
-		return 0, fmt.Errorf("i2c driver not started")
+		return 0, fmt.Errorf("i2c driver not started for '%s'", d.name)
 	}
 
 	return d.connection.Read(data)
@@ -218,7 +227,7 @@ func (d *Driver) read(data []byte) (int, error) {
 
 func (d *Driver) readByte() (byte, error) {
 	if d.connection == nil {
-		return 0, fmt.Errorf("i2c driver not started")
+		return 0, fmt.Errorf("i2c driver not started for '%s'", d.name)
 	}
 
 	return d.connection.ReadByte()
@@ -226,7 +235,7 @@ func (d *Driver) readByte() (byte, error) {
 
 func (d *Driver) readByteData(reg uint8) (byte, error) {
 	if d.connection == nil {
-		return 0, fmt.Errorf("i2c driver not started")
+		return 0, fmt.Errorf("i2c driver not started for '%s'", d.name)
 	}
 
 	return d.connection.ReadByteData(reg)
@@ -234,7 +243,7 @@ func (d *Driver) readByteData(reg uint8) (byte, error) {
 
 func (d *Driver) readWordData(reg uint8) (uint16, error) {
 	if d.connection == nil {
-		return 0, fmt.Errorf("i2c driver not started")
+		return 0, fmt.Errorf("i2c driver not started for '%s'", d.name)
 	}
 
 	return d.connection.ReadWordData(reg)
@@ -242,7 +251,7 @@ func (d *Driver) readWordData(reg uint8) (uint16, error) {
 
 func (d *Driver) readBlockData(reg uint8, data []byte) error {
 	if d.connection == nil {
-		return fmt.Errorf("i2c driver not started")
+		return fmt.Errorf("i2c driver not started for '%s'", d.name)
 	}
 
 	return d.connection.ReadBlockData(reg, data)

--- a/drivers/i2c/jhd1313m1_driver.go
+++ b/drivers/i2c/jhd1313m1_driver.go
@@ -147,8 +147,13 @@ func (d *JHD1313M1Driver) Name() string { return d.name }
 // SetName sets the name for the JHD1313M1 Driver.
 func (d *JHD1313M1Driver) SetName(n string) { d.name = n }
 
-// Connection returns the driver connection to the device.
+// Connection returns the gobot connection to the device.
 func (d *JHD1313M1Driver) Connection() gobot.Connection {
+	if d.connector == nil {
+		log.Printf("%s has no connector\n", d.name)
+		return nil
+	}
+
 	if conn, ok := d.connector.(gobot.Connection); ok {
 		return conn
 	}
@@ -159,6 +164,10 @@ func (d *JHD1313M1Driver) Connection() gobot.Connection {
 
 // Start starts the backlit and the screen and initializes the states.
 func (d *JHD1313M1Driver) Start() error {
+	if d.connector == nil {
+		return fmt.Errorf("%s has no connector", d.name)
+	}
+
 	bus := d.GetBusOrDefault(d.connector.DefaultI2cBus())
 
 	var err error

--- a/drivers/onewire/onewire_driver.go
+++ b/drivers/onewire/onewire_driver.go
@@ -90,7 +90,8 @@ func (d *driver) SetName(name string) {
 // Connection returns the gobot connection of the device.
 func (d *driver) Connection() gobot.Connection {
 	if d.connection == nil {
-		log.Printf("1-wire driver not started for %s\n", d.driverCfg.name)
+		log.Printf("1-wire driver not started for '%s'\n", d.driverCfg.name)
+		return nil
 	}
 
 	if conn, ok := d.connection.(gobot.Connection); ok {
@@ -105,6 +106,10 @@ func (d *driver) Connection() gobot.Connection {
 func (d *driver) Start() error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
+
+	if d.connector == nil {
+		return fmt.Errorf("%s has no connector", d.driverCfg.name)
+	}
 
 	var err error
 	d.connection, err = d.connector.GetOneWireConnection(d.driverCfg.familyCode, d.driverCfg.serialNumber)
@@ -132,7 +137,7 @@ func (d *driver) Halt() error {
 
 func (d *driver) id() (string, error) {
 	if d.connection == nil {
-		return "", fmt.Errorf("1-wire driver not started for %s", d.driverCfg.name)
+		return "", fmt.Errorf("1-wire driver not started for '%s'", d.driverCfg.name)
 	}
 
 	return d.connection.ID(), nil
@@ -141,7 +146,7 @@ func (d *driver) id() (string, error) {
 //nolint:unused // ok for now
 func (d *driver) readData(command string, data []byte) error {
 	if d.connection == nil {
-		return fmt.Errorf("1-wire driver not started for %s", d.driverCfg.name)
+		return fmt.Errorf("1-wire driver not started for '%s'", d.driverCfg.name)
 	}
 	return d.connection.ReadData(command, data)
 }
@@ -149,21 +154,21 @@ func (d *driver) readData(command string, data []byte) error {
 //nolint:unused // ok for now
 func (d *driver) writeData(command string, data []byte) error {
 	if d.connection == nil {
-		return fmt.Errorf("1-wire driver not started for %s", d.driverCfg.name)
+		return fmt.Errorf("1-wire driver not started for '%s'", d.driverCfg.name)
 	}
 	return d.connection.WriteData(command, data)
 }
 
 func (d *driver) readInteger(command string) (int, error) {
 	if d.connection == nil {
-		return 0, fmt.Errorf("1-wire driver not started for %s", d.driverCfg.name)
+		return 0, fmt.Errorf("1-wire driver not started for '%s'", d.driverCfg.name)
 	}
 	return d.connection.ReadInteger(command)
 }
 
 func (d *driver) writeInteger(command string, val int) error {
 	if d.connection == nil {
-		return fmt.Errorf("1-wire driver not started for %s", d.driverCfg.name)
+		return fmt.Errorf("1-wire driver not started for '%s'", d.driverCfg.name)
 	}
 	return d.connection.WriteInteger(command, val)
 }

--- a/drivers/serial/serial_driver.go
+++ b/drivers/serial/serial_driver.go
@@ -83,8 +83,13 @@ func (d *Driver) SetName(name string) {
 	WithName(name).apply(d.driverCfg)
 }
 
-// Connection returns the connection of the driver.
+// Connection returns the gobot connection of the driver.
 func (d *Driver) Connection() gobot.Connection {
+	if d.connection == nil {
+		log.Printf("%s has no connection\n", d.driverCfg.name)
+		return nil
+	}
+
 	if conn, ok := d.connection.(gobot.Connection); ok {
 		return conn
 	}

--- a/drivers/spi/spi_driver.go
+++ b/drivers/spi/spi_driver.go
@@ -112,6 +112,11 @@ func (d *Driver) SetName(n string) { d.name = n }
 
 // Connection returns the gobot connection of the SPI device.
 func (d *Driver) Connection() gobot.Connection {
+	if d.connector == nil {
+		log.Printf("%s has no connector\n", d.name)
+		return nil
+	}
+
 	if conn, ok := d.connector.(gobot.Connection); ok {
 		return conn
 	}
@@ -124,6 +129,10 @@ func (d *Driver) Connection() gobot.Connection {
 func (d *Driver) Start() error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
+
+	if d.connector == nil {
+		return fmt.Errorf("%s has no connector", d.name)
+	}
 
 	bus := d.GetBusNumberOrDefault(d.connector.SpiDefaultBusNumber())
 	chip := d.GetChipNumberOrDefault(d.connector.SpiDefaultChipNumber())
@@ -157,7 +166,7 @@ func (d *Driver) Halt() error {
 
 func (d *Driver) readCommandData(command []byte, data []byte) error {
 	if d.connection == nil {
-		return fmt.Errorf("spi driver not started")
+		return fmt.Errorf("spi driver not started for '%s'", d.name)
 	}
 
 	return d.connection.ReadCommandData(command, data)
@@ -166,7 +175,7 @@ func (d *Driver) readCommandData(command []byte, data []byte) error {
 //nolint:unused // ok for now
 func (d *Driver) readByteData(reg uint8) (uint8, error) {
 	if d.connection == nil {
-		return 0, fmt.Errorf("spi driver not started")
+		return 0, fmt.Errorf("spi driver not started for '%s'", d.name)
 	}
 
 	return d.connection.ReadByteData(reg)
@@ -175,7 +184,7 @@ func (d *Driver) readByteData(reg uint8) (uint8, error) {
 //nolint:unused // ok for now
 func (d *Driver) readBlockData(reg uint8, data []byte) error {
 	if d.connection == nil {
-		return fmt.Errorf("spi driver not started")
+		return fmt.Errorf("spi driver not started for '%s'", d.name)
 	}
 
 	return d.connection.ReadBlockData(reg, data)
@@ -183,7 +192,7 @@ func (d *Driver) readBlockData(reg uint8, data []byte) error {
 
 func (d *Driver) writeByte(val byte) error {
 	if d.connection == nil {
-		return fmt.Errorf("spi driver not started")
+		return fmt.Errorf("spi driver not started for '%s'", d.name)
 	}
 
 	return d.connection.WriteByte(val)
@@ -192,7 +201,7 @@ func (d *Driver) writeByte(val byte) error {
 //nolint:unused // ok for now
 func (d *Driver) writeByteData(reg byte, data byte) error {
 	if d.connection == nil {
-		return fmt.Errorf("spi driver not started")
+		return fmt.Errorf("spi driver not started for '%s'", d.name)
 	}
 
 	return d.connection.WriteByteData(reg, data)
@@ -200,7 +209,7 @@ func (d *Driver) writeByteData(reg byte, data byte) error {
 
 func (d *Driver) writeBlockData(reg byte, data []byte) error {
 	if d.connection == nil {
-		return fmt.Errorf("spi driver not started")
+		return fmt.Errorf("spi driver not started for '%s'", d.name)
 	}
 
 	return d.connection.WriteBlockData(reg, data)
@@ -208,7 +217,7 @@ func (d *Driver) writeBlockData(reg byte, data []byte) error {
 
 func (d *Driver) writeBytes(data []byte) error {
 	if d.connection == nil {
-		return fmt.Errorf("spi driver not started")
+		return fmt.Errorf("spi driver not started for '%s'", d.name)
 	}
 
 	return d.connection.WriteBytes(data)


### PR DESCRIPTION
## Solved issues and/or description of the change

There is no check at an point that connectors/adaptors are not given or becomes nil. This is fixed now.

## Manual test

none

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test_race`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code