### PR TITLE
Prevent linux-specific dependencies from breaking compatibility with macOS

### DIFF
--- a/system/digitalpin_cdev.go
+++ b/system/digitalpin_cdev.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package system
 
 import (

--- a/system/digitalpin_cdev_test.go
+++ b/system/digitalpin_cdev_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package system
 
 import (

--- a/system/digitalpin_cdev_unsupported.go
+++ b/system/digitalpin_cdev_unsupported.go
@@ -1,0 +1,74 @@
+//go:build !linux
+
+package system
+
+import (
+	"fmt"
+	"strconv"
+
+	"gobot.io/x/gobot/v2"
+)
+
+var errGPIOCdevNotSupported = fmt.Errorf("GPIO character device is not supported on this platform")
+
+type cdevLine interface {
+	SetValue(value int) error
+	Value() (int, error)
+	Close() error
+}
+
+type digitalPinCdev struct {
+	*digitalPinConfig
+
+	chipName string
+	pin      int
+	line     cdevLine
+}
+
+var digitalPinCdevReconfigure = func(*digitalPinCdev, bool) error {
+	return errGPIOCdevNotSupported
+}
+
+func newDigitalPinCdev(chipName string, pin int, options ...func(gobot.DigitalPinOptioner) bool) *digitalPinCdev {
+	if chipName == "" {
+		chipName = "gpiochip0"
+	}
+	cfg := newDigitalPinConfig("gobotio"+strconv.Itoa(pin), options...)
+	return &digitalPinCdev{
+		chipName:         chipName,
+		pin:              pin,
+		digitalPinConfig: cfg,
+	}
+}
+
+func (d *digitalPinCdev) ApplyOptions(_ ...func(gobot.DigitalPinOptioner) bool) error {
+	return errGPIOCdevNotSupported
+}
+
+func (d *digitalPinCdev) DirectionBehavior() string {
+	return d.direction
+}
+
+func (d *digitalPinCdev) Export() error {
+	return errGPIOCdevNotSupported
+}
+
+func (d *digitalPinCdev) Unexport() error {
+	return errGPIOCdevNotSupported
+}
+
+func (d *digitalPinCdev) Write(_ int) error {
+	return errGPIOCdevNotSupported
+}
+
+func (d *digitalPinCdev) Read() (int, error) {
+	return 0, errGPIOCdevNotSupported
+}
+
+func (d *digitalPinCdev) ListLines() error {
+	return errGPIOCdevNotSupported
+}
+
+func (d *digitalPinCdev) List() error {
+	return errGPIOCdevNotSupported
+}


### PR DESCRIPTION
## Solved issues and/or description of the change

Trying to build on macOS fails because `warthog618/go-gpiocdev` is for linux-only. This PR stubs that out and returns an error since there's no GPIO available on macOS that I know of.

My use case is being able to test locally with firmata. Actual project is deployed to linux.

Errors during build:
 
```
# github.com/warthog618/go-gpiocdev
../../.asdf/installs/golang/1.26.3/packages/pkg/mod/github.com/warthog618/go-gpiocdev@v0.9.1/options.go:93:50: undefined: uapi.OutputValues
../../.asdf/installs/golang/1.26.3/packages/pkg/mod/github.com/warthog618/go-gpiocdev@v0.9.1/options.go:101:34: undefined: uapi.LineConfigAttribute
../../.asdf/installs/golang/1.26.3/packages/pkg/mod/github.com/warthog618/go-gpiocdev@v0.9.1/gpiocdev.go:358:35: undefined: uapi.LineInfo
../../.asdf/installs/golang/1.26.3/packages/pkg/mod/github.com/warthog618/go-gpiocdev@v0.9.1/gpiocdev.go:383:37: undefined: uapi.LineInfoV2
../../.asdf/installs/golang/1.26.3/packages/pkg/mod/github.com/warthog618/go-gpiocdev@v0.9.1/gpiocdev.go:423:26: undefined: uapi.LineInfo
../../.asdf/installs/golang/1.26.3/packages/pkg/mod/github.com/warthog618/go-gpiocdev@v0.9.1/gpiocdev.go:433:28: undefined: uapi.LineInfoV2
../../.asdf/installs/golang/1.26.3/packages/pkg/mod/github.com/warthog618/go-gpiocdev@v0.9.1/gpiocdev.go:628:43: undefined: uapi.HandleFlag
../../.asdf/installs/golang/1.26.3/packages/pkg/mod/github.com/warthog618/go-gpiocdev@v0.9.1/gpiocdev.go:661:42: undefined: uapi.EventFlag
../../.asdf/installs/golang/1.26.3/packages/pkg/mod/github.com/warthog618/go-gpiocdev@v0.9.1/gpiocdev.go:674:49: undefined: uapi.LineFlagV2
../../.asdf/installs/golang/1.26.3/packages/pkg/mod/github.com/warthog618/go-gpiocdev@v0.9.1/gpiocdev.go:711:55: undefined: uapi.LineAttribute
../../.asdf/installs/golang/1.26.3/packages/pkg/mod/github.com/warthog618/go-gpiocdev@v0.9.1/options.go:93:50: too many errors
```

## Manual test

- OS and Version (Win/Mac/Linux): 
  - `Darwin hostname 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:54:46 PST 2026; root:xnu-12377.91.3~2/RELEASE_ARM64_T6000 arm64`
  - `go version go1.24.6 darwin/arm64`
- Adaptor(s) and/or driver(s): Firmata


The following script builds with no errors:

```golang
package main

import (
  "log/slog"

  "gobot.io/x/gobot/v2/platforms/firmata"
)

func main() {
  adaptor := firmata.NewAdaptor("/dev/tty.usbmodem211301")
  if err := adaptor.Connect(); err != nil {
    slog.Error("failed to connect to device", "error", err)
  }

  slog.Info("Connected to firmata on device")
}
```

## Checklist

- [x] The PR's target branch is 'hybridgroup:dev'
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (e.g. by run `make test_race`):  most test pass but `TestDigitalPinExportSysfs/error_write_direction_file`. I suspect these won't run properly in macOS, so I'm going to clone my branch on linux and re-run before requesting a review.
- [ ] No linter errors exist locally (e.g. by run `make fmt_check`): Could not make this pass since, on macOS a `bluetooth.Address` expects an UUID and not a MAC address.
- [x] I have performed a self-review of my own code
