### PR TITLE
common: fix hang on robot stop when error on start, improve robot level errors

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1,6 +1,7 @@
 package gobot
 
 import (
+	"fmt"
 	"log"
 	"reflect"
 
@@ -41,7 +42,7 @@ func (c *Connections) Each(f func(Connection)) {
 
 // Start calls Connect on each Connection in c
 func (c *Connections) Start() error {
-	log.Println("Starting connections...")
+	log.Printf("Starting %d connections...", len(*c))
 	var err error
 	for _, connection := range *c {
 		info := "Starting connection " + connection.Name()
@@ -53,7 +54,7 @@ func (c *Connections) Start() error {
 		log.Println(info + "...")
 
 		if cerr := connection.Connect(); cerr != nil {
-			err = multierror.Append(err, cerr)
+			err = multierror.Append(err, fmt.Errorf("'%s' connect error: %w", connection.Name(), cerr))
 		}
 	}
 	return err
@@ -61,10 +62,11 @@ func (c *Connections) Start() error {
 
 // Finalize calls Finalize on each Connection in c
 func (c *Connections) Finalize() error {
+	log.Printf("Finalize %d connections...", len(*c))
 	var err error
 	for _, connection := range *c {
 		if cerr := connection.Finalize(); cerr != nil {
-			err = multierror.Append(err, cerr)
+			err = multierror.Append(err, fmt.Errorf("'%s' finalize error: %w", connection.Name(), cerr))
 		}
 	}
 	return err

--- a/device.go
+++ b/device.go
@@ -1,6 +1,7 @@
 package gobot
 
 import (
+	"fmt"
 	"log"
 	"reflect"
 
@@ -54,7 +55,7 @@ func (d *Devices) Each(f func(Device)) {
 
 // Start calls Start on each Device in d
 func (d *Devices) Start() error {
-	log.Println("Starting devices...")
+	log.Printf("Starting %d devices...", d.Len())
 	var err error
 	for _, device := range *d {
 		info := "Starting device " + device.Name()
@@ -65,7 +66,7 @@ func (d *Devices) Start() error {
 
 		log.Println(info + "...")
 		if derr := device.Start(); derr != nil {
-			err = multierror.Append(err, derr)
+			err = multierror.Append(err, fmt.Errorf("'%s' start error: %w", device.Name(), derr))
 		}
 	}
 	return err
@@ -73,10 +74,11 @@ func (d *Devices) Start() error {
 
 // Halt calls Halt on each Device in d
 func (d *Devices) Halt() error {
+	log.Printf("Halt %d devices...", d.Len())
 	var err error
 	for _, device := range *d {
 		if derr := device.Halt(); derr != nil {
-			err = multierror.Append(err, derr)
+			err = multierror.Append(err, fmt.Errorf("'%s' halt error: %w", device.Name(), derr))
 		}
 	}
 	return err

--- a/manager_test.go
+++ b/manager_test.go
@@ -88,64 +88,91 @@ func TestManagerStartAutoRun(t *testing.T) {
 }
 
 func TestManagerStartDriverErrors(t *testing.T) {
+	// arrange
 	g := initTestManager1Robot()
-	e := errors.New("driver start error 1")
-	testDriverStart = func() error {
-		return e
+	var ec int
+	es := [4]error{
+		nil,
+		errors.New("driver start error 1"),
+		errors.New("driver start error 2"),
+		errors.New("driver start error 3"),
 	}
+	testDriverStart = func() error {
+		ec++
+		return es[ec]
+	}
+	defer func() { testDriverStart = func() error { return nil } }()
 
 	var want error
-	want = multierror.Append(want, e)
-	want = multierror.Append(want, e)
-	want = multierror.Append(want, e)
+	want = multierror.Append(want, fmt.Errorf("'Device1' start error: %w", es[1]))
+	want = multierror.Append(want, fmt.Errorf("'Device2' start error: %w", es[2]))
+	want = multierror.Append(want, fmt.Errorf("'' start error: %w", es[3]))
 
+	// act & assert
 	assert.Equal(t, want, g.Start())
 	require.NoError(t, g.Stop())
-
-	testDriverStart = func() error { return nil }
 }
 
 func TestManagerHaltFromRobotDriverErrors(t *testing.T) {
+	// arrange
 	g := initTestManager1Robot()
+	es := [4]error{
+		nil,
+		errors.New("driver halt error 1"),
+		errors.New("driver halt error 2"),
+		errors.New("driver halt error 3"),
+	}
 	var ec int
 	testDriverHalt = func() error {
 		ec++
-		return fmt.Errorf("driver halt error %d", ec)
+		return es[ec]
 	}
 	defer func() { testDriverHalt = func() error { return nil } }()
 
 	var want error
-	for i := 1; i <= 3; i++ {
-		e := fmt.Errorf("driver halt error %d", i)
-		want = multierror.Append(want, e)
-	}
+	want = multierror.Append(want, fmt.Errorf("'Device1' halt error: %w", es[1]))
+	want = multierror.Append(want, fmt.Errorf("'Device2' halt error: %w", es[2]))
+	want = multierror.Append(want, fmt.Errorf("'' halt error: %w", es[3]))
 
+	// act & assert
 	assert.Equal(t, want, g.Start())
 }
 
 func TestManagerStartRobotAdaptorErrors(t *testing.T) {
+	// arrange
 	g := initTestManager1Robot()
+	es := [4]error{
+		nil,
+		errors.New("adaptor start error 1"),
+		errors.New("adaptor start error 2"),
+		errors.New("adaptor start error 3"),
+	}
 	var ec int
 	testAdaptorConnect = func() error {
 		ec++
-		return fmt.Errorf("adaptor start error %d", ec)
+		return es[ec]
 	}
 	defer func() { testAdaptorConnect = func() error { return nil } }()
 
 	var want error
-	for i := 1; i <= 3; i++ {
-		e := fmt.Errorf("adaptor start error %d", i)
-		want = multierror.Append(want, e)
-	}
+	want = multierror.Append(want, fmt.Errorf("'Connection1' connect error: %w", es[1]))
+	want = multierror.Append(want, fmt.Errorf("'Connection2' connect error: %w", es[2]))
+	want = multierror.Append(want, fmt.Errorf("'' connect error: %w", es[3]))
 
+	// act & assert
 	assert.Equal(t, want, g.Start())
 	require.NoError(t, g.Stop())
-
-	testAdaptorConnect = func() error { return nil }
 }
 
 func TestManagerFinalizeErrors(t *testing.T) {
+	// arrange
 	g := initTestManager1Robot()
+	es := [4]error{
+		nil,
+		errors.New("adaptor finalize error 1"),
+		errors.New("adaptor finalize error 2"),
+		errors.New("adaptor finalize error 3"),
+	}
 	var ec int
 	testAdaptorFinalize = func() error {
 		ec++
@@ -154,10 +181,10 @@ func TestManagerFinalizeErrors(t *testing.T) {
 	defer func() { testAdaptorFinalize = func() error { return nil } }()
 
 	var want error
-	for i := 1; i <= 3; i++ {
-		e := fmt.Errorf("adaptor finalize error %d", i)
-		want = multierror.Append(want, e)
-	}
+	want = multierror.Append(want, fmt.Errorf("'Connection1' finalize error: %w", es[1]))
+	want = multierror.Append(want, fmt.Errorf("'Connection2' finalize error: %w", es[2]))
+	want = multierror.Append(want, fmt.Errorf("'' finalize error: %w", es[3]))
 
+	// act & assert
 	assert.Equal(t, want, g.Start())
 }

--- a/robot.go
+++ b/robot.go
@@ -218,6 +218,11 @@ func (r *Robot) Stop() error {
 		err = multierror.Append(err, e)
 	}
 
+	if !r.Running() {
+		// start was not successful, a full channel would block
+		return err
+	}
+
 	r.done <- true
 	r.running.Store(false)
 	return err


### PR DESCRIPTION
## Solved issues and/or description of the change

If the robot was not started successfully, there is no preparation for work or os signal. This can lead to a hang on robot-stop, because the channel is full.

Additionally added more descriptive information to the errors on Start/Halt/Finalize.

## Manual test

none

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (e.g. by run `make test_race`)
- [x] No linter errors exist locally (e.g. by run `make fmt_check`)
- [x] I have performed a self-review of my own code